### PR TITLE
read-only fields for Sample/Aspects/Subjects through the PUT/PATCH/POST api endpoints

### DIFF
--- a/api/v1/apiErrors.js
+++ b/api/v1/apiErrors.js
@@ -32,17 +32,6 @@ apiErrors.create({
 });
 
 apiErrors.create({
-  code: 11101,
-  status: 400,
-  name: 'SubjectValidationError',
-  parent: apiErrors.ValidationError,
-  fields: [],
-  defaultMessage: 'You are not allowed to set the subject\'s absolutePath ' +
-    'attribute directly--it is generated based on the subject\'s name and ' +
-    'parent.',
-});
-
-apiErrors.create({
   code: 11102,
   status: 400,
   name: 'InvalidTokenActionError',

--- a/api/v1/controllers/aspects.js
+++ b/api/v1/controllers/aspects.js
@@ -55,6 +55,16 @@ function validateTags(requestBody, params) {
   }
 }
 
+/**
+ * Validates the aspect request coming in and throws an error if the request
+ * does not pass the validation.
+ * @param  {Object} req - The request object
+ */
+function validateRequest(req) {
+  utils.noReadOnlyFieldsInReq(req, helper);
+  validateTags(req.body);
+} // validateRequest
+
 module.exports = {
 
   /**
@@ -184,7 +194,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchAspect(req, res, next) {
-    validateTags(req.body);
+    validateRequest(req);
     doPatch(req, res, next, helper);
   },
 
@@ -198,7 +208,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   postAspect(req, res, next) {
-    validateTags(req.body);
+    validateRequest(req);
     doPost(req, res, next, helper);
   },
 
@@ -213,7 +223,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   putAspect(req, res, next) {
-    validateTags(req.body);
+    validateRequest(req);
     doPut(req, res, next, helper);
   },
 

--- a/api/v1/controllers/samples.js
+++ b/api/v1/controllers/samples.js
@@ -26,8 +26,8 @@ const httpStatus = require('../constants').httpStatus;
 const sampleStore = require('../../../cache/sampleStore');
 const constants = sampleStore.constants;
 const redisModelSample = require('../../../cache/models/samples');
+const utils = require('./utils');
 const publisher = u.publisher;
-const event = u.realtimeEvents;
 module.exports = {
 
   /**
@@ -98,6 +98,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchSample(req, res, next) {
+    utils.noReadOnlyFieldsInReq(req, helper);
     doPatch(req, res, next, helper);
   },
 
@@ -111,6 +112,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   postSample(req, res, next) {
+    utils.noReadOnlyFieldsInReq(req, helper);
     doPost(req, res, next, helper);
   },
 
@@ -125,6 +127,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   putSample(req, res, next) {
+    utils.noReadOnlyFieldsInReq(req, helper);
     doPut(req, res, next, helper);
   },
 
@@ -140,6 +143,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   upsertSample(req, res, next) {
+    utils.noReadOnlyFieldsInReq(req, helper);
     const resultObj = { reqStartTime: new Date() };
     const sampleQueryBody = req.swagger.params.queryBody.value;
 
@@ -193,6 +197,7 @@ module.exports = {
    *  bulk upsert request has been received.
    */
   bulkUpsertSample(req, res/* , next */) {
+    utils.noReadOnlyFieldsInReq(req, helper);
     const resultObj = { reqStartTime: new Date() };
     const reqStartTime = Date.now();
     const value = req.swagger.params.queryBody.value;

--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -70,10 +70,6 @@ function validateTags(requestBody, params) {
     tags = params.tags.value ? params.tags.value.split(',') : [];
   }
 
-  if (absolutePath) {
-    throw new apiErrors.SubjectValidationError();
-  }
-
   if (tags && tags.length) {
     if (utils.hasDuplicates(tags)) {
       throw new apiErrors.DuplicateFieldError();
@@ -82,29 +78,12 @@ function validateTags(requestBody, params) {
 } // validateTags
 
 /**
- * Throws a validation error if the read-only fields are found in the request.
- * @param  {Object} req - The request object
- */
-function noReadOnlyFieldsInReq(req) {
-  const requestBody = req.body;
-  if (helper.readOnlyFields) {
-    helper.readOnlyFields.forEach((field) => {
-      if (requestBody[field]) {
-        throw new apiErrors.ValidationError(
-          { explanation: `You cannot modify the read-only field: ${field}` }
-        );
-      }
-    });
-  }
-} // noReadOnlyFieldsInReq
-
-/**
  * Validates the subject request coming in and throws an error if the request
  * does not pass the validation.
  * @param  {Object} req - The request object
  */
 function validateRequest(req) {
-  noReadOnlyFieldsInReq(req);
+  utils.noReadOnlyFieldsInReq(req, helper);
   validateTags(req.body);
 } // validateRequest
 

--- a/api/v1/controllers/utils.js
+++ b/api/v1/controllers/utils.js
@@ -70,8 +70,7 @@ function noReadOnlyFieldsInReq(req, props) {
   if (props.readOnlyFields) {
     props.readOnlyFields.forEach((field) => {
       // if request body is an array, check each object in array.
-      if (typeof requestBody !== 'undefined' &&
-            requestBody && requestBody.constructor === Array) {
+      if (Array.isArray(requestBody)) {
         requestBody.forEach((reqObj) => {
           checkReadOnlyFieldInObj(field, reqObj);
         });

--- a/api/v1/controllers/utils.js
+++ b/api/v1/controllers/utils.js
@@ -9,6 +9,7 @@
 /**
  * api/v1/controllers/utils.js
  */
+const apiErrors = require('../apiErrors');
 const ZERO = 0;
 const ONE = 1;
 
@@ -44,6 +45,44 @@ function hasDuplicates(tagsArr) {
   return false;
 }
 
+/**
+ * Check if read only field exists in given object
+ * @param  {String} field - Field name
+ * @param  {Object} obj - Request object
+ * @throws {Object} - Throws validation error is field exists
+ */
+function checkReadOnlyFieldInObj(field, obj) {
+  if (obj.hasOwnProperty(field)) {
+    throw new apiErrors.ValidationError(
+      { explanation: `You cannot modify the read-only field: ${field}` }
+    );
+  }
+}
+
+/**
+ * Throws a validation error if the read-only fields are found in the request.
+ * @param  {Object} req - The request object
+ * @param  {Object} props - The module containing the properties of the
+ *  resource type.
+ */
+function noReadOnlyFieldsInReq(req, props) {
+  const requestBody = req.body;
+  if (props.readOnlyFields) {
+    props.readOnlyFields.forEach((field) => {
+      // if request body is an array, check each object in array.
+      if (typeof requestBody !== 'undefined' &&
+            requestBody && requestBody.constructor === Array) {
+        requestBody.forEach((reqObj) => {
+          checkReadOnlyFieldInObj(field, reqObj);
+        });
+      } else {
+        checkReadOnlyFieldInObj(field, requestBody);
+      }
+    });
+  }
+} // noReadOnlyFieldsInReq
+
 module.exports = {
   hasDuplicates,
+  noReadOnlyFieldsInReq,
 };

--- a/api/v1/helpers/nouns/aspects.js
+++ b/api/v1/helpers/nouns/aspects.js
@@ -42,4 +42,5 @@ module.exports = {
   fieldsWithJsonArrayType,
   fieldsWithEnum,
   tagFilterName: 'tags',
+  readOnlyFields: ['id', 'isDeleted'],
 }; // exports

--- a/api/v1/helpers/nouns/samples.js
+++ b/api/v1/helpers/nouns/samples.js
@@ -41,5 +41,8 @@ module.exports = {
     aspect: Aspect,
     subject: Subject,
   },
-
+  readOnlyFields: [
+    'id', 'isDeleted', 'status', 'previousStatus',
+    'statusChangedAt', 'createdAt', 'updatedAt',
+  ],
 }; // exports

--- a/api/v1/helpers/nouns/subjects.js
+++ b/api/v1/helpers/nouns/subjects.js
@@ -173,5 +173,7 @@ module.exports = {
   fieldsWithJsonArrayType,
   fieldsWithArrayType,
   tagFilterName: 'tags',
-  readOnlyFields: ['hierarchyLevel'],
+  readOnlyFields: [
+    'hierarchyLevel', 'absolutePath', 'childCount', 'id', 'isDeleted',
+  ],
 }; // exports

--- a/tests/api/v1/aspects/patch.js
+++ b/tests/api/v1/aspects/patch.js
@@ -9,7 +9,7 @@
 /**
  * tests/api/v1/aspects/patch.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
@@ -164,6 +164,38 @@ describe(`api: PATCH ${path}`, () => {
       expect(res.body.tags).to.have.length(tags.length);
       expect(res.body.tags).to.have.members(tags);
       done();
+    });
+  });
+
+  it('patching with readOnly field isDeleted should fail', (done) => {
+    api.patch(`${path}/${i}`)
+    .set('Authorization', token)
+    .send({ isDeleted: 0 })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: isDeleted');
+      return done();
+    });
+  });
+
+  it('patching with readOnly field id should fail', (done) => {
+    api.patch(`${path}/${i}`)
+    .set('Authorization', token)
+    .send({ id: 'abcdefgh' })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: id');
+      return done();
     });
   });
 });

--- a/tests/api/v1/aspects/post.js
+++ b/tests/api/v1/aspects/post.js
@@ -9,7 +9,7 @@
 /**
  * tests/api/v1/aspects/post.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
@@ -46,6 +46,48 @@ describe(`api: POST ${path}`, () => {
       }
 
       done();
+    });
+  });
+
+  it('posting with readOnly field id should fail', (done) => {
+    api.post(path)
+    .set('Authorization', token)
+    .send({
+      name: `${tu.namePrefix}ASPECTNAME`,
+      isPublished: true,
+      timeout: '110s',
+      id: 'abcd1234',
+    })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: id');
+      return done();
+    });
+  });
+
+  it('posting with readOnly field isDeleted should fail', (done) => {
+    api.post(path)
+    .set('Authorization', token)
+    .send({
+      name: `${tu.namePrefix}ASPECTNAME`,
+      isPublished: true,
+      timeout: '110s',
+      isDeleted: 0,
+    })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: isDeleted');
+      return done();
     });
   });
 

--- a/tests/api/v1/aspects/put.js
+++ b/tests/api/v1/aspects/put.js
@@ -9,7 +9,7 @@
 /**
  * tests/api/v1/aspects/put.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
@@ -181,6 +181,46 @@ describe(`api: PUT ${path}`, () => {
 
         done();
       });
+    });
+  });
+
+  it('put with readOnly field id should fail', (done) => {
+    api.put(`${path}/${aspectId}`)
+    .set('Authorization', token)
+    .send({
+      name: `${tu.namePrefix}newName`,
+      timeout: '220s',
+      id: 'abcd1234',
+    })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: id');
+      return done();
+    });
+  });
+
+  it('put with readOnly field isDeleted should fail', (done) => {
+    api.put(`${path}/${aspectId}`)
+    .set('Authorization', token)
+    .send({
+      name: `${tu.namePrefix}newName`,
+      timeout: '220s',
+      isDeleted: 0,
+    })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: isDeleted');
+      return done();
     });
   });
 

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -262,6 +262,82 @@ describe(`api: PATCH ${path}`, () => {
         done();
       });
     });
+
+    it('patching with readOnly field id should fail', (done) => {
+      api.patch(`${path}/${sampleName}`)
+      .set('Authorization', token)
+      .send({
+        value: '2',
+        id: 'abc123',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: id');
+        return done();
+      });
+    });
+
+    it('patching with readOnly field status should fail', (done) => {
+      api.patch(`${path}/${sampleName}`)
+      .set('Authorization', token)
+      .send({
+        value: '2',
+        status: 'Invalid',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: status');
+        return done();
+      });
+    });
+
+    it('patching with readOnly field previousStatus should fail', (done) => {
+      api.patch(`${path}/${sampleName}`)
+      .set('Authorization', token)
+      .send({
+        value: '2',
+        previousStatus: 'Invalid',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: previousStatus');
+        return done();
+      });
+    });
+
+    it('patching with readOnly field statusChangedAt should fail', (done) => {
+      api.patch(`${path}/${sampleName}`)
+      .set('Authorization', token)
+      .send({
+        value: '2',
+        statusChangedAt: new Date().toString(),
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: statusChangedAt');
+        return done();
+      });
+    });
   });
 });
 

--- a/tests/api/v1/samples/post.js
+++ b/tests/api/v1/samples/post.js
@@ -215,6 +215,57 @@ describe(`api: POST ${path}`, () => {
       done();
     });
   });
+
+  it('posting with readOnly field previousStatus should fail', (done) => {
+    sampleToPost.previousStatus = 'Invalid';
+    api.post(path)
+    .set('Authorization', token)
+    .send(sampleToPost)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: previousStatus');
+      return done();
+    });
+  });
+
+  it('posting with readOnly field id should fail', (done) => {
+    sampleToPost.id = 'abcd1234';
+    api.post(path)
+    .set('Authorization', token)
+    .send(sampleToPost)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: id');
+      return done();
+    });
+  });
+
+  it('posting with readOnly field updatedAt should fail', (done) => {
+    sampleToPost.updatedAt = new Date().toString();
+    api.post(path)
+    .set('Authorization', token)
+    .send(sampleToPost)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: updatedAt');
+      return done();
+    });
+  });
 });
 
 describe(`api: POST ${path} aspect isPublished false`, () => {

--- a/tests/api/v1/samples/put.js
+++ b/tests/api/v1/samples/put.js
@@ -96,6 +96,54 @@ describe(`api: PUT ${path}`, () => {
     });
   });
 
+  it('put with readOnly field isDeleted should fail', (done) => {
+    api.put(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .send({ subjectId, aspectId, isDeleted: 0 })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: isDeleted');
+      return done();
+    });
+  });
+
+  it('put with readOnly field createdAt should fail', (done) => {
+    api.put(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .send({ subjectId, aspectId, createdAt: new Date().toString() })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: createdAt');
+      return done();
+    });
+  });
+
+  it('put with readOnly field previousStatus should fail', (done) => {
+    api.put(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .send({ subjectId, aspectId, previousStatus: 'Invalid' })
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: previousStatus');
+      return done();
+    });
+  });
+
   it('put does not return id', (done) => {
     api.put(`${path}/${sampleName}`)
     .set('Authorization', token)

--- a/tests/api/v1/samples/upsert.js
+++ b/tests/api/v1/samples/upsert.js
@@ -354,6 +354,63 @@ describe(`api: POST ${path}`, () => {
         });
       });
     });
+
+    it('upsert with readOnly field status should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: `${subject.absolutePath}|${aspect.name}`,
+        status: 'Invalid',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: status');
+        return done();
+      });
+    });
+
+    it('upsert with readOnly field isDeleted should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: `${subject.absolutePath}|${aspect.name}`,
+        isDeleted: 0,
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: isDeleted');
+        return done();
+      });
+    });
+
+    it('upsert with readOnly field createdAt should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: `${subject.absolutePath}|${aspect.name}`,
+        createdAt: new Date().toString(),
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: createdAt');
+        return done();
+      });
+    });
   });
 
   describe('on case insensitive upsert', () => {

--- a/tests/api/v1/samples/upsertBulk.js
+++ b/tests/api/v1/samples/upsertBulk.js
@@ -193,6 +193,58 @@ describe('api: POST ' + path, () => {
     });
   });
 
+  it('upsert with readOnly field status should fail', (done) => {
+    api.post(path)
+    .set('Authorization', token)
+    .send([
+      {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}AspectX`,
+        value: '2',
+        status: 'Invalid',
+      }, {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}AspectX`,
+        value: '4',
+        statusChangedAt: new Date().toString(),
+      },
+    ])
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: status');
+      return done();
+    });
+  });
+
+  it('upsert with readOnly field statusChangedAt should fail', (done) => {
+    api.post(path)
+    .set('Authorization', token)
+    .send([
+      {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}AspectX`,
+        value: '2',
+        statusChangedAt: new Date().toString(),
+      }, {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}AspectX`,
+        value: '4',
+        updatedAt: new Date().toString(),
+      },
+    ])
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: statusChangedAt');
+      return done();
+    });
+  });
+
   describe('upsert bulk when sample already exists', () => {
     it('check that duplication of sample is not happening', (done) => {
       api.post(path)

--- a/tests/api/v1/subjects/patch.js
+++ b/tests/api/v1/subjects/patch.js
@@ -9,7 +9,7 @@
 /**
  * tests/api/v1/subjects/patch.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
@@ -522,26 +522,6 @@ describe(`api: PATCH ${path}`, () => {
     });
   });
 
-  it('patch subject with absolutePath', (done) => {
-    const toPatch = {
-      absolutePath: 'test',
-      isPublished: p1.isPublished,
-      name: p1.name,
-    };
-    api.patch(`${path}/${i1}`)
-    .set('Authorization', token)
-    .send(toPatch)
-    .expect(constants.httpStatus.BAD_REQUEST)
-    .expect(/SubjectValidationError/)
-    .end((err /* , res */) => {
-      if (err) {
-        done(err);
-      }
-
-      done();
-    });
-  });
-
   it('geolocation array must not contain null elements while patching',
   (done) => {
     const toPatch = {
@@ -655,7 +635,7 @@ describe(`api: PATCH ${path}`, () => {
     });
   });
 
-  it('patching readOnly fields should fail', (done) => {
+  it('patching readOnly field hierarchyLevel should fail', (done) => {
     const toPatch = {
       isPublished: p1.isPublished,
       name: p1.name,
@@ -667,6 +647,83 @@ describe(`api: PATCH ${path}`, () => {
     .expect(constants.httpStatus.BAD_REQUEST)
     .end((err /* , res */) => {
       return err ? done(err) : done();
+    });
+  });
+
+  it('patching readOnly field absolutePath should fail', (done) => {
+    const toPatch = {
+      isPublished: p1.isPublished,
+      name: p1.name,
+      absolutePath: 'test',
+    };
+    api.patch(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPatch)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      expect(res.body.errors[0].description).to.be.equal(
+        'You cannot modify the read-only field: absolutePath'
+      );
+      return err ? done(err) : done();
+    });
+  });
+
+  it('patching readOnly field childCount should fail', (done) => {
+    const toPatch = {
+      isPublished: p1.isPublished,
+      name: p1.name,
+      childCount: 2,
+    };
+    api.patch(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPatch)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      expect(res.body.errors[0].description).to.be.equal(
+        'You cannot modify the read-only field: childCount'
+      );
+      return err ? done(err) : done();
+    });
+  });
+
+  it('patching readOnly field id should fail', (done) => {
+    const toPatch = {
+      isPublished: p1.isPublished,
+      name: p1.name,
+      id: 'abcdef',
+    };
+    api.patch(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPatch)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      expect(res.body.errors[0].description).to.be.equal(
+        'You cannot modify the read-only field: id'
+      );
+      return err ? done(err) : done();
+    });
+  });
+
+  it('patching readOnly field isDeleted should fail', (done) => {
+    const toPatch = {
+      isPublished: p1.isPublished,
+      name: p1.name,
+      isDeleted: 0,
+    };
+    api.patch(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPatch)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to.be.equal(
+        'You cannot modify the read-only field: isDeleted'
+      );
+
+      done();
     });
   });
 });

--- a/tests/api/v1/subjects/post.js
+++ b/tests/api/v1/subjects/post.js
@@ -214,7 +214,7 @@ describe(`api: POST ${path}`, () => {
       });
     });
 
