### PR TITLE
fix bug: previously clicking cancel on admin details page opens edit panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "connect-redis": "^3.0.2",
     "cookie-parser": "^1.4.1",
     "debug": "^2.2.0",
+    "enzyme": "^2.6.0",
     "errors": "^0.3.0",
     "express": "^4.13.3",
     "express-enforces-ssl": "^1.1.0",

--- a/tests/view/components/detailViewTest.js
+++ b/tests/view/components/detailViewTest.js
@@ -16,9 +16,10 @@ import sinon from 'sinon';
 import Detail from '../../../view/admin/components/pages/Detail.js';
 import { mount } from 'enzyme';
 
-describe.only('Detail view ', () => {
+describe('Detail view ', () => {
+  const ONE = '1';
   const DUMMY_STRING = 'COOL';
-  const DUMMY_FUNCTION = ()=> {};
+  const DUMMY_FUNCTION = () => {};
   const DUMMY_OBJ = { dummy: DUMMY_STRING };
   const SUBJECT_URL = '/subjects/I/have/a/long/absolute/path';
 
@@ -31,12 +32,12 @@ describe.only('Detail view ', () => {
   function setup(fieldObj) {
     const defaultProps = {
       isEditing: false,
-      url:  SUBJECT_URL,
+      url: SUBJECT_URL,
       deleteResource: DUMMY_FUNCTION,
       putResource: DUMMY_FUNCTION,
       fetchResources: DUMMY_FUNCTION,
-      refocusReducer:  { subject: DUMMY_OBJ },
-      history: [],
+      refocusReducer: { subject: DUMMY_OBJ },
+      history: { push: DUMMY_FUNCTION },
       getFormData: DUMMY_FUNCTION,
       changeAspectRangeFormat: DUMMY_FUNCTION,
     };
@@ -46,42 +47,31 @@ describe.only('Detail view ', () => {
     // use monut to test all lifecycle methods, and children
     const enzymeWrapper = mount(<Detail {...props} />);
 
-    return {
-      props,
-      enzymeWrapper
-    };
+    return enzymeWrapper;
   }
 
-  it('should render button row with three buttons');
+  it('should render button row with three buttons as expected', () => {
+    const enzymeWrapper = setup();
+    // button row container
+    expect(enzymeWrapper.find('.readButtonRow')).to.have.length(ONE);
 
-  it('on click delete button, handleDeleteClick is called');
+    const editButton = enzymeWrapper.find('.editButton');
+    expect(editButton).to.have.length(ONE);
+    expect(editButton.text()).to.equal('Edit');
 
-  it('toggling isEditing change the url to expected value');
+    const deleteButton = enzymeWrapper.find('.deleteButton');
+    expect(deleteButton).to.have.length(ONE);
+    expect(deleteButton.text()).to.equal('Delete');
 
-  it('on setting state askDelete to true, delete modal is' +
-    ' rendered with expected title and Delete button', () => {
-    const { enzymeWrapper } = setup();
-    // no modal at the beginning
-    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(0);
-    enzymeWrapper.setState({ askDelete: true });
-    // delete modal should be rendered
-    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(1);
-    expect(enzymeWrapper.find('h2').text()).to.equal('Delete subject');
-    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Delete');
-  });
-
-  it('on setting prop isEditing to true, edit modal is' +
-    ' rendered with expected title and Save button', () => {
-    const { enzymeWrapper } = setup({ isEditing: true });
-    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(1);
-    expect(enzymeWrapper.find('h2').text()).to.equal('Edit subject');
-    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Save');
+    const addChildLink = enzymeWrapper.find('.addChildLink');
+    expect(addChildLink).to.have.length(ONE);
+    expect(addChildLink.text()).to.equal('Add Child');
   });
 
   it('on cancel delete, askDelete reverts to false', () => {
     // calling the delete handler should set the
     // delete status to true
-    const { enzymeWrapper } = setup();
+    const enzymeWrapper = setup();
     const instance = enzymeWrapper.instance();
     instance.handleDeleteClick();
     expect(instance.state.askDelete).to.equal(true);
@@ -89,5 +79,85 @@ describe.only('Detail view ', () => {
     // turn the delete state false
     instance.turnOffDelete();
     expect(instance.state.askDelete).to.equal(false);
+  });
+
+  it('on click delete button, state askDelete changes to true', () => {
+    const enzymeWrapper = setup();
+    const instance = enzymeWrapper.instance();
+    expect(instance.state.askDelete).to.equal(false);
+    enzymeWrapper.find('.deleteButton').last().simulate('click');
+    expect(instance.state.askDelete).to.equal(true);
+  });
+
+  it('on click cancel button, state askDelete changes to false', () => {
+    const enzymeWrapper = setup();
+    // set state askDelete to true, to show the cancel button
+    enzymeWrapper.setState({ askDelete: true });
+    const instance = enzymeWrapper.instance();
+    expect(instance.state.askDelete).to.equal(true);
+
+    enzymeWrapper.find('.cancelButton').simulate('click');
+    expect(instance.state.askDelete).to.equal(false);
+  });
+
+  it('toggleEdit on read only page pushes url + ?edit to history', () => {
+    const spy = { push: sinon.spy() };
+    const enzymeWrapper = setup({ history: spy });
+    const instance = enzymeWrapper.instance();
+    instance.toggleEdit();
+    expect(spy.push.calledOnce).to.be.true;
+    expect(spy.push.calledWith(SUBJECT_URL + '?edit')).to.be.true;
+  });
+
+  it('toggleEdit on edit page pushes url + ?edit to history', () => {
+    const spy = { push: sinon.spy() };
+    const enzymeWrapper = setup({
+      history: spy,
+      isEditing: true,
+    });
+    const instance = enzymeWrapper.instance();
+    instance.toggleEdit();
+    expect(spy.push.calledOnce).to.be.true;
+    expect(spy.push.calledWith(SUBJECT_URL)).to.be.true;
+  });
+
+  it('on click edit, component pushes url + ?edit to history', () => {
+    const spy = { push: sinon.spy() };
+    const enzymeWrapper = setup({ history: spy });
+    enzymeWrapper.find('.editButton').simulate('click');
+    expect(spy.push.calledOnce).to.be.true;
+    expect(spy.push.calledWith(SUBJECT_URL+ '?edit')).to.be.true;
+  });
+
+  it('on click cancel, component pushes url to history', () => {
+    const spy = { push: sinon.spy() };
+    // set props to is editing, so cancel button renders
+    const enzymeWrapper = setup({
+      history: spy,
+      isEditing: true,
+    });
+    enzymeWrapper.find('.cancelButton').simulate('click');
+    expect(spy.push.calledOnce).to.be.true;
+    expect(spy.push.calledWith(SUBJECT_URL)).to.be.true;
+  });
+
+  it('on setting state askDelete to true, delete modal is' +
+    ' rendered with expected title and Delete button', () => {
+    const enzymeWrapper = setup();
+    // no modal at the beginning
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(0);
+    enzymeWrapper.setState({ askDelete: true });
+    // delete modal should be rendered
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(ONE);
+    expect(enzymeWrapper.find('h2').text()).to.equal('Delete subject');
+    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Delete');
+  });
+
+  it('on setting prop isEditing to true, edit modal is' +
+    ' rendered with expected title and Save button', () => {
+    const enzymeWrapper = setup({ isEditing: true });
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(ONE);
+    expect(enzymeWrapper.find('h2').text()).to.equal('Edit subject');
+    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Save');
   });
 });

--- a/tests/view/components/detailViewTest.js
+++ b/tests/view/components/detailViewTest.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/view/components/detailViewTest.js
+ */
+
+import { expect } from 'chai';
+import React from 'react';
+import sinon from 'sinon';
+import Detail from '../../../view/admin/components/pages/Detail.js';
+import { mount } from 'enzyme';
+
+describe.only('Detail view ', () => {
+  const DUMMY_STRING = 'COOL';
+  const DUMMY_FUNCTION = ()=> {};
+  const DUMMY_OBJ = { dummy: DUMMY_STRING };
+  const SUBJECT_URL = '/subjects/I/have/a/long/absolute/path';
+
+  /**
+   * Sets up the component with props.
+   * @param {Object} fieldObj Optional object specifying
+   * overrides to the default props
+   * @returns {Object} The rendered component
+   */
+  function setup(fieldObj) {
+    const defaultProps = {
+      isEditing: false,
+      url:  SUBJECT_URL,
+      deleteResource: DUMMY_FUNCTION,
+      putResource: DUMMY_FUNCTION,
+      fetchResources: DUMMY_FUNCTION,
+      refocusReducer:  { subject: DUMMY_OBJ },
+      history: [],
+      getFormData: DUMMY_FUNCTION,
+      changeAspectRangeFormat: DUMMY_FUNCTION,
+    };
+    // update props as needed
+    const props = fieldObj ?
+      Object.assign(defaultProps, fieldObj) : defaultProps;
+    // use monut to test all lifecycle methods, and children
+    const enzymeWrapper = mount(<Detail {...props} />);
+
+    return {
+      props,
+      enzymeWrapper
+    };
+  }
+
+  it('should render button row with three buttons');
+
+  it('on click delete button, handleDeleteClick is called');
+
+  it('toggling isEditing change the url to expected value');
+
+  it('on setting state askDelete to true, delete modal is' +
+    ' rendered with expected title and Delete button', () => {
+    const { enzymeWrapper } = setup();
+    // no modal at the beginning
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(0);
+    enzymeWrapper.setState({ askDelete: true });
+    // delete modal should be rendered
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(1);
+    expect(enzymeWrapper.find('h2').text()).to.equal('Delete subject');
+    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Delete');
+  });
+
+  it('on setting prop isEditing to true, edit modal is' +
+    ' rendered with expected title and Save button', () => {
+    const { enzymeWrapper } = setup({ isEditing: true });
+    expect(enzymeWrapper.find('.slds-modal__container')).to.have.length(1);
+    expect(enzymeWrapper.find('h2').text()).to.equal('Edit subject');
+    expect(enzymeWrapper.find('.slds-button--brand').text()).to.equal('Save');
+  });
+
+  it('on cancel delete, askDelete reverts to false', () => {
+    // calling the delete handler should set the
+    // delete status to true
+    const { enzymeWrapper } = setup();
+    const instance = enzymeWrapper.instance();
+    instance.handleDeleteClick();
+    expect(instance.state.askDelete).to.equal(true);
+
+    // turn the delete state false
+    instance.turnOffDelete();
+    expect(instance.state.askDelete).to.equal(false);
+  });
+});

--- a/view/admin/components/common/Modal.js
+++ b/view/admin/components/common/Modal.js
@@ -13,12 +13,18 @@
  */
 
 import React, { PropTypes } from 'react';
-import { Link } from 'react-router';
 
 // props: need onClose, onSave handlers
 class Modal extends React.Component {
   render() {
-    const { title, onSave, onHide, primaryBtnTxt, notificationBox } = this.props;
+    const {
+      title,
+      onSave,
+      onHide,
+      primaryBtnTxt,
+      children,
+      notificationBox
+    } = this.props;
     return (
       <div>
         <div
@@ -29,9 +35,13 @@ class Modal extends React.Component {
                 <div className='slds-modal__header'>
                     <button
                       onClick={onHide}
-                      className='slds-button slds-button--icon-inverse slds-modal__close'>
-                        <svg aria-hidden='true' className='slds-button__icon slds-button__icon--large'>
-                          <use xlinkHref='../static/icons/action-sprite/svg/symbols.svg#close'></use>
+                      className={'slds-button slds-button--icon-inverse' +
+                      ' slds-modal__close'}>
+                        <svg aria-hidden='true'
+                          className={'slds-button__icon' +
+                          ' slds-button__icon--large'}>
+                          <use xlinkHref={'../static/icons/' +
+                            'action-sprite/svg/symbols.svg#close'}></use>
                         </svg>
                         <span className='slds-assistive-text'>Close</span>
                     </button>
@@ -39,15 +49,16 @@ class Modal extends React.Component {
                 </div>
                 { notificationBox }
                 <div className='slds-modal__content slds-p-around--medium'>
-                {this.props.children}
+                {children}
                 </div>
                 <div className='slds-modal__footer'>
                     <button
                       onClick={onHide}
-                      className='slds-button slds-button--neutral'
+                      className='slds-button slds-button--neutral cancelButton'
                     >Cancel</button>
                     <button
-                      className='slds-button slds-button--neutral slds-button--brand'
+                      className={'slds-button slds-button--neutral' +
+                      ' slds-button--brand'}
                       onClick={onSave}
                     >{primaryBtnTxt || 'Save'}</button>
                 </div>
@@ -65,7 +76,8 @@ Modal.propTypes = {
   cancelUrl: PropTypes.string,
   onSave: PropTypes.func,
   onHide: PropTypes.func,
-  primaryBtnTxt: PropTypes.string
+  primaryBtnTxt: PropTypes.string,
+  children: React.PropTypes.element,
 };
 
 export default Modal;

--- a/view/admin/components/pages/Detail.js
+++ b/view/admin/components/pages/Detail.js
@@ -78,7 +78,7 @@ class Detail extends React.Component {
   }
   render () {
     const { url, refocusReducer, isEditing } = this.props;
-    // ie. subject, aspect
+    // resource: ie. subject, aspect
     const resource = url.split('/')[ONE].slice(ZERO, -ONE);
     // if no subject, do not render
     if (!refocusReducer[resource]) {
@@ -110,8 +110,6 @@ class Detail extends React.Component {
           <Modal
             title={`Delete ${resource}`}
             onSave={ this.doDelete }
-            // if other modal is open, close both this
-            // and the other modal
             onHide={ this.turnOffDelete }
             primaryBtnTxt='Delete'
           >

--- a/view/admin/components/pages/Detail.js
+++ b/view/admin/components/pages/Detail.js
@@ -30,6 +30,7 @@ class Detail extends React.Component {
     this.putForm = this.putForm.bind(this);
     this.handleDeleteClick = this.handleDeleteClick.bind(this);
     this.toggleEdit = this.toggleEdit.bind(this);
+    this.turnOffDelete = this.turnOffDelete.bind(this);
     this.doDelete = this.doDelete.bind(this);
   }
 
@@ -43,6 +44,12 @@ class Detail extends React.Component {
     const resource = url.split('/')[ONE].slice(ZERO, -ONE);
     deleteResource(url);
     history.push(`/${resource}s`);
+  }
+
+  turnOffDelete() {
+    this.setState({
+      askDelete: false,
+    });
   }
 
   // toggleEdit: change url to ?edit if not editing, and vice-versa
@@ -103,7 +110,9 @@ class Detail extends React.Component {
           <Modal
             title={`Delete ${resource}`}
             onSave={ this.doDelete }
-            onHide={ this.toggleEdit }
+            // if other modal is open, close both this
+            // and the other modal
+            onHide={ this.turnOffDelete }
             primaryBtnTxt='Delete'
           >
             <p>{message}</p>
@@ -131,6 +140,7 @@ class Detail extends React.Component {
               title={`Edit ${resource}`}
               resource={ resource }
               onSave={ this.putForm }
+              // toggles isEditing to off
               onHide={ this.toggleEdit }
             >
               <Form


### PR DESCRIPTION
- fix UI bug
- add tests to show bug is fixed
- introduce airbnb enzyme to react unit testing. 

Why enzyme?
- more concise, easier to read tests --> easier to maintain
- .find(className or nodeName) to find DOM element in rendered tree,
vs. TestUtils verbose props.children...props.children
- based off of React.TestUtils 
- relatively stable (v.2.6) and well-documented:
http://brewhouse.io/2016/03/18/accelerate-your-react-testing-with-enzyme.html
https://medium.com/airbnb-engineering/enzyme-javascript-testing-utilities-for-react-a417e5e5090f#.xyjupa296
