### PR TITLE
User model's defaultScope should exclude password

### DIFF
--- a/api/v1/helpers/nouns/users.js
+++ b/api/v1/helpers/nouns/users.js
@@ -23,9 +23,6 @@ module.exports = {
     POST: `Create a new ${m}`,
     PUT: `Overwrite all attributes of this ${m}`,
   },
-  scopeMap: {
-    withoutSensitiveInfo: 'withoutSensitiveInfo',
-  },
   baseUrl: '/v1/users',
   model: User,
   modelName: 'User',

--- a/config/passportconfig.js
+++ b/config/passportconfig.js
@@ -13,7 +13,7 @@
 'use strict'; // eslint-disable-line strict
 
 const LocalStrategy = require('passport-local').Strategy;
-const User = require('../db/index').User;
+const User = require('../db/index').User.scope('withSensitiveInfo');
 const Token = require('../db/index').Token;
 const Profile = require('../db/index').Profile;
 const bcrypt = require('bcrypt-nodejs');

--- a/db/model/user.js
+++ b/db/model/user.js
@@ -91,17 +91,6 @@ module.exports = function user(seq, dataTypes) {
           foreignKey: 'userId',
         });
         User.addScope('defaultScope', {
-
-          include: [
-            {
-              association: assoc.profile,
-              attributes: ['name'],
-            },
-          ],
-        }, {
-          override: true,
-        });
-        User.addScope('withoutSensitiveInfo', {
           attributes: {
             exclude: ['password'],
           },
@@ -112,11 +101,19 @@ module.exports = function user(seq, dataTypes) {
             },
           ],
           order: ['User.name'],
+        }, {
+          override: true,
+        });
+        User.addScope('withSensitiveInfo', {
+          include: [
+            {
+              association: assoc.profile,
+              attributes: ['name'],
+            },
+          ],
+          order: ['User.name'],
         });
       },
-    },
-    defaultScope: {
-      order: ['User.name'],
     },
     hooks: {
 

--- a/tests/api/v1/aspects/getWriters.js
+++ b/tests/api/v1/aspects/getWriters.js
@@ -82,7 +82,7 @@ describe('api: aspects: get writer(s)', () => {
     });
   });
 
