### PR TITLE
Restrict deletion of default token

### DIFF
--- a/api/v1/controllers/userTokens.js
+++ b/api/v1/controllers/userTokens.js
@@ -65,63 +65,59 @@ module.exports = {
    */
   deleteUserToken(req, res, next) {
     const resultObj = { reqStartTime: new Date() };
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        const user = req.swagger.params.key.value;
-        const tokenName = req.swagger.params.tokenName.value;
-        const whr = whereClauseForUserAndTokenName(user, tokenName);
-        helper.model.findOne(whr)
-        .then((o) => {
-          if (o) {
-            return o.destroy();
-          }
+    const user = req.swagger.params.key.value;
+    const tokenName = req.swagger.params.tokenName.value;
+    const whr = whereClauseForUserAndTokenName(user, tokenName);
+    let tokenToDel;
 
-          const err = new apiErrors.ResourceNotFoundError();
-          err.resource = helper.model.name;
-          err.key = user + ', ' + tokenName;
-          throw err;
-        })
-        .then((o) => {
-          resultObj.dbTime = new Date() - resultObj.reqStartTime;
-          u.logAPI(req, resultObj, o.dataValues);
-          res.status(httpStatus.OK)
-            .json(u.responsify(o, helper, req.method));
-        })
-        .catch((err) => u.handleError(next, err, helper.modelName));
-      } else {
-        // also OK if user is NOT admin but is deleting own token
-        let userId;
-        authUtils.getUser(req)
-        .then((currentUser) => {
-          userId = currentUser.id;
-          const user = req.swagger.params.key.value;
-          const tokenName = req.swagger.params.tokenName.value;
-          const whr = whereClauseForUserAndTokenName(user, tokenName);
-          helper.model.findOne(whr)
-          .then((o) => {
-            if (o && o.createdBy === userId) {
-              return o.destroy();
-            }
-
-            const err = new apiErrors.ResourceNotFoundError();
-            err.resource = helper.model.name;
-            err.key = user + ', ' + tokenName;
-            throw err;
-          })
-          .then((o) => {
-            resultObj.dbTime = new Date() - resultObj.reqStartTime;
-            u.logAPI(req, resultObj, o.dataValues);
-            res.status(httpStatus.OK)
-              .json(u.responsify(o, helper, req.method));
-          })
-          .catch((err) => u.handleError(next, err, helper.modelName));
-        });
+    // get user token
+    helper.model.findOne(whr)
+    .then((token) => {
+      // if no token found, return error
+      if (!token) {
+        const err = new apiErrors.ResourceNotFoundError();
+        err.resource = helper.model.name;
+        err.key = user + ', ' + tokenName;
+        throw err;
       }
+
+      // Default token cannot be deleted
+      if (token.name === token.User.name) {
+        u.forbidden(next);
+      }
+
+      tokenToDel = token;
+
+      // Check if requesting user is Admin
+      return authUtils.isAdmin(req);
     })
-    .catch((err) => {
-      u.forbidden(next);
-    });
+    .then((isAdmin) => {
+      // if admin, delete the token
+      if (isAdmin) {
+        return tokenToDel.destroy();
+      }
+
+      return authUtils.getUser(req)
+      .then((currentUser) => {
+        // OK to delete if user is NOT admin but is deleting own token
+        if (tokenToDel && tokenToDel.createdBy === currentUser.id) {
+          return tokenToDel.destroy();
+        }
+
+        // else forbidden
+        return u.forbidden(next);
+      })
+      .catch((err) => {
+        throw err;
+      });
+    })
+    .then((o) => {
+      resultObj.dbTime = new Date() - resultObj.reqStartTime;
+      u.logAPI(req, resultObj, o.dataValues);
+      res.status(httpStatus.OK)
+      .json(u.responsify(o, helper, req.method));
+    })
+    .catch((err) => u.handleError(next, err, helper.modelName));
   },
 
   /**

--- a/config/passportconfig.js
+++ b/config/passportconfig.js
@@ -76,7 +76,7 @@ module.exports = (passportModule) => {
         newUserCreated = newUser;
         return Token.create({
           name: newUser.name,
-          createdby: newUser.id,
+          createdBy: newUser.id,
         });
       })
       .then(() => {

--- a/db/model/token.js
+++ b/db/model/token.js
@@ -12,8 +12,6 @@
 
 const constants = require('../constants');
 const common = require('../helpers/common');
-const dbErrors = require('../dbErrors');
-const u = require('../helpers/userUtils');
 
 const assoc = {};
 
@@ -65,12 +63,6 @@ module.exports = function token(seq, dataTypes) {
     },
     hooks: {
       beforeDestroy(inst /* , opts */) {
-        if (inst.name === inst.User.name && inst.User.isDeleted) {
-          // Not allowed to delete the system-created token record
-          const err = new dbErrors.TokenDeleteConstraintError();
-          throw err;
-        }
-
         return common.setIsDeleted(seq.Promise, inst);
       },
     },