-    it('posting with readOnly fields should fail', (done) => {
+    it('posting with readOnly field hierarchyLevel should fail', (done) => {
       api.post(path)
       .set('Authorization', token)
       .send({ name: n0.name, hierarchyLevel: 100 })
@@ -226,6 +226,70 @@ describe(`api: POST ${path}`, () => {
         expect(res.body.errors[0].description).to
         .contain('You cannot modify the read-only field');
         done();
+      });
+    });
+
+    it('posting with readOnly field absolutePath should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({ name: n0.name, absolutePath: 'test' })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: absolutePath');
+        return done();
+      });
+    });
+
+    it('posting with readOnly field childCount should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({ name: n0.name, childCount: 2 })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: childCount');
+        return done();
+      });
+    });
+
+    it('posting with readOnly field id should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({ name: n0.name, id: 'abcd1234' })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: id');
+        return done();
+      });
+    });
+
+    it('posting with readOnly field isDeleted should fail', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send({ name: n0.name, isDeleted: 0 })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].description).to
+        .contain('You cannot modify the read-only field: isDeleted');
+        return done();
       });
     });
 

--- a/tests/api/v1/subjects/put.js
+++ b/tests/api/v1/subjects/put.js
@@ -221,7 +221,7 @@ describe(`api: PUT ${path}`, () => {
     });
   });
 
