### PR TITLE
Get rid of unnecessary “test” environment

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,6 @@
  */
 'use strict'; // eslint-disable-line strict
 require('./config/toggles'); // Loads the feature toggles
-const featureToggles = require('feature-toggles');
 const configUtil = require('./config/configUtil');
 const defaultPort = 3000;
 const defaultPostgresPort = 5432;
@@ -123,22 +122,6 @@ module.exports = {
       dbUrl: pe.DATABASE_URL,
       isInHerokuPrivateSpace: pe.IS_IN_HEROKU_PRIVATE_SPACE || false,
       redisUrl: pe.REDIS_URL,
-      ipWhitelist: iplist,
-      dialect: 'postgres',
-      protocol: 'postgres',
-      dialectOptions: {
-        ssl: true,
-      },
-      tokenSecret: pe.SECRET_TOKEN ||
-       '7265666f637573726f636b7377697468677265656e6f776c7373616e6672616e',
-    },
-    test: {
-      checkTimeoutIntervalMillis: pe.CHECK_TIMEOUT_INTERVAL_MILLIS ||
-        DEFAULT_CHECK_TIMEOUT_INTERVAL_MILLIS,
-      dbLogging: false, // console.log | false | ...
-      dbUrl: pe.DATABASE_URL,
-      redisUrl: pe.REDIS_URL,
-      defaultNodePort: defaultPort,
       ipWhitelist: iplist,
       dialect: 'postgres',
       protocol: 'postgres',

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test-disablehttp": "DISABLE_HTTP=true mocha -R dot --recursive tests/disableHttp",
     "test-enforced": "USE_ACCESS_TOKEN=true mocha -R dot --recursive tests/enforceToken",
     "test-db": "npm run checkdb && mocha -R dot --recursive tests/db",
-    "test-view": "NODE_ENV=test mocha -R dot --recursive --compilers js:babel-core/register --require ./tests/view/setup.js tests/view",
+    "test-view": "NODE_ENV=build mocha -R dot --recursive --compilers js:babel-core/register --require ./tests/view/setup.js tests/view",
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R dot --recursive tests/api tests/config tests/db tests/jobQueue tests/realtime tests/tokenNotReq && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage && npm run test-view && npm run test-disablehttp && npm run test-enforced",
     "undo-migratedb": "node db/migrateUndo.js",
     "view": "NODE_ENV=production gulp browserifyViews && npm start"


### PR DESCRIPTION
(was only being used for view tests)—just use the “build” env for this