### PR TITLE
Get OKTA SAML app working from OKTA admin

### DIFF
--- a/view/loadView.js
+++ b/view/loadView.js
@@ -215,8 +215,13 @@ module.exports = function loadView(app, passport) {
       const token = jwtUtil.createToken(_req.user);
       _res.cookie('Authorization', token);
 
-      // get the redirect url from relay state
-      _res.redirect(_req.body.RelayState);
+      if (_req.body.RelayState) {
+        // get the redirect url from relay state if present
+        _res.redirect(_req.body.RelayState);
+      } else {
+        // redirect to home page
+        _res.redirect('/');
+      }
     }
   );
 


### PR DESCRIPTION
A Refocus deployment using OKTA for auth was not getting redirected when clicking on SAML app in OKTA admin (which was expected and was happening before Relay state redirection came in).

Added a condition that if relay state is set (which gets set when we click SSO button), redirect to the url requested, else redirect to home page (when SAML app is clicked from other source).