### PR TITLE
Immediate-term workaround: catch unhandled kue error and move on

### DIFF
--- a/jobQueue/jobWrapper.js
+++ b/jobQueue/jobWrapper.js
@@ -72,7 +72,12 @@ function processJobOnComplete(job, logObject) {
   if (job) {
     job.on('complete', (jobResultObj) => {
       setTimeout(() => {
-        job.remove();
+        try {
+          job.remove();
+        } catch (err) {
+          console.log( // eslint-disable-line no-console
+            'Error removing kue job', job, err);
+        }
       }, delayToRemoveJobs);
 
       // if enableWorkerActivityLogs is enabled, update logObject
@@ -86,12 +91,13 @@ function processJobOnComplete(job, logObject) {
       }
     });
   }
-} // removeJobOnComplete
+} // processJobOnComplete
 
 /**
- * Logs worker activity and remove job when complete
- * @param  {Object} job - Worker job
+ * Logs worker activity and remove job when complete.
+ *
  * @param  {Object} req - Request object
+ * @param  {Object} job - Worker job
  */
 function logAndRemoveJobOnComplete(req, job) {
   // if activity logs are enabled, log activity and remove job

--- a/jobQueue/jobWrapper.js
+++ b/jobQueue/jobWrapper.js
@@ -75,8 +75,8 @@ function processJobOnComplete(job, logObject) {
         try {
           job.remove();
         } catch (err) {
-          console.log( // eslint-disable-line no-console
-            'Error removing kue job', job, err);
+          console.log('Error removing ' + // eslint-disable-line no-console
+            'kue job', job, err);
         }
       }, delayToRemoveJobs);
 


### PR DESCRIPTION
worker dynos crashing:
```
throw er; // Unhandled 'error' event 
Error: job "..." doesnt exist 
at Command.callback (/app/node_modules/kue/lib/queue/job.js:175:17) 
at normal_reply (/app/node_modules/redis/index.js:721:21) 
at RedisClient.return_reply (/app/node_modules/redis/index.js:819:9) 
...
```