### PR TITLE
Fix sample api links

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -710,7 +710,14 @@ module.exports = {
    */
   responsify(rec, props, method) {
     const o = cleanAndStripNulls(rec);
-    o.apiLinks = getApiLinks(o.id, props, method);
+    let key = o.id;
+
+    // if do not return id, use name instead
+    if (props.fieldsToExclude && props.fieldsToExclude.indexOf('id') > -1) {
+      key = o.name;
+    }
+
+    o.apiLinks = getApiLinks(key, props, method);
     if (props.stringify) {
       props.stringify.forEach((f) => {
         o[f] = `${o[f]}`;

--- a/tests/api/v1/samples/delete.js
+++ b/tests/api/v1/samples/delete.js
@@ -50,6 +50,25 @@ describe(`api: DELETE ${path}`, () => {
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
 
+  it('in basic delete, apiLinks only contains the POST endpoint', (done) => {
+    api.delete(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      const { apiLinks } = res.body;
+      expect(apiLinks.length).to.equal(ONE);
+      expect(apiLinks[0].method).to.equal('POST');
+      expect(apiLinks[0].href).to.equal(path);
+    })
+    .end((err /* , res */) => {
+      if (err) {
+        done(err);
+      }
+
+      done();
+    });
+  });
+
   it('basic delete', (done) => {
     api.delete(`${path}/${sampleName}`)
     .set('Authorization', token)

--- a/tests/api/v1/samples/get.js
+++ b/tests/api/v1/samples/get.js
@@ -47,6 +47,33 @@ describe(`api: GET ${path}`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
+  it('apiLinks in basic get end  with sample name', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      let href = '';
+      for (let i = res.body.length - 1; i >= 0; i--) {
+        const apiLinks = res.body[i].apiLinks;
+        for (let j = apiLinks.length - 1; j >= 0; j--) {
+          href = apiLinks[j].href;
+          if (apiLinks[j].method!= 'POST') {
+            expect(href.split('/').pop()).to.equal(u.sampleName);
+          } else {
+            expect(href).to.equal(path);
+          }
+        }
+      }
+    })
+    .end((err /* , res */) => {
+      if (err) {
+        done(err);
+      }
+
+      done();
+    });
+  });
+
   it('basic get', (done) => {
     api.get(path)
     .set('Authorization', token)

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -63,8 +63,9 @@ describe(`api: PATCH ${path}`, () => {
       }
 
       const { apiLinks } = res.body;
+      expect(apiLinks.length).to.be.above(ZERO);
       let href = '';
-      for (let j = apiLinks.length - 1; j >= 0; j--) {
+      for (let j = apiLinks.length - 1; j >= ZERO; j--) {
         href = apiLinks[j].href;
         if (apiLinks[j].method!= 'POST') {
           expect(href.split('/').pop()).to.equal(u.sampleName);

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -51,8 +51,34 @@ describe(`api: PATCH ${path}`, () => {
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
 
+  it('apiLinks"s href ends with sample name' +
+    'updatedAt', (done) => {
+    api.patch(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .send({})
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      const { apiLinks } = res.body;
+      let href = '';
+      for (let j = apiLinks.length - 1; j >= 0; j--) {
+        href = apiLinks[j].href;
+        if (apiLinks[j].method!= 'POST') {
+          expect(href.split('/').pop()).to.equal(u.sampleName);
+        } else {
+          expect(href).to.equal(path);
+        }
+      }
+
+      done();
+    });
+  });
+
   describe('UpdatedAt tests: ', () => {
-    it('patch /samples without value does not increment ' +
+    it('without value does not increment ' +
       'updatedAt', (done) => {
       api.patch(`${path}/${sampleName}`)
       .set('Authorization', token)
@@ -70,7 +96,7 @@ describe(`api: PATCH ${path}`, () => {
       });
     });
 
-    it('patch /samples with only identical value increments ' +
+    it('with only identical value increments ' +
       'updatedAt', (done) => {
       api.patch(`${path}/${sampleName}`)
       .set('Authorization', token)

--- a/tests/api/v1/samples/post.js
+++ b/tests/api/v1/samples/post.js
@@ -92,6 +92,7 @@ describe(`api: POST ${path}`, () => {
     .expect(constants.httpStatus.CREATED)
     .expect((res) => {
       const { apiLinks } = res.body;
+      expect(apiLinks.length).to.be.above(ZERO);
       let href = '';
       for (let j = apiLinks.length - 1; j >= 0; j--) {
         href = apiLinks[j].href;

--- a/tests/api/v1/samples/post.js
+++ b/tests/api/v1/samples/post.js
@@ -85,6 +85,32 @@ describe(`api: POST ${path}`, () => {
     });
   });
 
+  it('check apiLinks end with sample name', (done) => {
+    api.post(path)
+    .set('Authorization', token)
+    .send(sampleToPost)
+    .expect(constants.httpStatus.CREATED)
+    .expect((res) => {
+      const { apiLinks } = res.body;
+      let href = '';
+      for (let j = apiLinks.length - 1; j >= 0; j--) {
+        href = apiLinks[j].href;
+        if (apiLinks[j].method!= 'POST') {
+          expect(href.split('/').pop()).to.equal(u.sampleName);
+        } else {
+          expect(href).to.equal(path);
+        }
+      }
+    })
+    .end((err /* , res */) => {
+      if (err) {
+        done(err);
+      }
+
+      done();
+    });
+  });
+
   it('basic post /samples', (done) => {
     api.post(path)
     .set('Authorization', token)

--- a/tests/api/v1/samples/put.js
+++ b/tests/api/v1/samples/put.js
@@ -55,6 +55,31 @@ describe(`api: PUT ${path}`, () => {
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
 
+  it('check apiLinks end with sample name', (done) => {
+    api.put(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .send({ subjectId, aspectId, value: '2' })
+    .expect(constants.httpStatus.OK)
+    .end((err, res ) => {
+      if (err) {
+        done(err);
+      }
+
+      const { apiLinks } = res.body;
+      let href = '';
+      for (let j = apiLinks.length - 1; j >= 0; j--) {
+        href = apiLinks[j].href;
+        if (apiLinks[j].method!= 'POST') {
+          expect(href.split('/').pop()).to.equal(sampleName);
+        } else {
+          expect(href).to.equal(path);
+        }
+      }
+
+      done();
+    });
+  });
+
   it('basic succeeds', (done) => {
     api.put(`${path}/${sampleName}`)
     .set('Authorization', token)

--- a/tests/api/v1/samples/put.js
+++ b/tests/api/v1/samples/put.js
@@ -66,6 +66,7 @@ describe(`api: PUT ${path}`, () => {
       }
 
       const { apiLinks } = res.body;
+      expect(apiLinks.length).to.be.above(ZERO);
       let href = '';
       for (let j = apiLinks.length - 1; j >= 0; j--) {
         href = apiLinks[j].href;

--- a/tests/api/v1/samples/upsert.js
+++ b/tests/api/v1/samples/upsert.js
@@ -22,6 +22,7 @@ const Aspect = tu.db.Aspect;
 const Subject = tu.db.Subject;
 
 const path = '/v1/samples/upsert';
+const POST_PATH = '/v1/samples';
 
 describe(`api: POST ${path}`, () => {
   let aspect;
@@ -133,6 +134,35 @@ describe(`api: POST ${path}`, () => {
       });
     });
 
+    it('check apiLinks end with sample name', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: `${subject.absolutePath}|${aspect.name}`,
+        value: '2',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+
+        const { apiLinks } = res.body;
+        expect(apiLinks.length).to.be.above(0);
+        let href = '';
+        for (let j = apiLinks.length - 1; j >= 0; j--) {
+          href = apiLinks[j].href;
+          if (apiLinks[j].method!= 'POST') {
+            expect(href.split('/').pop()).to.equal(u.sampleName);
+          } else {
+            expect(href).to.equal(POST_PATH);
+          }
+        }
+
+        done();
+      });
+    });
+
     it('update sample with relatedLinks', (done) => {
       api.post(path)
       .set('Authorization', token)
@@ -207,7 +237,7 @@ describe(`api: POST ${path}`, () => {
     });
   });
 
-  describe('upsert when the sample already exists', () => {
+  describe('when the sample already exists', () => {
     beforeEach((done) => {
       Sample.create({
         name: `${subject.absolutePath}|${aspect.name}`,
@@ -232,6 +262,35 @@ describe(`api: POST ${path}`, () => {
         }
 
         expect(res.body.id).to.be.undefined;
+        done();
+      });
+    });
+
+    it('check apiLinks end with sample name', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: `${subject.absolutePath}|${aspect.name}`,
+        value: '2',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+
+        const { apiLinks } = res.body;
+        expect(apiLinks.length).to.be.above(0);
+        let href = '';
+        for (let j = apiLinks.length - 1; j >= 0; j--) {
+          href = apiLinks[j].href;
+          if (apiLinks[j].method!= 'POST') {
+            expect(href.split('/').pop()).to.equal(u.sampleName);
+          } else {
+            expect(href).to.equal(POST_PATH);
+          }
+        }
+
         done();
       });
     });


### PR DESCRIPTION
tests in api confirm that hrefs in sample apiLinks end with sampleName when not POST. 
Previously the hrefs in sample apiLinks were ending with undefined