### PR TITLE
compress all static resource

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,12 @@ function start() { // eslint-disable-line max-statements
 
   const app = express();
   
-  // Compress(gzip) all the responses
+  /*
+   * Compress(gzip) all the api responses and all the static files. 
+   * Since this is called before the static pages and the API routes, this will
+   * ensure that both the static pages and the API response are compressed.
+   */
+  
   app.use(compress());
   
   const httpServer = require('http').Server(app);

--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ function start() { // eslint-disable-line max-statements
   const enforcesSSL = require('express-enforces-ssl');
 
   const app = express();
+  
+  // Compress(gzip) all the responses
+  app.use(compress());
+  
   const httpServer = require('http').Server(app);
   
   const io = require('socket.io')(httpServer);
@@ -129,9 +133,6 @@ function start() { // eslint-disable-line max-statements
   const swaggerDoc = yaml.safeLoad(swaggerFile);
   swaggerTools.initializeMiddleware(swaggerDoc, (mw) => {
     app.use('/static', express.static(path.join(__dirname, 'public')));
-
-    // Compress(gzip) all the responses
-    app.use(compress());
 
     // Set the X-XSS-Protection HTTP header as a basic protection against XSS
     app.use(helmet.xssFilter());


### PR DESCRIPTION
moved compression to the top of the index.js file, so that all the resources are compressed.
