### PR TITLE
Check enforce token toggle when checking for write permission

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -19,6 +19,7 @@ const jwtUtil = require('../../../../utils/jwtUtil');
 const logAPI = require('../../../../utils/apiLog').logAPI;
 const publisher = require('../../../../realtime/redisPublisher');
 const realtimeEvents = require('../../../../realtime/constants').events;
+const featureToggles = require('feature-toggles');
 
 /**
  * In-place removal of certain keys from the input object
@@ -212,7 +213,7 @@ function isWritable(req, modelInst, isEnabled) {
  */
 function getUserNameFromToken(req, doDecode) {
   return new Promise((resolve, reject) => {
-    if (!doDecode) {
+    if (!doDecode || !featureToggles.isFeatureEnabled('requireAccessToken')) {
       resolve(true);
     }
 


### PR DESCRIPTION
@shriramshankar The bulk upsert request was getting rejected because of invalid token when checking for write permission, and hence we were not able to push samples from Focus in Staging. We need to resolve getUserNameFromToken  promise to true if token is not enforced.