### PR TITLE
Make Upserts More Efficient to improve performance

### DIFF
--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -170,31 +170,43 @@ module.exports = function sample(seq, dataTypes) {
        *  encountered while performing the sample upsert operation itself.
        */
       upsertByName(toUpsert, isBulk) {
-        let subjasp;
+        let sampleExists = true;
         return new seq.Promise((resolve, reject) => {
-          u.getSubjectAndAspectBySampleName(seq, toUpsert.name)
-          .then((sa) => {
-            subjasp = sa;
-            toUpsert.subjectId = sa.subject.id;
-            toUpsert.aspectId = sa.aspect.id;
-          })
-          .then(() => Sample.findOne({
+          // get sample by name
+          Sample.findOne({
             where: {
-              subjectId: subjasp.subject.id,
-              aspectId: subjasp.aspect.id,
-              isDeleted: NO,
+              name: {
+                $iLike: toUpsert.name,
+              },
             },
-          }))
+          })
           .then((o) => {
+            // If sample does not exist, set sampleExists to false, which is
+            // used after this promise returns. Get corresponding subject and
+            //  aspect to check if the sample name is valid.
             if (o === null) {
-              return Sample.create(toUpsert);
+              sampleExists = false;
+              return u.getSubjectAndAspectBySampleName(seq, toUpsert.name);
             }
 
+            // Else, if sample exists, update the sample.
             // set value changed to true, during updates to avoid timeouts
             // Adding this to the before update hook does
             // give the needed effect; so adding it here!!!.
             o.changed('value', true);
             return o.update(toUpsert);
+          })
+          .then((returnedObj) => {
+            // If sample existed, return the updated object.
+            if (sampleExists) {
+              return returnedObj;
+            }
+
+            // If sample does not exist, update subject and aspect id in sample
+            // object to be created. Create sample.
+            toUpsert.subjectId = returnedObj.subject.id;
+            toUpsert.aspectId = returnedObj.aspect.id;
+            return Sample.create(toUpsert);
           })
           .then((o) => resolve(o))
           .catch((err) => {
@@ -412,6 +424,14 @@ module.exports = function sample(seq, dataTypes) {
         fields: [
           'deletedAt',
           'status',
+        ],
+      },
+      {
+        name: 'SampleUniqueLowercaseNameIsDeleted',
+        unique: true,
+        fields: [
+          seq.fn('lower', seq.col('name')),
+          'isDeleted',
         ],
       },
     ],

--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -427,11 +427,9 @@ module.exports = function sample(seq, dataTypes) {
         ],
       },
       {
-        name: 'SampleUniqueLowercaseNameIsDeleted',
-        unique: true,
+        name: 'SampleName',
         fields: [
-          seq.fn('lower', seq.col('name')),
-          'isDeleted',
+          'name',
         ],
       },
     ],

--- a/migrations/20161011235253-samplesAddNameIndex.js
+++ b/migrations/20161011235253-samplesAddNameIndex.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    queryInterface.addIndex(
+      'Samples',
+      [Sequelize.fn('lower', Sequelize.col('name')), 'isDeleted'],
+      {
+        indexName: 'SampleUniqueLowercaseNameIsDeleted',
+        indicesType: 'UNIQUE',
+      }
+    );
+  },
+
+  down: function (queryInterface, Sequelize) {
+    queryInterface.removeIndex('Samples', 'SampleUniqueLowercaseNameIsDeleted');
+  },
+};

--- a/migrations/20161011235253-samplesAddNameIndex.js
+++ b/migrations/20161011235253-samplesAddNameIndex.js
@@ -4,15 +4,14 @@ module.exports = {
   up: function (queryInterface, Sequelize) {
     queryInterface.addIndex(
       'Samples',
-      [Sequelize.fn('lower', Sequelize.col('name')), 'isDeleted'],
+      ['name'],
       {
-        indexName: 'SampleUniqueLowercaseNameIsDeleted',
-        indicesType: 'UNIQUE',
+        indexName: 'SampleName',
       }
     );
   },
 
   down: function (queryInterface, Sequelize) {
-    queryInterface.removeIndex('Samples', 'SampleUniqueLowercaseNameIsDeleted');
+    queryInterface.removeIndex('Samples', 'SampleName');
   },
 };


### PR DESCRIPTION
Previously:
----------
1. Find subject and aspect from sample name - 2 db calls
2. Get sample from db, 1 db call
3. If sample exists, update sample, else create sample, 1 call

Total:
Sample create: 4 calls
Sample update: 3 calls

Now:
-------
1. Get sample by sample name. 1 db call
2. If sample exists, update (1 call), else, get subject and aspect from db, and create sample (3 calls)

Total:
Sample create: 4 calls
Sample update: 2 calls

We  cannot do Sample.update directly because it does not return sample object, just the number of rows updated, so we will have to make a sample.find call anyway.
