### PR TITLE
fixed API GET operations should return results in alphabetical order and respects query parameter ordering

### DIFF
--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -145,9 +145,9 @@ function toSequelizeOrder(sortOrder, modelName) {
 function options(params, props) {
   const opts = u.buildFieldList(params);
 
-  // Specify the sort order. If defaultOrder is defined in props then
-  // update sort order otherwise take value from model defination
-  if (props.defaultOrder) {
+  // Specify the sort order. If defaultOrder is defined in props or sort value
+  // then update sort order otherwise take value from model defination
+  if (params.sort.value || props.defaultOrder) {
     const ord = (params.sort ? params.sort.value : null) || props.defaultOrder;
     opts.order = toSequelizeOrder(ord, props.modelName);
   }

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -124,10 +124,10 @@ function toSequelizeOrder(sortOrder, modelName) {
       sortOrder : [sortOrder];
     return sortOrderArray.map((s) => {
       if (s.indexOf(constants.MINUS) === 0) {
-        return [`${modelName}.${s.substr(1)}`, constants.SEQ_DESC];
+        return [`${s.substr(1)}`, constants.SEQ_DESC];
       }
 
-      return `${modelName}.${s}`;
+      return `${s}`;
     });
   }
 
@@ -145,9 +145,12 @@ function toSequelizeOrder(sortOrder, modelName) {
 function options(params, props) {
   const opts = u.buildFieldList(params);
 
-  // Specify the sort order
-  const ord = (params.sort ? params.sort.value : null) || props.defaultOrder;
-  opts.order = toSequelizeOrder(ord, props.modelName);
+  // Specify the sort order. If defaultOrder is defined in props then
+  // update sort order otherwise take value from model defination
+  if (props.defaultOrder) {
+    const ord = (params.sort ? params.sort.value : null) || props.defaultOrder;
+    opts.order = toSequelizeOrder(ord, props.modelName);
+  }
 
   // Specify the limit
   if (params.limit.value) {

--- a/tests/api/v1/subjects/get.js
+++ b/tests/api/v1/subjects/get.js
@@ -67,6 +67,61 @@ describe(`api: GET ${path}`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
+  it('Check return result of get in alphabetical order of' +
+  'absolutePath by default', (done) => {
+    api.get(`${path}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body[0].absolutePath).to.equal(na.name);
+      expect(res.body[1].absolutePath).to.equal(na.name + '.' + us.name);
+      expect(res.body[2].absolutePath).to.equal(na.name + '.' + us.name +
+        '.' + vt.name);
+
+      done();
+    });
+  });
+
+  it('Check return result of get in alphabetical order of' +
+  'name when use of ?sort=name', (done) => {
+    api.get(`${path}?sort=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body[0].name).to.equal(na.name);
+      expect(res.body[1].name).to.equal(us.name);
+      expect(res.body[2].name).to.equal(vt.name);
+
+      done();
+    });
+  });
+
+  it('Check return result of get in alphabetical order of' +
+  'name when use of ?sort=-name', (done) => {
+    api.get(`${path}?sort=-name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body[2].name).to.equal(na.name);
+      expect(res.body[1].name).to.equal(us.name);
+      expect(res.body[0].name).to.equal(vt.name);
+
+      done();
+    });
+  });
+
   it('GET returns parentAbsolutePath, from root', (done) => {
     api.get(`${path}/${na.id}`)
     .set('Authorization', token)


### PR DESCRIPTION
- Now if defaultOrder is defined in props then it will take that defaultOrder and return the result as per that. If defaultOrder is not defined then it will take sort order based on model. 

- Fixed all swagger parameter sort option

 