### PR TITLE
Fix realtime events when subject is reparented

### DIFF
--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -323,7 +323,6 @@ module.exports = function sample(seq, dataTypes) {
 
       /**
        * Update isDeleted.
-       * Publishes the deleted sample to redis channel.
        *
        * @param {Sample} inst - The Sample instance being deleted
        * @returns {Promise} which resolves undefined or rejects if an error

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -408,15 +408,17 @@ module.exports = function subject(seq, dataTypes) {
         if (inst.getDataValue('isPublished')) {
           if (inst.previous('isPublished')) {
             /*
-             * If tags were updated, send a "delete" event followed by an "add"
-             * event so that perspectives using subject tag filters will get
-             * the right realtime events. If subject tags were not updated,
-             * just send the usual "update" event.
+             * If tags OR parent were updated, send a "delete" event followed
+             * by an "add" event so that perspectives get notified and lenses
+             * can re-render correctly. Tag changes have to be handled this
+             * way for filtering.
+             * If subject tags or parent were not updated, just send the usual
+             * "update" event.
              *
              * TODO : Right now don't have the ability to mock the socket.io
              * test for this.
              */
-            if (inst.changed('tags')) {
+            if (inst.changed('tags') || inst.changed('parentId')) {
               common.publishChange(inst, eventName.del, changedKeys,
                 ignoreAttributes);
               common.publishChange(inst, eventName.add, changedKeys,


### PR DESCRIPTION
Send a “delete” followed by “add” for the subject to be removed from the old parent then added to the new parent.

(Note: the current version of the MultiTable lens doesn't handle this sequence of events, pending a bug fix in that lens. Regardless, we can still confirm the events are sent out correctly.)