### PR TITLE
#Refocus get /subjects filtering by tag working

### DIFF
--- a/api/v1/constants.js
+++ b/api/v1/constants.js
@@ -38,6 +38,7 @@ module.exports = {
   SEQ_DEFAULT_SCOPE: 'defaultScope',
   SEQ_DESC: 'DESC',
   SEQ_LIKE: '$iLike',
+  SEQ_CONTAINS: '$contains',
   SEQ_OR: '$or',
   SEQ_WILDCARD: '%',
   SLASH: '/',

--- a/api/v1/helpers/nouns/subjects.js
+++ b/api/v1/helpers/nouns/subjects.js
@@ -304,4 +304,5 @@ module.exports = {
   fieldsWithJsonArrayType,
   fieldsWithArrayType,
   loggingEnabled,
+  tagFilterName: 'tags',
 }; // exports

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -3094,6 +3094,17 @@ paths:
             Filter by parentAbsolutePath; asterisk (*) wildcards ok.
           required: false
           type: string
+        -
+          name: tags
+          in: query
+          items:
+            type: string
+            maxLength: 60
+            pattern: ^[0-9A-Za-z_][0-9A-Za-z_\\-]{1,59}$
+          description: >-
+            Filter by tags.
+          required: false
+          type: array
       responses:
         200:
           description: >-

--- a/config.js
+++ b/config.js
@@ -53,6 +53,9 @@ const optimizeUpsert = pe.OPTIMIZE_UPSERT === 'true' ||
 // env variable to enable caching for /GET /v1/perspectives/{key}
 const enableCachePerspective = pe.ENABLE_CACHE_PERSPECTIVE || false;
 
+const filterSubjByTags = pe.FILTER_SUBJ_BY_TAGS === 'true' ||
+ pe.FILTER_SUBJ_BY_TAGS === true || false;
+
 module.exports = {
 
   api: {
@@ -247,4 +250,5 @@ module.exports = {
   optimizeUpsert,
   enableCachePerspective,
   enableClockDyno,
+  filterSubjByTags,
 };

--- a/config.js
+++ b/config.js
@@ -114,6 +114,7 @@ module.exports = {
       useAccessToken: pe.USE_ACCESS_TOKEN || false,
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     development: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -133,6 +134,7 @@ module.exports = {
       useAccessToken: pe.USE_ACCESS_TOKEN || false,
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     production: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -151,6 +153,7 @@ module.exports = {
       useAccessToken: pe.USE_ACCESS_TOKEN || false,
       tokenSecret: pe.SECRET_TOKEN ||
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     test: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -169,6 +172,7 @@ module.exports = {
       useAccessToken: pe.USE_ACCESS_TOKEN || false,
       tokenSecret: pe.SECRET_TOKEN ||
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     testDisableHttp: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -182,6 +186,7 @@ module.exports = {
       useAccessToken: 'true',
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     testWhitelistLocalhost: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -195,6 +200,7 @@ module.exports = {
       ipWhitelist: iplist,
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     testBlockAllhosts: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -208,6 +214,7 @@ module.exports = {
       ipWhitelist: [''],
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     testTokenReq: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -221,6 +228,7 @@ module.exports = {
       useAccessToken: 'true',
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
     testTokenNotReq: {
       checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
@@ -234,8 +242,22 @@ module.exports = {
       useAccessToken: false,
       tokenSecret:
        '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags,
     },
-
+    testSubjTagFilter: {
+      checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
+        DEFAULT_CHECK_TIMEOUT_INTERVAL_MILLIS,
+      dbLogging: false, // console.log | false | ...
+      dbUrl: defaultDbUrl,
+      disableHttp,
+      redisUrl: '//127.0.0.1:6379',
+      defaultNodePort: defaultPort,
+      host: '127.0.0.1',
+      useAccessToken: false,
+      tokenSecret:
+       '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
+      filterSubjByTags: true,
+    }
   },
 
   nodeEnv,
@@ -250,5 +272,4 @@ module.exports = {
   optimizeUpsert,
   enableCachePerspective,
   enableClockDyno,
-  filterSubjByTags,
 };

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "test-token-notreq": "NODE_ENV=testTokenNotReq mocha -R dot --recursive tests/tokenNotReq",
     "test-db": "npm run resetdb && mocha -R dot --recursive tests/db",
     "test-realtime": "mocha -R dot --recursive tests/realtime",
+    "test-subj-tag-filter": "NODE_ENV=testSubjTagFilter mocha -R dot --recursive tests/subjectTagFilter",
     "test-view": "NODE_ENV=test mocha -R dot --recursive --compilers js:babel-core/register --require ./tests/view/setup.js tests/view",
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R dot --recursive tests/api tests/db && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage && npm run test-view && npm run test-realtime && npm run test-token-req && npm run test-token-notreq && npm run test-disablehttp",
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R dot --recursive tests/api tests/db && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage && npm run test-view && npm run test-realtime && npm run test-token-req && npm run test-token-notreq && npm run test-disablehttp && npm run test-subj-tag-filter",
     "postinstall": "NODE_ENV=production gulp browserifyViews && gulp movecss && gulp movesocket && gulp movelensutil && npm run checkdb",
     "prestart": "npm run checkprivatedb"
   },

--- a/tests/api/v1/subjects/get.js
+++ b/tests/api/v1/subjects/get.js
@@ -19,6 +19,7 @@ const u = require('./utils');
 const Subject = tu.db.Subject;
 const path = '/v1/subjects';
 const expect = require('chai').expect;
+const filterSubjByTags = require('../../../../config').filterSubjByTags;
 
 describe(`api: GET ${path}`, () => {
   let token;
@@ -30,10 +31,12 @@ describe(`api: GET ${path}`, () => {
   const us = {
     name: `${tu.namePrefix}UnitedStates`,
     description: 'country',
+    tags: ['US'],
   };
   const vt = {
     name: `${tu.namePrefix}Vermont`,
     description: 'state',
+    tags: ['US', 'NE'],
   };
 
   before((done) => {
@@ -184,6 +187,41 @@ describe(`api: GET ${path}`, () => {
       done();
     });
   });
+
+  if (filterSubjByTags) {
+    it('GET with tag filter :: one tag', (done) => {
+      api.get(`${path}/?tags=US`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(2);
+        expect(res.body[0].tags).to.eql(['US']);
+        expect(res.body[1].tags).to.eql(['US', 'NE']);
+
+        done();
+      });
+    });
+
+    it('GET with tag filter :: multiple tags', (done) => {
+      api.get(`${path}/?tags=NE,US`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(1);
+        expect(res.body[0].tags).to.eql(['US', 'NE']);
+
+        done();
+      });
+    });
+  }
 
   it('pagination tests');
   it('childCount, descendentCount');

--- a/tests/api/v1/subjects/get.js
+++ b/tests/api/v1/subjects/get.js
@@ -19,7 +19,6 @@ const u = require('./utils');
 const Subject = tu.db.Subject;
 const path = '/v1/subjects';
 const expect = require('chai').expect;
-const filterSubjByTags = require('../../../../config').filterSubjByTags;
 
 describe(`api: GET ${path}`, () => {
   let token;
@@ -187,41 +186,6 @@ describe(`api: GET ${path}`, () => {
       done();
     });
   });
-
-  if (filterSubjByTags) {
-    it('GET with tag filter :: one tag', (done) => {
-      api.get(`${path}/?tags=US`)
-      .set('Authorization', token)
-      .expect(constants.httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
-        expect(res.body.length).to.equal(2);
-        expect(res.body[0].tags).to.eql(['US']);
-        expect(res.body[1].tags).to.eql(['US', 'NE']);
-
-        done();
-      });
-    });
-
-    it('GET with tag filter :: multiple tags', (done) => {
-      api.get(`${path}/?tags=NE,US`)
-      .set('Authorization', token)
-      .expect(constants.httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
-        expect(res.body.length).to.equal(1);
-        expect(res.body[0].tags).to.eql(['US', 'NE']);
-
-        done();
-      });
-    });
-  }
 
   it('pagination tests');
   it('childCount, descendentCount');

--- a/tests/subjectTagFilter/subjectTagFilter.js
+++ b/tests/subjectTagFilter/subjectTagFilter.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/subjectTagFilter/subjectTagFilter.js
+ */
+'use strict';
+const supertest = require('supertest');
+
+const api = supertest(require('../../index').app);
+const constants = require('../../api/v1/constants');
+const tu = require('../testUtils');
+const u = require('./utils');
+const Subject = tu.db.Subject;
+const path = '/v1/subjects';
+const expect = require('chai').expect;
+
+describe(`api: GET ${path}`, () => {
+  let token;
+
+  const na = {
+    name: `${tu.namePrefix}NorthAmerica`,
+    description: 'continent',
+  };
+  const us = {
+    name: `${tu.namePrefix}UnitedStates`,
+    description: 'country',
+    tags: ['US'],
+  };
+  const vt = {
+    name: `${tu.namePrefix}Vermont`,
+    description: 'state',
+    tags: ['US', 'NE'],
+  };
+
+  before((done) => {
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  before((done) => {
+    Subject.create(na)
+    .then((createdNa) => {
+      na.id = createdNa.id;
+      us.parentId = na.id;
+      return Subject.create(us);
+    })
+    .then((createdUs) => {
+      us.id = createdUs.id;
+      vt.parentId = us.id;
+      return Subject.create(vt);
+    })
+    .then((createdVt) => {
+      vt.id = createdVt.id;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  after(u.forceDelete);
+  after(tu.forceDeleteUser);
+
+  it('GET with tag filter :: one tag', (done) => {
+    api.get(`${path}?tags=US`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.length).to.equal(2);
+      expect(res.body[0].tags).to.eql(['US']);
+      expect(res.body[1].tags).to.eql(['US', 'NE']);
+
+      done();
+    });
+  });
+
+  it('GET with tag filter :: multiple tags', (done) => {
+    api.get(`${path}?tags=NE,US`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.length).to.equal(1);
+      expect(res.body[0].tags).to.eql(['US', 'NE']);
+
+      done();
+    });
+  });
+});

--- a/tests/subjectTagFilter/utils.js
+++ b/tests/subjectTagFilter/utils.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/subjectTagFilter/utils.js
+ */
+'use strict';
+
+const tu = require('../testUtils');
+
+const testStartTime = new Date();
+
+module.exports = {
+  forceDelete(done) {
+    tu.forceDelete(tu.db.Sample, testStartTime)
+    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Tag, testStartTime))
+    .then(() => done())
+    .catch((err) => done(err));
+  },
+};


### PR DESCRIPTION
Using env var for new changes.
When env var us enables, subjects are filtered by tags, like GET /v1/subjects?tags=tag1,tag2
Added tests behind config var.