### PR TITLE
Do db sync on server start for table and index creation

### DIFF
--- a/db/createOrUpdatePrivateDb.js
+++ b/db/createOrUpdatePrivateDb.js
@@ -9,19 +9,14 @@
 /**
  * ./db/createOrUpdatePrivateDb.js
  *
- * This is script is for private space installation
- * First check whethere table is present or not
- * If tables are present then performs migratedb otherwise resetdb to
- * create new tables and false migrations to keep migration table up to date
- *
+ * If Refocus is deployed in a heroku private space, check whether our tables
+ * exist. If yes, run any necessary migrations, otherwize do a full reset to
+ * create all the tables and insert pseudo-migrations to bring the migration
+ * table up to date.\
  */
-
 const models = require('./index');
-const conf = require('../config');
 const utils = require('./utils');
 
-// Heroku Private space postgres contains IP in host so check wthether
-// it is IP or not, if it is IP then perform reset or migratedb
 if (utils.isInHerokuPrivateSpace()) {
   models.sequelize.query(`select count(*) from
    information_schema.tables where table_schema = 'public'`)

--- a/db/index.js
+++ b/db/index.js
@@ -59,6 +59,12 @@ function doImport(modelDirName) {
     imported[m.name] = m;
   }
 
+  /*
+   * Add any missing tables and indexes based on the imported model
+   * definitions.
+   */
+  seq.sync();
+
   const keys = Object.keys(imported);
   for (let i = 0; i < keys.length; i++) {
     const m = keys[i];
@@ -73,8 +79,7 @@ function doImport(modelDirName) {
 
 /*
  * Set up the "db" object and prepare it to be exported. It will contain the
- * imported models, the "reset" function, the "sequelize" instance and the
- * Sequelize class.
+ * imported models, the "sequelize" instance and the Sequelize class.
  */
 const db = doImport(conf.db.modelDirName);
 db.sequelize = seq;

--- a/db/model/globalconfig.js
+++ b/db/model/globalconfig.js
@@ -14,7 +14,7 @@ const constants = require('../constants');
 
 const assoc = {};
 
-module.exports = function user(seq, dataTypes) {
+module.exports = function globalconfig(seq, dataTypes) {
   const GlobalConfig = seq.define('GlobalConfig', {
     id: {
       type: dataTypes.UUID,

--- a/migrations/20161013215314-dropglobalconfig.js
+++ b/migrations/20161013215314-dropglobalconfig.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Because a deployment may have a poorly-defined GlobalConfig table at this
+ * time, this migration tests for the existence of the "createdAt" field and
+ * only drops the table if that field does not exist. After this migration,
+ * when the server starts up and index.js calls sync on all the models, the
+ * GlobalConfig table will be created properly.
+ */
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+    return queryInterface.describeTable('GlobalConfig')
+    .then((attributes) => {
+      return 'createdAt' in attributes;
+    })
+    .then((hasCreatedAtField) => {
+      if (!hasCreatedAtField) {
+        return queryInterface.dropTable('GlobalConfig');
+      }
+
+      return true;
+    });
+  },
+
+  down: function (queryInterface, Sequelize) {
+    /*
+     * There is no "down" function defined in this migration, i.e. there is
+     * nothing to undo here to restore the database to a desired state.
+     */
+  }
+};


### PR DESCRIPTION
(since table creation via migration doesn't do everything we need it to do)

Also add a migration to remove the vestigial GlobalConfig table if it had already been partially created.