--- a/db/model/user.js
+++ b/db/model/user.js
@@ -90,6 +90,11 @@ module.exports = function user(seq, dataTypes) {
           through: 'SubjectWriters',
           foreignKey: 'userId',
         });
+        assoc.tokens = User.hasMany(models.Token, {
+          as: 'tokens',
+          foreignKey: 'createdBy',
+          hooks: true,
+        });
         User.addScope('defaultScope', {
           attributes: {
             exclude: ['password'],
@@ -152,6 +157,8 @@ module.exports = function user(seq, dataTypes) {
         return new seq.Promise((resolve, reject) =>
           inst.getProfile()
           .then((p) => p.decrement('userCount'))
+          .then(() => inst.getTokens())
+          .each((token) => token.destroy())
           .then(() => common.setIsDeleted(seq.Promise, inst))
           .then(() => resolve(inst))
           .catch((err) => reject(err))

--- a/tests/api/v1/register/registerUser.js
+++ b/tests/api/v1/register/registerUser.js
@@ -38,6 +38,7 @@ describe('api: registerUser', () => {
       Token.findAll({ where: { name: res.body.name } })
       .then((tokens) => {
         expect(tokens.length).to.be.equal(1);
+        expect(tokens[0].createdBy).to.be.equal(res.body.id);
         expect(tokens[0].isRevoked).to.be.equal('0');
       })
       .catch(done);

--- a/tests/api/v1/userTokens/delete.js
+++ b/tests/api/v1/userTokens/delete.js
@@ -18,9 +18,7 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
-const Profile = tu.db.Profile;
-const User = tu.db.User;
-const Token = tu.db.Token;
+
 const jwtUtil = require('../../../../utils/jwtUtil');
 const adminUser = require('../../../../config').db.adminUser;
 const regPath = '/v1/register';
@@ -176,9 +174,9 @@ describe(`api: DELETE ${path}/U/tokens/T`, () => {
     });
   });
 
-  it('not admin user, user found but token name not found', (done) => {
+  it('non-admin user, user found but token name not found', (done) => {
     api.delete(`${path}/${uname}/tokens/foo`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
       if (err) {

--- a/tests/api/v1/userTokens/get.js
+++ b/tests/api/v1/userTokens/get.js
@@ -30,6 +30,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
   const tname2 = `${tu.namePrefix}Tom`;
   const tnameOther = `${tu.namePrefix}Dumbledore`;
   let userId;
+  let unameToken;
 
   before((done) => {
     // create user __test@refocus.com
@@ -45,6 +46,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
       }
 
       userId = res.body.id;
+      unameToken = res.body.token;
 
       // create token ___Voldemort
       api.post(tokenPath)
@@ -97,7 +99,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user by name and token found', (done) => {
     api.get(`${path}/${uname}/tokens/${tname1}`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
@@ -112,7 +114,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user by Id and token found', (done) => {
     api.get(`${path}/${userId}/tokens/${tname1}`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
@@ -127,7 +129,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user not found, one token', (done) => {
     api.get(`${path}/who@what.com/tokens/foo`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
       if (err) {
@@ -141,7 +143,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user not found, all tokens', (done) => {
     api.get(`${path}/who@what.com/tokens`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
@@ -155,7 +157,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user found but token name not found', (done) => {
     api.get(`${path}/${uname}/tokens/foo`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
       if (err) {
@@ -169,7 +171,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user found, token found, but token of different user', (done) => {
     api.get(`${path}/${uname}/tokens/${tnameOther}`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
       if (err) {
@@ -183,7 +185,7 @@ describe(`api: GET ${path}/U/tokens`, () => {
 
   it('user, get all tokens', (done) => {
     api.get(`${path}/${uname}/tokens`)
-    .set('Authorization', '???')
+    .set('Authorization', unameToken)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {

--- a/tests/api/v1/userTokens/get.js
+++ b/tests/api/v1/userTokens/get.js
@@ -18,11 +18,10 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
-const Profile = tu.db.Profile;
-const User = tu.db.User;
-const Token = tu.db.Token;
+const regPath = '/v1/register';
+const tokenPath = '/v1/tokens';
 
-describe(`api: GET ${path}/U/tokens/T`, () => {
+describe(`api: GET ${path}/U/tokens`, () => {
   /* user uname has 2 tokens: Voldemort and Tom
    user with unameOther has 1 token: Dumbledore */
   const uname = `${tu.namePrefix}test@refocus.com`;
@@ -30,47 +29,68 @@ describe(`api: GET ${path}/U/tokens/T`, () => {
   const tname1 = `${tu.namePrefix}Voldemort`;
   const tname2 = `${tu.namePrefix}Tom`;
   const tnameOther = `${tu.namePrefix}Dumbledore`;
-  let profileId;
   let userId;
 
   before((done) => {
-    Profile.create({
-      name: `${tu.namePrefix}testProfile`,
+    // create user __test@refocus.com
+    api.post(regPath)
+    .send({
+      email: uname,
+      password: 'fakePasswd',
+      username: uname,
     })
-    .then((profile) => {
-      profileId = profile.id;
-      return User.create({
-        profileId: profile.id,
-        name: uname,
-        email: uname,
-        password: 'user123password',
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      userId = res.body.id;
+
+      // create token ___Voldemort
+      api.post(tokenPath)
+      .set('Authorization', res.body.token)
+      .send({ name: tname1 })
+      .end((err1, res1) => {
+        if (err1) {
+          done(err1);
+        }
+
+        // create token ___Tom
+        api.post(tokenPath)
+        .set('Authorization', res.body.token)
+        .send({ name: tname2 })
+        .end((err2, res2) => {
+          if (err2) {
+            done(err2);
+          }
+
+          // create user __testOther@refocus.com
+          api.post(regPath)
+          .send({
+            email: unameOther,
+            password: 'fakePasswd',
+            username: unameOther,
+          })
+          .end((err3, res3) => {
+            if (err3) {
+              done(err3);
+            }
+
+            // create token ___Tom
+            api.post(tokenPath)
+            .set('Authorization', res3.body.token)
+            .send({ name: tnameOther })
+            .end((err4, res4) => {
+              if (err4) {
+                done(err4);
+              }
+
+              done();
+            });
+          });
+        });
       });
-    })
-    .then((user) => {
-      userId = user.id;
-      return Token.create({
-        name: tname1,
-        createdBy: user.id,
-      });
-    })
-    .then(() => Token.create({
-      name: tname2,
-      createdBy: userId,
-    }))
-    .then(() =>
-      User.create({
-        profileId: profileId,
-        name: unameOther,
-        email: unameOther,
-        password: 'user123password',
-      })
-    )
-    .then((user) => Token.create({
-      name: tnameOther,
-      createdBy: user.id,
-    }))
-    .then(() => done())
-    .catch(done);
+    });
   });
 
   after(u.forceDelete);
@@ -169,10 +189,10 @@ describe(`api: GET ${path}/U/tokens/T`, () => {
       if (err) {
         done(err);
       } else {
-        expect(res.body).to.have.length(2);
-        expect(res.body[0]).to.have.property('name', tname2);
-        expect(res.body[1]).to.have.property('name', tname1);
-        expect(res.body.isDeleted).to.not.equal(0);
+        expect(res.body).to.have.length(3);
+        expect(res.body[0].User).to.have.property('name', uname);
+        expect(res.body[1].User).to.have.property('name', uname);
+        expect(res.body[2].User).to.have.property('name', uname);
         done();
       }
     });

--- a/tests/api/v1/users/delete.js
+++ b/tests/api/v1/users/delete.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/users/delete.js
+ */
+'use strict';
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const path = '/v1/users';
+const expect = require('chai').expect;
+// const Profile = tu.db.Profile;
+// const User = tu.db.User;
+const Token = tu.db.Token;
+const jwtUtil = require('../../../../utils/jwtUtil');
+const adminUser = require('../../../../config').db.adminUser;
+const registerPath = '/v1/register';
+const tokenPath = '/v1/tokens';
+
+describe(`api: DELETE ${path}/:id`, () => {
+  const predefinedAdminUserToken = jwtUtil.createToken(
+    adminUser.name, adminUser.name
+  );
+  const uname = `${tu.namePrefix}test@refocus.com`;
+  const tname = `${tu.namePrefix}Voldemort`;
+  let userId;
+
+  before((done) => {
+    // create user __test@refocus.com
+    api.post(registerPath)
+    .send({
+      email: uname,
+      password: 'fakePasswd',
+      username: uname,
+    })
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      userId = res.body.id;
+
+      // create token ___Voldemort
+      api.post(tokenPath)
+      .set('Authorization', res.body.token)
+      .send({ name: tname })
+      .end((err1, res1) => {
+        if (err1) {
+          done(err1);
+        }
+
+        done();
+      });
+    });
+  });
+
+  afterEach(u.forceDelete);
+
+  it('deletion of user deletes default token', (done) => {
+    api.delete(`${path}/${uname}`)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      } else {
+        expect(res.body).to.have.property('name', uname);
+        expect(res.body).to.not.have.property('password');
+        expect(res.body.isDeleted).to.not.equal(0);
+
+        Token.findOne({ where: { name: uname, createdBy: userId } })
+        .then((tobj) => {
+          if (tobj) {
+            done(new Error('Default token should have been deleted'));
+          }
+
+          done();
+        })
+        .catch((err1) => done(err1));
+      }
+    });
+  });
+});

--- a/tests/api/v1/users/delete.js
+++ b/tests/api/v1/users/delete.js
@@ -18,18 +18,11 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
-// const Profile = tu.db.Profile;
-// const User = tu.db.User;
 const Token = tu.db.Token;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 const registerPath = '/v1/register';
 const tokenPath = '/v1/tokens';
 
 describe(`api: DELETE ${path}/:id`, () => {
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
   const uname = `${tu.namePrefix}test@refocus.com`;
   const tname = `${tu.namePrefix}Voldemort`;
   let userId;

--- a/tests/api/v1/users/utils.js
+++ b/tests/api/v1/users/utils.js
@@ -17,7 +17,8 @@ const testStartTime = new Date();
 
 module.exports = {
   forceDelete(done) {
-    tu.forceDelete(tu.db.User, testStartTime)
+    tu.forceDelete(tu.db.Token, testStartTime)
+    .then(() => tu.forceDelete(tu.db.User, testStartTime))
     .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
     .then(() => done())
     .catch(done);

--- a/tests/db/model/token/delete.js
+++ b/tests/db/model/token/delete.js
@@ -43,25 +43,3 @@ describe('db: Token: delete', () => {
     .catch(done);
   });
 });
-
-describe('db: System Token: delete', () => {
-  let t;
-  beforeEach((done) => {
-    u.createSystemToken()
-    .then((token) => {
-      t = token;
-      done();
-    })
-    .catch(done);
-  });
-  afterEach(u.forceDelete);
-  it('Not allowed to delete system token', (done) => {
-    Token.findOne({ where: { name: t.name } })
-    .then((token) => token.destroy())
-    .then(() => done('expecting error here'))
-    .catch((err) => {
-      expect(err).to.have.property('name', 'TokenDeleteConstraintError');
-      done();
-    });
-  });
-});

--- a/tests/db/model/token/utils.js
+++ b/tests/db/model/token/utils.js
@@ -44,22 +44,4 @@ module.exports = {
       createdBy: returnedUser.id,
     }));
   },
-
-  createSystemToken() {
-    return tu.db.Profile.create({
-      name: `${pfx}testProfile`,
-    })
-    .then((createdProfile) =>
-      tu.db.User.create({
-        profileId: createdProfile.id,
-        name: `${pfx}test@refocus.com`,
-        email: `${pfx}test@refocus.com`,
-        password: 'user123password',
-      })
-    )
-    .then((returnedUser) => tu.db.Token.create({
-      name: returnedUser.name,
-      createdBy: returnedUser.id,
-    }));
-  },
 };

--- a/utils/jwtUtil.js
+++ b/utils/jwtUtil.js
@@ -62,6 +62,7 @@ function verifyToken(req, cb) {
       } else {
         User.findOne({ where: { name: decodedData.username } })
         .then((user) => {
+          // set user in request
           if (user) {
             req.user = user;
             return cb();


### PR DESCRIPTION
List all tokens in /v1/user/:id/tokens including default token
No user (admin/non-admin) can delete default token
Cascade delete token on user deletion
Refactor postToken
Refactor deleteUserToken  to restrict default token deletion
Added/updated tests