-  it('put subject with a read-only field', (done) => {
+  it('put subject with a read-only field hierarchyLevel', (done) => {
     const toPut = {
       name: `${tu.namePrefix}newName`,
       isPublished: true,
@@ -236,7 +236,87 @@ describe(`api: PUT ${path}`, () => {
         done(err);
       }
       expect(res.body.errors[0].description).to
-      .contain('You cannot modify the read-only field');
+      .contain('You cannot modify the read-only field: hierarchyLevel');
+      done();
+    });
+  });
+
+  it('put subject with a read-only field absolutePath', (done) => {
+    const toPut = {
+      name: `${tu.namePrefix}newName`,
+      isPublished: true,
+      absolutePath: 'test',
+    };
+    api.put(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPut)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: absolutePath');
+      done();
+    });
+  });
+
+  it('put subject with a read-only field childCount', (done) => {
+    const toPut = {
+      name: `${tu.namePrefix}newName`,
+      isPublished: true,
+      childCount: 2,
+    };
+    api.put(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPut)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: childCount');
+      done();
+    });
+  });
+
+  it('put subject with a read-only field id', (done) => {
+    const toPut = {
+      name: `${tu.namePrefix}newName`,
+      isPublished: true,
+      id: 'abc123',
+    };
+    api.put(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPut)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: id');
+      done();
+    });
+  });
+
+  it('put subject with a read-only field isDeleted', (done) => {
+    const toPut = {
+      name: `${tu.namePrefix}newName`,
+      isPublished: true,
+      isDeleted: 0,
+    };
+    api.put(`${path}/${i1}`)
+    .set('Authorization', token)
+    .send(toPut)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+      expect(res.body.errors[0].description).to
+      .contain('You cannot modify the read-only field: isDeleted');
       done();
     });
   });
@@ -538,25 +618,6 @@ describe('api: PUT subjects with tags', () => {
       expect(res.body.tags).to.have.length(ONE);
       expect(res.body.tags).to.deep.equal(toPut.tags);
     })
-    .end((err /* , res */) => {
-      if (err) {
-        done(err);
-      }
-
-      done();
-    });
-  });
-
-  it('put subject with absolutePath', (done) => {
-    const toPut = {
-      name: `${tu.namePrefix}newName`,
-      absolutePath: 'test',
-    };
-    api.put(`${path}/${subjectId}`)
-    .set('Authorization', token)
-    .send(toPut)
-    .expect(constants.httpStatus.BAD_REQUEST)
-    .expect(/SubjectValidationError/)
     .end((err /* , res */) => {
       if (err) {
         done(err);


### PR DESCRIPTION
Read only fields:
- Aspect: id, isDeleted
- Sample: id, isDeleted, status, previousStatus, statusChangedAt, createdAt, updatedAt
- Subject: absolutePath, childCount, id, isDeleted

Added tests.