### PR TITLE
changes to assemble the complete subject hierarchy from the cache layer

### DIFF
--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -31,8 +31,10 @@ const u = require('../helpers/verbs/utils');
 const httpStatus = require('../constants').httpStatus;
 const apiErrors = require('../apiErrors');
 const logAuditAPI = require('../../../utils/loggingUtil').logAuditAPI;
+const redisSubjectModel = require('../../../cache/models/subject');
+const sampleStoreFeature =
+                  require('../../../cache/sampleStore').constants.featureName;
 const ZERO = 0;
-const ONE = 1;
 
 /**
  * Validates the correct filter parameter
@@ -199,7 +201,11 @@ module.exports = {
       }
     }
 
-    u.findByKey(helper, params, ['hierarchy', 'samples'])
+    const findByKeyPromise =
+      featureToggles.isFeatureEnabled(sampleStoreFeature) ?
+            u.findByKey(helper, params, ['hierarchy']) :
+              u.findByKey(helper, params, ['hierarchy', 'samples']);
+    findByKeyPromise
     .then((o) => {
       resultObj.dbTime = new Date() - resultObj.reqStartTime;
       let retval = u.responsify(o, helper, req.method);
@@ -207,9 +213,18 @@ module.exports = {
         retval = helper.deleteChildren(retval, depth);
       }
 
-      retval = helper.modifyAPIResponse(retval, params);
-      u.logAPI(req, resultObj, retval);
-      res.status(httpStatus.OK).json(retval);
+      // if samples are stored in redis, get the samples from there.
+      if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
+        redisSubjectModel.completeSubjectHierarchy(retval, params)
+        .then((_retval) => {
+          u.logAPI(req, resultObj, _retval);
+          res.status(httpStatus.OK).json(_retval);
+        });
+      } else {
+        retval = helper.modifyAPIResponse(retval, params);
+        u.logAPI(req, resultObj, retval);
+        res.status(httpStatus.OK).json(retval);
+      }
     })
     .catch((err) => u.handleError(next, err, helper.modelName));
   }, // getSubjectHierarchy

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * cache/model/subject.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const sampleStore = require('../sampleStore');
+const constants = sampleStore.constants;
+const redisClient = require('../redisCache').client.sampleStore;
+const u = require('../../utils/filters');
+const ONE = 1;
+const TWO = 2;
+
+// using the bluebird promise implementation instead of the native promise
+const Promise = require('bluebird');
+
+/*
+ * All the query params that can be expected in the hierarchy endpoint are
+ * defined as a key. The values of the query parameters are later added to them
+ * by the set filters function
+ */
+const filters = {
+  aspect: {},
+  subjectTags: {},
+  aspectTags: {},
+  status: {},
+};
+
+/**
+ * Get the aspect information from the redis and attach it to the sample object
+ * @param  {String} aspectName - Aspect name
+ * @returns {Promise} - which resolves to an aspect object
+ */
+function getAspectFromRedis(aspectName) {
+  const aspectKey = sampleStore.toKey(constants.objectType.aspect,
+                              aspectName);
+  return redisClient.hgetallAsync(aspectKey)
+    .then((aspect) => {
+      const fieldsToStringify = constants.fieldsToStringify.aspect;
+      if (aspect) {
+        fieldsToStringify.forEach((field) => {
+          if (aspect[field] && !Array.isArray(aspect[field])) {
+            aspect[field] = JSON.parse(aspect[field]);
+          }
+        });
+      }
+
+      return aspect;
+    });
+} // getAspectFromRedis
+
+/**
+ * Get the sample information from Redis
+ * @param  {String} sampleName - Sample name
+ * @returns {Promise} - which resolves to a sample object
+ */
+function getSampleFromRedis(sampleName) {
+  const sampleKey = sampleStore.toKey(constants.objectType.sample,
+                              sampleName);
+  return redisClient.hgetallAsync(sampleKey)
+    .then((samp) => {
+      const fieldsToStringify = constants.fieldsToStringify.sample;
+      if (samp) {
+        fieldsToStringify.forEach((field) => {
+          if (samp[field] && !Array.isArray(samp[field])) {
+            samp[field] = JSON.parse(samp[field]);
+          }
+        });
+      }
+
+      return samp;
+    });
+} // getSampleFromReids
+
+/**
+ * Given a subject with its samples, aspect, aspectTags and sampleStatus filters
+ * are applied to the samples and the filtered samples are attached back to the
+ * subject
+ * @param  {Object} subj - Subject object on which the filters are applied
+ * @returns {Object} - filtered subject
+ */
+function filterSamples(subj) {
+  const filteredSamples = [];
+  for (let i = 0; i < subj.samples.length; i++) {
+    if (subj.samples[i].aspect) {
+      if (u.applyFilters(subj.samples[i].aspect.name, 'aspect', filters) &&
+        u.applyTagFilters(subj.samples[i].aspect.tags, 'aspectTags', filters) &&
+        u.applyFilters(subj.samples[i].status, 'status', filters)) {
+        filteredSamples.push(subj.samples[i]);
+      }
+    }
+  }
+
+  subj.samples = filteredSamples;
+  return subj;
+} // filterSamples
+
+/**
+ * For every subject object passed to this function, it attaches the
+ * corresponding samples, if any, from Redis, while also applying the filters
+ * to it.
+ *
+ * @param {Object} res - Subject object
+ * @returns {Promise} - when resolved, the subject node has samples attached
+ * to it and filter applied. The resolved value indicates if the subject node
+ * has passed the filters or not. 0, indicates the subject has not passed the
+ * filter criteria and any value greater than 0 indicates that the subject has
+ * passed the filter criteria
+ */
+function attachSamples(res) {
+  res.samples = [];
+  const filterOnSubject = u.applyTagFilters(res.tags, 'subjectTags', filters);
+  if (!filterOnSubject) {
+    return Promise.resolve(filterOnSubject);
+  }
+
+  const subjectKey = sampleStore.toKey(constants.objectType.subject,
+                              res.absolutePath);
+  return redisClient.smembersAsync(subjectKey).then((aspectNames) => {
+    // console.log(1);
+    const sampleAspectPromise = [];
+    aspectNames.forEach((aspect) => {
+      const sampleName = res.absolutePath + '|' + aspect;
+      sampleAspectPromise.push(getSampleFromRedis(sampleName));
+      sampleAspectPromise.push(getAspectFromRedis(aspect));
+    });
+
+    return Promise.all(sampleAspectPromise);
+  }).then((saArray) => {
+    for (let i = 0; i < saArray.length; i += TWO) {
+      const sample = saArray[i];
+      const asp = saArray[i + ONE];
+      if (sample && asp) {
+        sample.aspect = asp;
+        res.samples.push(sample);
+      }
+    }
+
+    // apply aspect, aspectTag and sampleStatus filters to the samples
+    filterSamples(res);
+
+    /* filterOnSubject: returns true(integer > 0) only if the subjecttags are
+     *   not set or if the subjecttags are set and the subject node passes the
+     *   subjecttags filter condition
+     * res.samples.length: returns true (length > 0) only if filterOnSubject is
+     *   true and the samples have passed the aspect, aspectTags and the sample
+     *   status filter condition.
+     * filters.aspect.includes/filters.aspectTags.includes/filters.status
+     *    .includes: are each true only if they are not set. Check on this is
+     *    done so that we can return subjects without samples too.
+     */
+    const isFiltered = (filterOnSubject &&
+      (res.samples.length || (!filters.aspect.includes &&
+    !filters.aspectTags.includes && !filters.status.includes)));
+
+    return Promise.resolve(isFiltered);
+  }).catch((err) => {
+    throw err;
+  });
+} // attachSamples
+
+/**
+ * This recursive function does a bottom up traversal of the hierarchy tree,
+ * while calling the attachSamples function to attach samples to each node in
+ * the hierarchy.
+ * @param {Object} res - The subject hierarchy
+ * @returns {Promise} - when resolved, the subject node (on which this function
+ * is called) has the samples attached to it.
+ */
+function traverseHierarchy(res) {
+  const traveHPromises = [];
+  const filteredChildrenArr = [];
+  if (res.children) {
+    for (let i = 0; i < res.children.length; i++) {
+      traveHPromises.push(traverseHierarchy(res.children[i]));
+    }
+  }
+
+  return Promise.all(traveHPromises)
+  .then((values) => {
+
+    /*
+     * the resolved values from each of the promises is used to check if that
+     * node needs to be added to the final list of children
+     */
+    for (let i = 0; i < values.length; i++) {
+      if (values[i]) {
+        filteredChildrenArr.push(res.children[i]);
+      }
+    }
+
+    res.children = filteredChildrenArr;
+    return attachSamples(res);
+  }).then((ret) => Promise.resolve(ret || filteredChildrenArr.length));
+} // traverseHierarchy
+
+/**
+ *  When passed a partial subject hierarchy without samples, the subject
+ *  hierarchy is completed by attaching samples to it.
+ *
+ * @param {ServerResponse} res - The subject response containing the samples
+ *  and children as an array
+ * @param {Object} params - The query parameters in the request along with its
+ *  values
+ * @returns {Promise} - when resolved, the resolved value will have the
+ * complete subject hierarchy with samples
+ */
+function completeSubjectHierarchy(res, params) {
+  // set the filters
+  u.setFilters(params, filters);
+  return traverseHierarchy(res)
+  .then(() => {
+    // once the filtering is done, reset it back.
+    u.resetFilters(filters);
+    return Promise.resolve(res);
+  });
+} // completeSubjectHierarchy
+
+module.exports = {
+  completeSubjectHierarchy,
+}; // exports

