### PR TITLE
Aspect tag change realtime events

### DIFF
--- a/tests/db/model/aspect/tags.js
+++ b/tests/db/model/aspect/tags.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * tests/db/model/aspect/tagsAndLinks.js
+ * tests/db/model/aspect/tags.js
  */
 'use strict';
 

--- a/tests/db/model/aspect/tags.js
+++ b/tests/db/model/aspect/tags.js
@@ -67,7 +67,7 @@ describe('db: aspect: tags: update', () => {
       name: `${tu.namePrefix}Subject|${tu.namePrefix}A`,
     }))
     .then((s) => {
-      expect(s.dataValues.aspect.tags).to.have.members(['T3']);
+      expect(s.dataValues.aspect.tags).to.deep.equal(['T3']);
       done();
     })
     .catch(done);

--- a/tests/db/model/aspect/tags.js
+++ b/tests/db/model/aspect/tags.js
@@ -18,7 +18,7 @@ const Aspect = tu.db.Aspect;
 const Subject = tu.db.Subject;
 const Sample = tu.db.Sample;
 
-describe.only('db: aspect: tags: update', () => {
+describe('db: aspect: tags: update', () => {
   beforeEach((done) => {
     Aspect.create({
       isPublished: true,

--- a/tests/db/model/aspect/tags.js
+++ b/tests/db/model/aspect/tags.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/db/model/aspect/tagsAndLinks.js
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const Aspect = tu.db.Aspect;
+const Subject = tu.db.Subject;
+const Sample = tu.db.Sample;
+
+describe.only('db: aspect: tags: update', () => {
+  beforeEach((done) => {
+    Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}A`,
+      timeout: '1s',
+      valueType: 'NUMERIC',
+      criticalRange: [0, 0],
+      warningRange: [1, 1],
+      infoRange: [2, 2],
+      okRange: [3, 3],
+      tags: ['T1'],
+    })
+    .then(() => Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}B`,
+      timeout: '2m',
+      valueType: 'NUMERIC',
+      criticalRange: [0, 0],
+      warningRange: [1, 1],
+      infoRange: [2, 2],
+      okRange: [3, 3],
+      tags: ['T2'],
+    }))
+    .then(() => Subject.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Subject`,
+    }))
+    .then(() => Sample.bulkUpsertByName([
+      { name: `${tu.namePrefix}Subject|${tu.namePrefix}A`, value: 1 },
+      { name: `${tu.namePrefix}Subject|${tu.namePrefix}B`, value: 2 },
+    ]))
+    .then(() => done())
+    .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  it('update an aspect tag, samples have it next time they are loaded',
+  (done) => {
+    Aspect.findOne({ name: `${tu.namePrefix}A` })
+    .then((o) => {
+      o.tags = ['T3'];
+      return o.save();
+    })
+    .then(() => Sample.findOne({
+      name: `${tu.namePrefix}Subject|${tu.namePrefix}A`,
+    }))
+    .then((s) => {
+      expect(s.dataValues.aspect.tags).to.have.members(['T3']);
+      done();
+    })
+    .catch(done);
+  });
+});

--- a/tests/db/model/aspect/unpublish.js
+++ b/tests/db/model/aspect/unpublish.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/db/model/aspect/unpublish.js
+ */
+'use strict';
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+const expect = require('chai').expect;
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const Sample = tu.db.Sample;
+const Aspect = tu.db.Aspect;
+const Subject = tu.db.Subject;
+const Profile = tu.db.Profile;
+const User = tu.db.User;
+
+describe('aspect gets unpublished:', () => {
+  let asp;
+
+  beforeEach((done) => {
+    Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Aspect`,
+      timeout: '30s',
+      valueType: 'NUMERIC',
+    })
+    .then((a) => {
+      asp = a;
+      return Subject.create({
+        isPublished: true,
+        name: `${tu.namePrefix}Subject`,
+      });
+    })
+    .then((subj) => Sample.create({ aspectId: asp.id, subjectId: subj.id }))
+    .then(() => done())
+    .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  it('sample is deleted when aspect is unpublished', (done) => {
+    asp.update({ isPublished: false })
+    .then((a) => a.getSamples())
+    .then((samples) => {
+      expect(samples.length).to.equal(0);
+      done();
+    })
+    .catch(done);
+  });
+});

--- a/tests/db/model/aspect/update.js
+++ b/tests/db/model/aspect/update.js
@@ -261,7 +261,7 @@ describe('db: aspect: update: associations: relatedLinks & Tags ', () => {
   describe('relatedLinks: ', () => {
     it('update a relatedLink', (done) => {
       const asp = u.getSmall();
-      asp.relatedLinks = [{ name: '___reLink', url: 'https://fakelink.com'}];
+      asp.relatedLinks = [{ name: '___reLink', url: 'https://fakelink.com' }];
       Aspect.create(asp)
         .then((o) => {
           // console.log(o.dataValues.relatedLinks);
@@ -280,7 +280,7 @@ describe('db: aspect: update: associations: relatedLinks & Tags ', () => {
     });
     it('update a relatedLink', (done) => {
       const asp = u.getSmall();
-      asp.relatedLinks = [{ name: '___reLink', url: 'https://fakelink.com'}];
+      asp.relatedLinks = [{ name: '___reLink', url: 'https://fakelink.com' }];
       Aspect.create(asp)
         .then((o) => {
           // console.log(o.dataValues.relatedLinks);


### PR DESCRIPTION
When an aspect’s tags change, send “delete” and “add” realtime events (instead of “update”)
so that perspectives which filter by aspect tag will get the right sample events.
