### PR TITLE
make the find function in movesocket more flexible

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,6 @@ const conf = {
     default: [
       'browserifyViews',
       'movecss',
-      'movesocket',
     ],
   },
   paths: {
@@ -134,24 +133,6 @@ gulp.task('movecss', () =>
     .on('end', () => {
       process.exit();
     })
-);
-
-/*
- * Moves socket io client side js to public folder
- */
-gulp.task('movesocket', () =>
-  gulp.src('./node_modules/socket.io-client/socket.io.js')
-    .pipe(gulp.dest(conf.view.dest))
-    .on('end', () => {
-      process.exit();
-    })
-);
-
-/*
- * Runs default tasks on any changes to src.
- */
-gulp.task('watch', () =>
-  gulp.watch(conf.paths.src, ['browserifyViews', 'movecss', 'movesocket'])
 );
 
 /*

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "type": "git",
     "url": "https://github.com/Salesforce/refocus.git"
   },
-  "watch": {
-    "view": "view/**/*/app.js"
-  },
   "scripts": {
     "build": "NODE_ENV=development && webpack --config ./webpack.config.js --progress --profile",
     "checkdb": "node db/createOrUpdateDb.js",
@@ -23,7 +20,7 @@
     "jscs": "./node_modules/jscs/bin/jscs *.js api cache clock config db jobQueue migrations realtime tests utils view worker",
     "lint": "eslint view/admin",
     "migratedb": "node db/migrate.js",
-    "postinstall": "NODE_ENV=production gulp browserifyViews && gulp movecss && gulp movesocket",
+    "postinstall": "NODE_ENV=production gulp browserifyViews && gulp movecss && node scripts/moveSocket.js",
     "prestart": "npm run checkdb",
     "start": "node --max_old_space_size=1500 --nouse-idle-notification index.js",
     "start-clock": "node --max_old_space_size=1500 --nouse-idle-notification clock/index.js",
@@ -88,7 +85,6 @@
     "multer": "^1.0.3",
     "nock": "^3.6.0",
     "npm": "^3.10.9",
-    "npm-watch": "^0.1.3",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "passport-saml": "^0.15.0",
@@ -116,6 +112,7 @@
     "sequelize-cli": "^2.1.0",
     "sequelize-hierarchy": "^0.5.0",
     "serve-favicon": "^2.3.0",
+    "shelljs": "^0.7.5",
     "sinon": "^1.17.2",
     "socket.io": "^1.4.5",
     "socket.io-client": "^1.4.5",

--- a/scripts/moveSocket.js
+++ b/scripts/moveSocket.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+ /**
+ * ./scripts/moveSocket.js
+ *
+ * Call this script from the command line to move the socket.io.js from
+ * any folder in socket.io-client  to the destination folder.
+ */
+
+require('shelljs/global');
+const DEST_PATH = 'public';
+
+const arr = find('node_modules/socket.io-client')
+  .filter((file) => {
+    return file.match(/socket.io.js$/);
+  });
+if (arr.length !== 1) {
+  throw new Error('Did not find client-side socket.io script');
+} else {
+  cp('-f', arr[0], DEST_PATH);
+}


### PR DESCRIPTION
- no more GET socket.io.js 404 errors, as long as there is a socket.io.js script in socket.io-client folder
- took movesocket task out from gulp, move int separate bash script