--- a/tests/cache/models/redisTestUtil.js
+++ b/tests/cache/models/redisTestUtil.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/redisTestUtil.js
+ */
+'use strict'; // eslint-disable-line strict
+const sampleStore = require('../../../cache/sampleStore');
+const samstoinit = require('../../../cache/sampleStoreInit');
+const redisClient = require('../../../cache/redisCache').client.sampleStore;
+const tu = require('../../testUtils');
+const Aspect = tu.db.Aspect;
+const Subject = tu.db.Subject;
+const Sample = tu.db.Sample;
+const testStartTime = new Date();
+
+module.exports = {
+  populateRedis(done) {
+    let a1;
+    let a2;
+    let s1;
+    let s2;
+    let s3;
+    tu.toggleOverride(sampleStore.constants.featureName, true);
+    Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Aspect1`,
+      timeout: '30s',
+      valueType: 'NUMERIC',
+      criticalRange: [0, 1],
+      relatedLinks: [
+        { name: 'Google', value: 'http://www.google.com' },
+        { name: 'Yahoo', value: 'http://www.yahoo.com' },
+      ],
+    })
+    .then((created) => (a1 = created))
+    .then(() => Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Aspect2`,
+      timeout: '10m',
+      valueType: 'BOOLEAN',
+      okRange: [10, 100],
+    }))
+    .then((created) => (a2 = created))
+    .then(() => Subject.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Subject1`,
+    }))
+    .then((created) => (s1 = created))
+    .then(() => Subject.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Subject2`,
+      parentId: s1.id,
+    }))
+    .then((created) => (s2 = created))
+    .then(() => Subject.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Subject3`,
+      parentId: s1.id,
+    }))
+    .then((created) => (s3 = created))
+    .then(() => Sample.create({
+      subjectId: s2.id,
+      aspectId: a1.id,
+      value: '0',
+      relatedLinks: [
+        { name: 'Salesforce', value: 'http://www.salesforce.com' },
+      ],
+    }))
+    .then(() => Sample.create({
+      subjectId: s2.id,
+      aspectId: a2.id,
+      value: '50',
+      relatedLinks: [
+        { name: 'Salesforce', value: 'http://www.salesforce.com' },
+      ],
+    }))
+    .then(() => Sample.create({
+      subjectId: s3.id,
+      aspectId: a1.id,
+      value: '5',
+      relatedLinks: [
+        { name: 'Salesforce', value: 'http://www.salesforce.com' },
+      ],
+    }))
+    .then(() => samstoinit.init())
+    .then(() => done())
+    .catch(done);
+  },
+
+  forceDelete: (done) => {
+    tu.forceDelete(tu.db.Sample, testStartTime)
+    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+    .then(() => tu.forceDelete(tu.db.User, testStartTime))
+    .then(() => redisClient.flushallAsync())
+    .then(() => done())
+    .catch(done);
+  },
+};

--- a/tests/cache/models/subjects/getHierarchy.js
+++ b/tests/cache/models/subjects/getHierarchy.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/getHierarchy.js
+ */
+'use strict';
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const samstoinit = require('../../../../cache/sampleStoreInit');
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const Subject = tu.db.Subject;
+const path = '/v1/subjects/{key}/hierarchy';
+const expect = require('chai').expect;
+
+describe(`api: GET ${path}`, () => {
+  let token;
+
+  const par = { name: `${tu.namePrefix}NorthAmerica`, isPublished: true };
+  const chi = { name: `${tu.namePrefix}Canada`, isPublished: true };
+  const grn = { name: `${tu.namePrefix}Quebec`, isPublished: true };
+
+  const aspect = {
+    name: 'temperature',
+    timeout: '30s',
+    isPublished: true,
+    rank: 10,
+  };
+
+  const sample1 = { value: '10' };
+
+  let ipar = 0;
+  let ichi = 0;
+  let igrn = 0;
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch(done);
+  });
+
+  before((done) => {
+    Subject.create(par)
+    .then((subj) => {
+      ipar = subj.id;
+    })
+    .then(() => {
+      chi.parentId = ipar;
+      return Subject.create(chi);
+    })
+    .then((subj) => {
+      ichi = subj.id;
+      grn.parentId = ichi;
+      return Subject.create(grn);
+    })
+    .then((sub) => {
+      sample1.subjectId = sub.id;
+      igrn = sub.id;
+      return tu.db.Aspect.create(aspect);
+    })
+    .then((a) => {
+      sample1.aspectId = a.id;
+      return tu.db.Sample.create(sample1);
+    })
+    .then((samp) => {
+      sample1.id = samp.id;
+      return samstoinit.init();
+    })
+    .then(() => done())
+    .catch(done);
+  });
+
+  after(rtu.forceDelete);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  describe('subject hierarchy with samples', () => {
+    it('should be an empty object at the parent level', (done) => {
+      api.get(path.replace('{key}', ipar))
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.be.an('array');
+        expect(res.body.samples).to.be.empty;
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('should be a non empty object at the grandchild level', (done) => {
+      api.get(path.replace('{key}', ipar))
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children[0].children[0].samples).to.be
+          .an('array');
+        expect(res.body.children[0].children[0].samples).to.not
+          .empty;
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it.skip('aspect rank must be included in the hierarchy', (done) => {
+      api.get(path.replace('{key}', ipar))
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children[0].children[0].samples).to.be
+          .an('array');
+        console.log(res.body);
+        expect(res.body.children[0].children[0].samples).to.have.lengthOf(1);
+        expect(res.body.children[0].children[0].samples[0].aspect.rank).
+          to.equal(10);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        // done();
+      });
+    });
+
+    it('should be a non empty object at the 1st  of grandchild', (done) => {
+      api.get(path.replace('{key}', igrn))
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.be.an('array');
+        expect(res.body.samples).to.not.empty;
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  it('by id', (done) => {
+    api.get(path.replace('{key}', ipar))
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      // parent level
+      expect(res.body.samples).to.be.an('array');
+      expect(res.body.children).to.have.length(res.body.childCount);
+
+      // child level
+      expect(res.body.children[0].samples).to.be.an('array');
+      expect(res.body.children[0].children).to.be.an('array');
+      expect(res.body.children[0].children).to.have
+        .length(res.body.children[0].childCount);
+    })
+    .end((err /* , res */) => {
+      if (err) {
+        done(err);
+      }
+
+      done();
+    });
+  });
+
+  it('by abs path', (done) => {
+    api.get(path.replace('{key}', par.name))
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      // parent level
+      expect(res.body.samples).to.be.an('array');
+      expect(res.body.children).to.have.length(res.body.childCount);
+
+      // child level
+      expect(res.body.children[0].samples).to.be.an('array');
+      expect(res.body.children[0].children).to.be.an('array');
+      expect(res.body.children[0].children).to.have
+        .length(res.body.children[0].childCount);
+    })
+    .end((err /* , res */) => {
+      if (err) {
+        done(err);
+      }
+
+      done();
+    });
+  });
+});

--- a/tests/cache/models/subjects/getHierarchyAspectAndTagsFilters.js
+++ b/tests/cache/models/subjects/getHierarchyAspectAndTagsFilters.js
@@ -1,0 +1,563 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/getHierarchyAspectAndTagsFilters.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const samstoinit = require('../../../../cache/sampleStoreInit');
+const rtu = require('../redisTestUtil');
+const Subject = tu.db.Subject;
+const Aspect = tu.db.Aspect;
+const path = '/v1/subjects/{key}/hierarchy';
+const expect = require('chai').expect;
+
+describe(`api: GET ${path}:`, () => {
+  let token;
+
+  //
+  // the before hook creates this following hierarchy
+  // gp
+  //  |parOther1
+  //  |parOther2 - [subjectTags: ea]
+  //  |par - [sample2: humidity[tags: hum], sample1: temperature[tags: temp]]
+  //    |chi - [sample3: humidity[tags: hum]]
+  //      |grn - subjectTags[cold,verycold],[sample4: wind-speed[tags: wnd]]
+
+  let gp = { name: `${tu.namePrefix}America`, isPublished: true };
+  let par = { name: `${tu.namePrefix}NorthAmerica`, isPublished: true };
+  let parOther1 = { name: `${tu.namePrefix}SouthAmerica`, isPublished: true };
+  let parOther2 = {
+    name: `${tu.namePrefix}EastAmerica`,
+    isPublished: true,
+    tags: ['ea'],
+  };
+  let chi = { name: `${tu.namePrefix}Canada`, isPublished: true };
+  let grn = {
+    name: `${tu.namePrefix}Quebec`,
+    isPublished: true,
+    tags: ['cold', 'verycold'],
+  };
+  const aspectTemp = {
+    name: 'temperature',
+    timeout: '30s',
+    isPublished: true,
+    tags: ['temp'],
+  };
+  const aspectHumid = {
+    name: 'humidity',
+    timeout: '30s',
+    isPublished: true,
+  };
+  const aspectWind = {
+    name: 'wind-speed',
+    timeout: '30s',
+    isPublished: true,
+    tags: ['wnd'],
+  };
+
+  const sample1 = { value: '10' };
+  const sample2 = { value: '10' };
+  const sample3 = { value: '10' };
+  const sample4 = { value: '100' };
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch(done);
+  });
+
+  before((done) => {
+    Subject.create(gp)
+    .then((subj) => {
+      gp = subj;
+      par.parentId = gp.id;
+      parOther1.parentId = gp.id;
+      parOther2.parentId = gp.id;
+      return Subject.create(par);
+    })
+    .then((subj) => {
+      par = subj;
+      chi.parentId = par.id;
+      sample1.subjectId = subj.id;
+      sample2.subjectId = subj.id;
+      return Subject.create(chi);
+    })
+    .then((subj) => {
+      chi = subj;
+      sample3.subjectId = subj.id;
+      grn.parentId = chi.id;
+      return Subject.create(grn);
+    })
+    .then((subj) => {
+      grn = subj;
+      return tu.db.Aspect.create(aspectHumid);
+    })
+    .then((a) => {
+      sample2.aspectId = a.id;
+      sample3.aspectId = a.id;
+      return tu.db.Aspect.create(aspectTemp);
+    })
+    .then((a) => {
+      sample1.aspectId = a.id;
+      return tu.db.Sample.create(sample1);
+    })
+    .then(() => tu.db.Sample.create(sample2))
+    .then(() => tu.db.Sample.create(sample3))
+    .then(() => tu.db.Subject.create(parOther1))
+    .then((subj) => {
+      parOther1 = subj;
+      return tu.db.Subject.create(parOther2);
+    })
+    .then((subj) => {
+      parOther2 = subj;
+      return Aspect.create(aspectWind);
+    })
+    .then((a) => {
+      sample4.aspectId = a.id;
+      sample4.subjectId = grn.id;
+      return tu.db.Sample.create(sample4);
+    })
+    .then(() => samstoinit.init())
+    .then(() => done())
+    .catch(done);
+  });
+
+  after(rtu.forceDelete);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  describe('SubjectTag filter on hierarchy', () => {
+    it('Only subjects matching the tag and its hierarchy should be returned',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?subjectTags=cold';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+
+        // canada
+        expect(res.body.children[0].children).to.have.length(1);
+
+        // quebec
+        const quebecSubj = res.body.children[0].children[0].children[0];
+        expect(quebecSubj.tags).to.include.members(['cold']);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Multiple Query Params: Only subjects matching the tag and' +
+    ' its hierarchy should be returned', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=cold,ea,verycold';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(2);
+
+        // canada
+        let na = null;
+        for (let i = 0; i < res.body.children.length; i++) {
+          if (res.body.children[i].name === '___NorthAmerica') {
+            na = res.body.children[i];
+            break;
+          }
+        }
+
+        expect(na).to.not.equal(null);
+        expect(na.children).to.have.length(1);
+        expect(na.children[0].children).to.have.length(1);
+        expect(na.children[0].children[0].tags).to.include.members(['cold']);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Negation test: Subject with tags not matching the negated tag name ',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?subjectTags=-verycold';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(3);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Negation test: Multiple Tags: Subject with tags not matching the ' +
+      'negated tag name', (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?subjectTags=-cold,-ea';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(2);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Multiple Query Params: Tags should be passed as include filter' +
+    'or exclude filter not the combination of both', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=-cold,ea,-verycold';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res ) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to
+        .equal('InvalidFilterParameterError');
+        done();
+      });
+    });
+
+    it('Multiple Query Params: Tags should be passed as include filter' +
+    'or exclude filter not the combination of both', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=cold,-ea,verycold';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .expect((res) => {
+        expect(res.body.errors[0].type).to
+        .equal('InvalidFilterParameterError');
+      })
+      .end((err /* , res */) => {
+        return err ? done(err) : done();
+      });
+    });
+  });
+
+  describe('Aspect Filter on Hierarchy', () => {
+    it('should return samples with temperature and humidity aspects',
+    (done) => {
+      const endpoint = path.replace('{key}', par.id) +
+        '?aspect=humidity,temperature';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(2);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('should return sample with just humidity aspect', (done) => {
+      const endpoint = path.replace('{key}', par.id) + '?aspect=humidity';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.samples).to.have.length(1);
+        expect(res.body.samples[0]).to.have.deep
+          .property('aspect.name', 'humidity');
+        expect(res.body.children[0].samples[0]).to.have.deep
+          .property('aspect.name', 'humidity');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('test negitation humidity but no temperature', (done) => {
+      const endpoint = path.replace('{key}', par.id) + '?aspect=-temperature';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(1);
+        expect(res.body.samples[0]).to.have.deep
+          .property('aspect.name', 'humidity');
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples[0]).to.have.deep
+        .property('aspect.name', 'humidity');
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0]).to.have.deep
+        .property('aspect.name', 'wind-speed');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('test with aspect name not in the hierarchy', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=invalidName';
+      api.get(endpoint2)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(Object.keys(res.body.samples)).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter should apply to all levels of hierarchy', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) +
+        '?aspect=humidity,temperature';
+      api.get(endpoint2)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res ) => {
+        if (err) {
+          return done(err);
+        }
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(2);
+        const aspectNameArr = [];
+        res.body.samples.forEach((sample) => {
+          aspectNameArr.push(sample.aspect.name);
+        });
+        expect(aspectNameArr).to.have.members(['humidity', 'temperature']);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(0);
+        expect(res.body.children[0].samples[0]).to.have.deep
+          .property('aspect.name', 'humidity');
+        done();
+      });
+    });
+
+    it('filter with aspect name having a hyphen', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=wind-speed';
+      api.get(endpoint2)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(0);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0]).to.have.deep
+          .property('aspect.name', 'wind-speed');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('negation on aspect name filter with aspect name ' +
+    'having a hyphen', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=-wind-speed';
+      api.get(endpoint2)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(2);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  describe('aspectTags filter on hierarchy', () => {
+    it('Hierarchy for subject with Aspect tags matching the quuery params ' +
+    'should be returned', (done) => {
+      const endpoint = path.replace('{key}', chi.id) + '?aspectTags=wnd';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.not.equal(null);
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0]).to.have.deep
+          .property('aspect.name', 'wind-speed');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Hierarchy for subject with Aspect tags matching the query params ' +
+    'should be returned', (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?aspectTags=notpresent';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Multiple Query Params: Hierarchy for subject with Aspect tags' +
+      ' matching the quuery params should be returned',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?aspectTags=wnd,temp';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].aspect.tags[0])
+          .to.equal('temp');
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].samples).to.have.length(0);
+        expect(res.body.children[0].children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].children[0].samples)
+          .to.have.length(1);
+        expect(res.body.children[0].children[0].children[0]
+          .samples[0].aspect.tags[0]).to.equal('wnd');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Negation: Hierarchy for subject with Aspect tags' +
+      ' matching the quuery params should be returned',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?aspectTags=-temp';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].children).to.have.length(1);
+        expect(res.body.children[0].children[0].children[0].samples)
+          .to.have.length(1);
+        expect(res.body.children[0].children[0].children[0]
+          .samples[0].aspect.tags[0]).to.equal('wnd');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('Negation: Multiple Query Params: Hierarchy for subject with Aspect' +
+      ' tags matching the quuery params should be returned',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?aspectTags=-temp,-wnd';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.samples).to.have.length(0);
+        expect(res.body.children).to.have.length(1);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+  });
+});

--- a/tests/cache/models/subjects/getHierarchyStatusAndCombinedFilters.js
+++ b/tests/cache/models/subjects/getHierarchyStatusAndCombinedFilters.js
@@ -1,0 +1,596 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/getHierarchyStatusAndCombinedFilters.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const samstoinit = require('../../../../cache/sampleStoreInit');
+const rtu = require('../redisTestUtil');
+const Subject = tu.db.Subject;
+const Aspect = tu.db.Aspect;
+const path = '/v1/subjects/{key}/hierarchy';
+const expect = require('chai').expect;
+
+describe(`api: GET ${path}:`, () => {
+  let token;
+
+  // The below code creates the following hierarchy.
+  // gp
+  //  |parOther1
+  //  |parOther2 - [subjectTags: ea]
+  //  |par-[subjectTags - na] - [sample2: humidity[tags: hum], sample1:
+  //     temperature[tags: temp]]
+  //    |chi - [sample3: humidity]
+  //      |grn - subjectTags[cold,verycold],[sample4: wind-speed[tags: wnd]]
+
+  let gp = { name: `${tu.namePrefix}America`, isPublished: true };
+  let par = {
+    name: `${tu.namePrefix}NorthAmerica`,
+    isPublished: true,
+    tags: ['na'],
+  };
+  let parOther1 = { name: `${tu.namePrefix}SouthAmerica`, isPublished: true };
+  let parOther2 = {
+    name: `${tu.namePrefix}EastAmerica`,
+    isPublished: true,
+    tags: ['ea'],
+  };
+  let chi = { name: `${tu.namePrefix}Canada`, isPublished: true };
+  let grn = {
+    name: `${tu.namePrefix}Quebec`,
+    isPublished: true,
+    tags: ['cold', 'verycold'],
+  };
+  const aspectTemp = {
+    criticalRange: [3, 5],
+    name: 'temperature',
+    timeout: '60s',
+    isPublished: true,
+    tags: ['temp'],
+  };
+  const aspectHumid = {
+    infoRange: [1, 1],
+    name: 'humidity',
+    timeout: '60s',
+    isPublished: true,
+  };
+  const aspectWind = {
+    name: 'wind-speed',
+    timeout: '60s',
+    isPublished: true,
+    tags: ['wnd'],
+  };
+
+  const sample1 = { value: '4' };
+  const sample2 = { value: '1' };
+  const sample3 = { value: '1' };
+  const sample4 = { value: '100' };
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch(done);
+  });
+
+  before((done) => {
+    Subject.create(gp)
+    .then((subj) => {
+      gp = subj;
+      par.parentId = gp.id;
+      parOther1.parentId = gp.id;
+      parOther2.parentId = gp.id;
+      return Subject.create(par);
+    })
+    .then((subj) => {
+      par = subj;
+      chi.parentId = par.id;
+      sample1.subjectId = subj.id;
+      sample2.subjectId = subj.id;
+      return Subject.create(chi);
+    })
+    .then((subj) => {
+      chi = subj;
+      sample3.subjectId = subj.id;
+      grn.parentId = chi.id;
+      return Subject.create(grn);
+    })
+    .then((subj) => {
+      grn = subj;
+      return tu.db.Aspect.create(aspectHumid);
+    })
+    .then((a) => {
+      sample2.aspectId = a.id;
+      sample3.aspectId = a.id;
+      return tu.db.Aspect.create(aspectTemp);
+    })
+    .then((a) => {
+      sample1.aspectId = a.id;
+      return tu.db.Sample.create(sample1);
+    })
+    .then(() => tu.db.Sample.create(sample2))
+    .then(() => tu.db.Sample.create(sample3))
+    .then(() => tu.db.Subject.create(parOther1))
+    .then((subj) => {
+      parOther1 = subj;
+      return tu.db.Subject.create(parOther2);
+    })
+    .then((subj) => {
+      parOther2 = subj;
+      return Aspect.create(aspectWind);
+    })
+    .then((a) => {
+      sample4.aspectId = a.id;
+      sample4.subjectId = grn.id;
+      return tu.db.Sample.create(sample4);
+    })
+    .then(() => samstoinit.init())
+    .then(() => done())
+    .catch(done);
+  });
+
+  after(rtu.forceDelete);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  describe('Sample Status filter', () => {
+    it('filter :: status=critical', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?status=Critical';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].aspect.name)
+          .to.equal('temperature');
+        expect(res.body.children[0].samples[0].status)
+          .to.equal('Critical');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('multiple query params :: filter :: status=Critical,Info', (done) => {
+      const endpoint = path.replace('{key}', gp.id) + '?status=Critical,Info';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(2);
+        const samples = res.body.children[0].samples;
+        for (let i = 0; i < samples.length; i++) {
+          if (samples[i].name.includes('humidity')) {
+            expect(samples[i].status).equal('Info');
+          } else if (samples[i].name.includes('temperature')) {
+            expect(samples[i].status).equal('Critical');
+          }
+        }
+
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0].status)
+          .to.equal('Info');
+        expect(res.body.children[0].children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('negation :: filter :: status=-Critical', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?status=-Critical';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].status).equal('Info');
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0].status)
+          .to.equal('Info');
+        const quebecSubj = res.body.children[0].children[0].children[0];
+        expect(quebecSubj.samples[0].status).to.equal('Invalid');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  describe('aspect + status filters', () => {
+    it('filter:: aspect=wind-speed and status=Invalid', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?aspect=wind-speed&status=Invalid';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(0);
+        expect(res.body.children[0].children[0].samples).to.have.length(0);
+        const quebecSubj = res.body.children[0].children[0].children[0];
+        expect(quebecSubj.samples[0].status).to.equal('Invalid');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('negation:: filter:: aspect=-wind-speed and status=-Invalid',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?aspect=-wind-speed&status=-Invalid';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(2);
+        const samples = res.body.children[0].samples;
+        for (let i = 0; i < samples.length; i++) {
+          if (samples[i].name.includes('humidity')) {
+            expect(samples[i].status).equal('Info');
+          } else if (samples[i].name.includes('temperature')) {
+            expect(samples[i].status).equal('Critical');
+          }
+        }
+
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0].status)
+          .to.equal('Info');
+        expect(res.body.children[0].children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('negation:: filter:: aspect=-wind-speed and status=-Invalid,-Critical',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?aspect=-wind-speed&status=-Invalid,-Critical';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        const samples = res.body.children[0].samples;
+        expect(samples[0].status).equal('Info');
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0].status)
+          .to.equal('Info');
+        expect(res.body.children[0].children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  // The below code creates the following hierarchy.
+  // gp
+  //  |parOther1
+  //  |parOther2 - [subjectTags: ea]
+  //  |par-[subjectTags - na] - [sample2: humidity[tags: hum], sample1:
+  //     temperature[tags: temp]]
+  //    |chi - [sample3: humidity]
+  //      |grn - subjectTags[cold,verycold],[sample4: wind-speed[tags: wnd]]
+  describe('aspect + subjectTags filters', () => {
+    it('filter:: subjectTags=cold&aspect=wind-speed', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?subjectTags=cold&aspect=wind-speed';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        // canada
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(0);
+
+        // quebec
+        expect(res.body.children[0].children[0].samples).to.have.length(0);
+        const quebecSubj = res.body.children[0].children[0].children[0];
+        expect(quebecSubj.tags[0]).to.contain('cold');
+        expect(quebecSubj.samples[0].aspect.name).to.equal('wind-speed');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter:: subjectTags=cold,na&aspect=temperature,wind-speed',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?subjectTags=cold,na&aspect=temperature,wind-speed';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        const na = res.body.children[0];
+        expect(na.samples).to.have.length(1);
+        expect(na.samples[0]).to.have.deep
+          .property('aspect.name', 'temperature');
+        expect(na.children).to.have.length(1);
+        expect(na.children[0].samples).to.have.length(0);
+        expect(na.children[0].children).to.have.length(1);
+        expect(na.children[0].children[0].samples).to.have.length(1);
+        const quebecSubj = na.children[0].children[0];
+        expect(quebecSubj.tags[0]).to.contain('cold');
+        expect(quebecSubj.samples[0].aspect.name).to.equal('wind-speed');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter :: subjectTags=-cold  and aspect=temperature', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=-cold&aspect=temperature';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0]
+          .aspect.name).to.equal('temperature');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  describe('All params combined filters', () => {
+    it('filter :: subjectTags=na and aspect=humidity,wind-speed&,' +
+    'aspectTags=hum', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?subjectTags=na,ea&aspect=temperature&aspectTags=temp,hum';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].tags[0]).to.equal('na');
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].aspect.name)
+          .to.equal('temperature');
+        expect(res.body.children[0].samples[0].aspect.tags[0])
+          .to.equal('temp');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter :: subjectTags=na, -ea and aspect=humidity,wind-speed&,' +
+    'aspectTags=hum gives error because of mismatch of filter', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?subjectTags=na,-ea&aspect=temperature&aspectTags=temp,hum';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .expect((res) => {
+        expect(res.body.errors[0].type).to
+        .equal('InvalidFilterParameterError');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter :: subjectTags=na and aspect=humidity,wind-speed and ' +
+    'aspectTags=hum and status = Critical', (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=na,ea&aspect=temperature&aspectTags=temp,hum' +
+        '&status=Critical';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].tags[0]).to.equal('na');
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].aspect.name)
+          .to.equal('temperature');
+        expect(res.body.children[0].samples[0].aspect.tags[0])
+          .to.equal('temp');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter :: subjectTags=na,ea and aspect=temperature and ' +
+    'aspectTags=temp,hum and status = -Critical',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+        '?subjectTags=na,ea&aspect=temperature&aspectTags=temp,hum' +
+        '&status=-Critical';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+
+  describe('Filters should not be case sensitive', () => {
+    it('Filter with all upper case:: filter :: status=Critical,Info',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?status=CRITICAL,INFO';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(2);
+        const samples = res.body.children[0].samples;
+        for (let i = 0; i < samples.length; i++) {
+          if (samples[i].name.includes('humidity')) {
+            expect(samples[i].status).equal('Info');
+          } else if (samples[i].name.includes('temperature')) {
+            expect(samples[i].status).equal('Critical');
+          }
+        }
+
+        expect(res.body.children[0].children[0].samples).to.have.length(1);
+        expect(res.body.children[0].children[0].samples[0].status)
+          .to.equal('Info');
+        expect(res.body.children[0].children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('filter:: mixed cases:: aspect=wind-speed and status=Invalid',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?aspect=Wind-Speed&status=InvaLid';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        // north america. Check to make sure it does not return the parOther
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].children).to.have.length(1);
+        expect(res.body.children[0].samples).to.have.length(0);
+        expect(res.body.children[0].children[0].samples).to.have.length(0);
+        const quebecSubj = res.body.children[0].children[0].children[0];
+        expect(quebecSubj.samples[0].status).to.equal('Invalid');
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+
+    it('All filters Mixed case :: subjectTags=Na,ea and aspect=tempeRature' +
+      'and aspectTags=temp,HUM',
+    (done) => {
+      const endpoint = path.replace('{key}', gp.id) +
+              '?subjectTags=Na,ea&aspect=tempeRature&aspectTags=temp,HUM';
+      api.get(endpoint)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.children).to.have.length(1);
+        expect(res.body.children[0].tags[0]).to.equal('na');
+        expect(res.body.children[0].samples).to.have.length(1);
+        expect(res.body.children[0].samples[0].aspect.name)
+          .to.equal('temperature');
+        expect(res.body.children[0].samples[0].aspect.tags[0])
+          .to.equal('temp');
+        expect(res.body.children[0].children).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        done();
+      });
+    });
+  });
+});

--- a/utils/filters.js
+++ b/utils/filters.js
@@ -1,0 +1,173 @@
+
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * utils/filters.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const FILTER_DELIMITER = ',';
+const FILTER_NEGATION = '-';
+
+/**
+ * Sets the filters object defined at the top. All the query params which can
+ * be expected in the hierarchy endpoint are defined as a key in the "filter"
+ * object above. For each of the keys defined in the filters object, this
+ * function parses the query params and sets the includes and excludes
+ * fields of the object.
+ *
+ * @param {Object} params - The query parameters in the request along with its
+ *  values
+ *  @param {Object} filters - The filter object which needs to be set based on
+ *  the query params
+ *  @returns {Object} - the filter object that is set based on the query param
+ */
+function setFilters(params, filters) {
+  for (const key in filters) {
+    if (params[key] && params[key].value) {
+      const arr = params[key].value.split(FILTER_DELIMITER);
+      filters[key].includes = new Set();
+      filters[key].excludes = new Set();
+      for (const i in arr) {
+        if (arr[i].charAt(0) === FILTER_NEGATION) {
+          filters[key].excludes.add(arr[i].substr(1).toLowerCase());
+        } else {
+          filters[key].includes.add(arr[i].toLowerCase());
+        }
+      }
+    }
+  }
+
+  return filters;
+} // setFilters
+
+/**
+ * Resets the filter object and its properties to null.
+ * @param {Object} filters - The filter object
+ * @returns {Object} - the filter object, with all the filters reset
+ */
+function resetFilters(filters) {
+  for (const key in filters) {
+    if (key) {
+      filters[key].includes = null;
+      filters[key].excludes = null;
+    }
+  }
+
+  return filters;
+} // resetFilters
+
+/**
+ * Applies one of the filters defined in the "filters" object to the entity
+ * array.
+ *
+ * @param {Array} keys - The array on which the filters will be
+ *  applied, e.g. if filtering by subject tags, keys should be the
+ *  subject.tags field of the subject model
+ * @param {String} filterBy - If filtering by subject tags the key would be
+ *  the query param "subjectTags".
+ *  @param {Object} filters - The filter object based on which the filters are
+ *   applied
+ * @returns {Boolean} - Returns true if the filter criteria is matched.
+ */
+function applyTagFilters(keys, filterBy, filters) {
+  // when a filter is not set, return true.
+  if (!filters[filterBy].includes || !filters[filterBy].excludes) {
+    return true;
+  }
+
+  // When tags are not present and an excludes filter is set, return true
+  if (!keys.length && filters[filterBy].excludes.size) {
+    return true;
+  }
+
+  let isPartOfInFilter = false;
+  let isPartOfNotInFilter = false;
+
+  // check if the elements of keys are part of the "includes" filter
+  for (let i = 0; i < keys.length; i++) {
+    if (filters[filterBy].includes.has(keys[i].toLowerCase())) {
+      isPartOfInFilter = true;
+      break;
+    }
+  }
+
+  // check if the elements of keys are part of the "excludes" filter
+  for (let i = 0; i < keys.length; i++) {
+    if (filters[filterBy].excludes.has(keys[i].toLowerCase())) {
+      isPartOfNotInFilter = true;
+      break;
+    }
+  }
+
+  /*
+   * If the excludes filter clause is set and if no elements of the keys array
+   * were a part of the excludes filter, return true.
+   */
+  if (filters[filterBy].excludes.size && !isPartOfNotInFilter) {
+    return true;
+  }
+
+  /*
+   * If atleast one element of the keys array were a part of the includes filter
+   * return true
+   */
+  if (isPartOfInFilter) {
+    return true;
+  }
+
+  return false;
+} // applyTagFilters
+
+/**
+ * Applies one of the filters defined in the "filters" object
+ * to the entity.
+ *
+ * @param  {String} key - The key on which the filters are to be applied.
+ *  for eg .. if filtering by aspect name. entity should be an "aspect name"
+ *  like "aspect1"
+ * @param  {String} filterBy - The filter that is to be applied. For eg.. if
+ *  filtering by aspect name , this should be 'aspect'.
+ * @param {Object} filters - The filter object based on which the filters are
+ *   applied
+ * @returns {Boolean} - Returns true if the filter criteria is matched.
+ */
+function applyFilters(key, filterBy, filters) {
+  // When a filter is not set return true
+  if (!filters[filterBy].includes || !filters[filterBy].excludes) {
+    return true;
+  }
+
+  /*
+   * If the excludes filter clause is set and if the entity is not present
+   * in this filter return true.
+   */
+  if (filters[filterBy].excludes.size &&
+        !filters[filterBy].excludes.has(key.toLowerCase())) {
+    return true;
+  }
+
+  // If the entity is present in the includes filter clause return true.
+  if (filters[filterBy].includes.has(key.toLowerCase())) {
+    return true;
+  }
+
+  return false;
+} // applyFilters
+
+module.exports = {
+  applyFilters,
+
+  applyTagFilters,
+
+  setFilters,
+
+  resetFilters,
+
+}; // exports


### PR DESCRIPTION
We need to merge PR  #262  and #264 before this. I have checked in @pallavi2209's redisTestUtil.js file too for the tests to pass.  I have also done some refracting for the cache layer and the DB layer to be able to use the same set of filters. 