### PR TITLE
API: PUT perspectives/key should update the filterType

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -2405,6 +2405,26 @@ paths:
                 type: string
                 description: >
                   The id of Lens.
+              aspectFilterType:
+                type: string
+                enum:
+                  - INCLUDE
+                  - EXCLUDE
+              aspectTagFilterType:
+                type: string
+                enum:
+                  - INCLUDE
+                  - EXCLUDE
+              subjectTagFilterType:
+                type: string
+                enum:
+                  - INCLUDE
+                  - EXCLUDE
+              statusFilterType:
+                type: string
+                enum:
+                  - INCLUDE
+                  - EXCLUDE
             required:
               - name
               - lensId

--- a/tests/api/v1/perspectives/patch.js
+++ b/tests/api/v1/perspectives/patch.js
@@ -22,6 +22,10 @@ const expect = require('chai').expect;
 describe(`api: PATCH ${path}`, () => {
   let perspectiveId;
   let token;
+  const aspectFilterArr = ['temperature', 'humidity'];
+  const aspectTagFilterArr = ['temp', 'hum'];
+  const subjectTagFilterArr = ['ea', 'na'];
+  const statusFilterArr = ['Critical', '-OK'];
 
   before((done) => {
     tu.createToken()
@@ -38,10 +42,10 @@ describe(`api: PATCH ${path}`, () => {
       name: `${tu.namePrefix}testPersp`,
       lensId: createdLens.id,
       rootSubject: 'myMainSubject',
-      aspectFilter: ['temperature', 'humidity'],
-      aspectTagFilter: ['temp', 'hum'],
-      subjectTagFilter: ['ea', 'na'],
-      statusFilter: ['Critical', '-OK'],
+      aspectFilter: aspectFilterArr,
+      aspectTagFilter: aspectTagFilterArr,
+      subjectTagFilter: subjectTagFilterArr,
+      statusFilter: statusFilterArr,
     }))
     .then((createdPersp) => {
       perspectiveId = createdPersp.id;

--- a/tests/api/v1/perspectives/put.js
+++ b/tests/api/v1/perspectives/put.js
@@ -24,6 +24,10 @@ describe(`api: PUT ${path}`, () => {
   let createdLensId;
   let token;
   const name = 'testPersp';
+  const aspectFilterArr = ['temperature', 'humidity'];
+  const aspectTagFilterArr = ['temp', 'hum'];
+  const subjectTagFilterArr = ['ea', 'na'];
+  const statusFilterArr = ['Critical', '-OK'];
 
   before((done) => {
     tu.createToken()
@@ -40,10 +44,10 @@ describe(`api: PUT ${path}`, () => {
       name,
       lensId: createdLens.id,
       rootSubject: 'myMainSubject',
-      aspectFilter: ['temperature', 'humidity'],
-      aspectTagFilter: ['temp', 'hum'],
-      subjectTagFilter: ['ea', 'na'],
-      statusFilter: ['Critical', '-OK'],
+      aspectFilter: aspectFilterArr,
+      aspectTagFilter: aspectTagFilterArr,
+      subjectTagFilter: subjectTagFilterArr,
+      statusFilter: statusFilterArr,
     }))
     .then((createdPersp) => {
       perspectiveId = createdPersp.id;
@@ -55,6 +59,37 @@ describe(`api: PUT ${path}`, () => {
 
   after(u.forceDelete);
   after(tu.forceDeleteUser);
+
+  it('update an perspective with include ', (done) => {
+    const ARR = ['temp', 'hum'];
+    api.put(`${path}/${perspectiveId}`)
+    .set('Authorization', token)
+    .send({
+      name: 'testPersp',
+      lensId: createdLensId,
+      rootSubject: 'changedMainSubject',
+      aspectFilter: aspectFilterArr,
+      aspectTagFilter: aspectTagFilterArr,
+      subjectTagFilter: subjectTagFilterArr,
+      statusFilter: statusFilterArr,
+      aspectFilterType: 'INCLUDE',
+      aspectTagFilterType: 'INCLUDE',
+      subjectTagFilterType: 'INCLUDE',
+      statusFilterType: 'INCLUDE',
+    })
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.aspectFilterType).to.equal('INCLUDE');
+      expect(res.body.aspectTagFilterType).to.equal('INCLUDE');
+      expect(res.body.subjectTagFilterType).to.equal('INCLUDE');
+      expect(res.body.statusFilterType).to.equal('INCLUDE');
+      done();
+    });
+  });
 
   it('update name with different case succeeds', (done) => {
     const newName = name.toUpperCase();


### PR DESCRIPTION
- tested on the UI: user can update filterTypes as a result of this PR
- add filterType fields to swagger 