### PR TITLE
resolve problem where api get was failing if no params.sort

### DIFF
--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -164,8 +164,8 @@ function options(params, props) {
 
   // Specify the sort order. If defaultOrder is defined in props or sort value
   // then update sort order otherwise take value from model defination
-  if (params.sort.value || props.defaultOrder) {
-    const ord = (params.sort ? params.sort.value : null) || props.defaultOrder;
+  if ((params.sort && params.sort.value) || props.defaultOrder) {
+    const ord = params.sort.value || props.defaultOrder;
     opts.order = toSequelizeOrder(ord, props.modelName);
   }
 


### PR DESCRIPTION
 (e.g. globalconfig)