-  it.skip('find Writers and make sure the passwords are not returned', (done) => {
+  it('find Writers and make sure the passwords are not returned', (done) => {
     api.get(getWritersPath.replace('{key}', aspect.name))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/api/v1/lenses/getWriters.js
+++ b/tests/api/v1/lenses/getWriters.js
@@ -77,7 +77,7 @@ describe('api: lenses: get writers}', () => {
     });
   });
 
-  it.skip('find Writers and make sure the passwords are not returned', (done) => {
+  it('find Writers and make sure the passwords are not returned', (done) => {
     api.get(getWritersPath.replace('{key}', lens.name))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/api/v1/perspectives/getWriters.js
+++ b/tests/api/v1/perspectives/getWriters.js
@@ -85,7 +85,7 @@ describe('api: perspective: get writers', () => {
     });
   });
 
-  it.skip('find Writers and make sure the passwords are not returned', (done) => {
+  it('find Writers and make sure the passwords are not returned', (done) => {
     api.get(getWritersPath.replace('{key}', perspective.name))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/api/v1/subjects/getWriters.js
+++ b/tests/api/v1/subjects/getWriters.js
@@ -81,7 +81,7 @@ describe('api: subjects: get writers}', () => {
     });
   });
 
-  it.skip('find Writers and make sure the passwords are not returned', (done) => {
+  it('find Writers and make sure the passwords are not returned', (done) => {
     api.get(getWritersPath.replace('{key}', subject.name))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/api/v1/users/get.js
+++ b/tests/api/v1/users/get.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * tests/api/v1/userTokens/get.js
+ * tests/api/v1/users/get.js
  */
 'use strict';
 
@@ -22,7 +22,7 @@ const Profile = tu.db.Profile;
 const User = tu.db.User;
 const Token = tu.db.Token;
 
-describe(`api: GET ${path}/U/tokens/T`, () => {
+describe(`api: GET ${path}`, () => {
   const uname = `${tu.namePrefix}test@refocus.com`;
   const tname = `${tu.namePrefix}Voldemort`;
 
@@ -38,42 +38,43 @@ describe(`api: GET ${path}/U/tokens/T`, () => {
         password: 'user123password',
       })
     )
-    .then((user) => {
-      return Token.create({
-        name: tname,
-        createdBy: user.id,
-      });
-    })
     .then(() => done())
     .catch(done);
   });
 
   after(u.forceDelete);
 
-  it('user and token found', (done) => {
-    api.get(`${path}/${uname}/tokens/${tname}`)
-    .set('Authorization', '???')
+  it('user found', (done) => {
+    api.get(`${path}/${uname}`)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
         done(err);
       } else {
-        expect(res.body).to.have.property('name', tname);
+        expect(res.body).to.have.property('name', uname);
+        expect(res.body).to.not.have.property('password');
         expect(res.body.isDeleted).to.not.equal(0);
         done();
       }
     });
   });
 
-  it('user not found', (done) => {
-    api.get(`${path}/who@what.com/tokens/foo`)
-    .set('Authorization', '???')
-    .expect(constants.httpStatus.NOT_FOUND)
-    .end(() => done());
+  it('users array returned', (done) => {
+    api.get(`${path}`)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      } else {
+        expect(res.body).to.be.instanceof(Array);
+        expect(res.body[0]).to.not.have.property('password');
+        done();
+      }
+    });
   });
 
-  it('user found but token name not found', (done) => {
-    api.get(`${path}/${uname}/tokens/foo`)
+  it('user not found', (done) => {
+    api.get(`${path}/who@what.com`)
     .set('Authorization', '???')
     .expect(constants.httpStatus.NOT_FOUND)
     .end(() => done());

--- a/tests/api/v1/users/utils.js
+++ b/tests/api/v1/users/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/users/utils.js
+ */
+'use strict';
+
+const tu = require('../../../testUtils');
+
+const testStartTime = new Date();
+
+module.exports = {
+  forceDelete(done) {
+    tu.forceDelete(tu.db.User, testStartTime)
+    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+    .then(() => done())
+    .catch(done);
+  },
+};

--- a/tests/db/model/user/create.js
+++ b/tests/db/model/user/create.js
@@ -48,10 +48,11 @@ describe('db: User: create', () => {
     expect(user).to.have.property('email').to.equal('user@example.com');
     expect(user.password).to.not.equal('user123password');
     bcrypt.compare('user123password', user.password, (err, res) => {
-      if(err){
+      if (err) {
         throw err;
       }
-      expect(res).to.be.true;  // eslint-disable-line no-unused-expressions
+
+      expect(res).to.be.true; // eslint-disable-line no-unused-expressions
     });
     done();
   });

--- a/tests/db/model/user/find.js
+++ b/tests/db/model/user/find.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/db/model/user/find.js
+ */
+'use strict';  // eslint-disable-line strict
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const expect = require('chai').expect;
+const User = tu.db.User;
+const Profile = tu.db.Profile;
+
+describe('db: user: find: ', () => {
+  beforeEach((done) => {
+    Profile.create({ name: `${tu.namePrefix}1` })
+    .then((createdProfile) => {
+      return User.create({
+        profileId: createdProfile.id,
+        name: `${tu.namePrefix}1`,
+        email: 'user@example.com',
+        password: 'user123password',
+      });
+    })
+    .then(() => done())
+    .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  it('default scope no password', (done) => {
+    User.find({ name: `${tu.namePrefix}1` })
+    .then((found) => {
+      expect(found.dataValues).to.not.have.property('password');
+      done();
+    })
+    .catch(done);
+  });
+
+  it('withSensitiveInfo scope', (done) => {
+    User.scope('withSensitiveInfo').find({ name: `${tu.namePrefix}1` })
+    .then((found) => {
+      expect(found.dataValues).to.have.property('password');
+      done();
+    })
+    .catch(done);
+  });
+});


### PR DESCRIPTION
By default, the API will now return User records *without* the encrypted password field.
Explicitly use the db model scope “withSensitiveInfo” to include the encrypted password field in the response (e.g. for passport configuration).
Add tests to confirm both the default and the scoped behavior.
Unskip all the “getWriters” tests.