### PR TITLE
without filters, get hierarchy url contains no queries

### DIFF
--- a/tests/view/components/perspectiveStatic.js
+++ b/tests/view/components/perspectiveStatic.js
@@ -16,7 +16,7 @@ import { getArray,
   getConfig,
   filteredArray,
   getOptions,
-} from '../../../view/perspective/configCreatePerspective';
+} from '../../../view/perspective/utils';
 import { getSubjects } from './utils';
 
 describe('Config perspective functions', () => {

--- a/tests/view/perspectives/app.js
+++ b/tests/view/perspectives/app.js
@@ -1,0 +1,208 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/view/perspectives/utils.js
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const utils = require(
+  '../../../view/perspective/utils'
+);
+
+describe('get filter query', () => {
+  it('given default exclude and no filter, should return ' +
+    'empty string', () => {
+    const perspectiveObject = {
+      aspectFilter: [],
+      aspectFilterType: 'EXCLUDE',
+      statusFilter: [],
+      statusFilterType: 'EXCLUDE',
+      subjectTagFilterType: 'EXCLUDE',
+      subjectTagFilter: [],
+      aspectTagFilterType: 'EXCLUDE',
+      aspectTagFilter: [],
+    };
+
+    const url = utils.getFilterQuery(perspectiveObject);
+    expect(url).to.equal('');
+  });
+
+  describe('mix INCLUDE with EXCLUDE', () => {
+    it('one of each', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: ['Critical'],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: [],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: [],
+      };
+
+      const url = utils.getFilterQuery(perspectiveObject);
+      expect(url).to.equal('?aspect=aspect1&status=-Critical');
+    });
+
+    it('two of each', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1', 'aspect2'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: ['Critical', 'OK'],
+        statusFilterType: 'INCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: ['subjectTag1', 'subjectTag2'],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: ['aspectTag1', 'aspectTag2'],
+      };
+
+      const url = '?aspect=aspect1,aspect2&aspectTags=-' +
+        'aspectTag1,-aspectTag2&subjectTags=-subjectTag1,-subjectTag2&status=Critical,OK';
+      expect(utils.getFilterQuery(perspectiveObject)).to.equal(url);
+    });
+  });
+
+  describe('all EXCLUDE', () => {
+    it('one filter', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1', 'aspect2'],
+        aspectFilterType: 'EXCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: [],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: [],
+      };
+
+      const url = utils.getFilterQuery(perspectiveObject);
+      expect(url).to.equal('?aspect=-aspect1,-aspect2');
+    });
+
+    it('two filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'EXCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: [],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: ['aspectTag1'],
+      };
+
+      const url = utils.getFilterQuery(perspectiveObject);
+      expect(url).to.equal('?aspect=-aspect1&aspectTags=-aspectTag1');
+    });
+
+    it('three filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'EXCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: ['subjectTag1'],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: ['aspectTag1'],
+      };
+
+      const url = '?aspect=-aspect1&aspectTags' +
+        '=-aspectTag1&subjectTags=-subjectTag1';
+      expect(utils.getFilterQuery(perspectiveObject)).to.equal(url);
+    });
+
+    it('all filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1', 'aspect2'],
+        aspectFilterType: 'EXCLUDE',
+        statusFilter: ['Critical,OK'],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: ['subjectTag1', 'subjectTag2'],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: ['aspectTag1', 'aspectTag2'],
+      };
+
+      const url = '?aspect=-aspect1,-aspect2&aspectTags=-aspectTag1,-aspectTag2' +
+        '&subjectTags=-subjectTag1,-subjectTag2&status=-Critical,-OK';
+      expect(utils.getFilterQuery(perspectiveObject))
+        .to.equal(url);
+    });
+  });
+
+  describe('all INCLUDE', () => {
+    it('with one filter', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: [],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: [],
+      };
+
+      const url = utils.getFilterQuery(perspectiveObject);
+      expect(url).to.equal('?aspect=aspect1');
+    });
+
+    it('with two filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        subjectTagFilter: [],
+        aspectTagFilterType: 'INCLUDE',
+        aspectTagFilter: ['aspectTag1', 'aspectTag2'],
+      };
+
+      const url = utils.getFilterQuery(perspectiveObject);
+      expect(url).to.equal('?aspect=aspect1&aspectTags=aspectTag1,aspectTag2');
+    });
+
+    it('with three filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: [],
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'INCLUDE',
+        subjectTagFilter: ['subjectTag1', 'subjectTag2'],
+        aspectTagFilterType: 'INCLUDE',
+        aspectTagFilter: ['aspectTag1'],
+      };
+
+      const url = '?aspect=aspect1&aspectTags=aspectTag1' +
+        '&subjectTags=subjectTag1,subjectTag2';
+      expect(utils.getFilterQuery(perspectiveObject)).to.equal(url);
+    });
+
+    it('all filters', () => {
+      const perspectiveObject = {
+        aspectFilter: ['aspect1'],
+        aspectFilterType: 'INCLUDE',
+        statusFilter: ['Critical'],
+        statusFilterType: 'INCLUDE',
+        subjectTagFilterType: 'INCLUDE',
+        subjectTagFilter: ['subjectTag1'],
+        aspectTagFilterType: 'INCLUDE',
+        aspectTagFilter: ['aspectTag1'],
+      };
+
+      const url = '?aspect=aspect1&aspectTags=aspectTag1' +
+        '&subjectTags=subjectTag1&status=Critical';
+      expect(utils.getFilterQuery(perspectiveObject)).to.equal(url);
+    });
+  });
+});

--- a/view/perspective/CreatePerspective.js
+++ b/view/perspective/CreatePerspective.js
@@ -18,7 +18,7 @@ import Dropdown from '../admin/components/common/Dropdown';
 import ControlledInput from '../admin/components/common/ControlledInput';
 import ErrorRender from '../admin/components/common/ErrorRender';
 import RadioGroup from '../admin/components/common/RadioGroup';
-import { filteredArray, getConfig } from './configCreatePerspective';
+import { filteredArray, getConfig } from './utils';
 
 const ZERO = 0;
 

--- a/view/perspective/app.js
+++ b/view/perspective/app.js
@@ -48,7 +48,7 @@ import request from 'superagent';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PerspectiveController from './PerspectiveController';
-import { getTagsFromResources } from './configCreatePerspective';
+import { getFilterQuery, getTagsFromResources } from './utils';
 const u = require('../utils');
 const eventsQueue = require('./eventsQueue');
 let gotLens = false;
@@ -232,55 +232,6 @@ function handleLibraryFiles(res) {
    */
   document.body.appendChild(lensScript);
 } // handleLibraryFiles
-
-/**
- * Generate the filter string for the hierarchy API GET.
- *
- * @param {Object} p - The perspective object
- * @returns {String} - The query string created generated based on the
- *  perspective filters
- */
-function getFilterQuery(p) {
-  let q = '?';
-
-  if (p.aspectFilter && p.aspectFilter.length) {
-    const sign = p.aspectFilterType === 'INCLUDE' ? '' : '-';
-    q += 'aspect' + '=' + sign +
-        p.aspectFilter.join().replace(/,/g, ',' + sign);
-  }
-
-  if (p.aspectTagFilter && p.aspectTagFilter.length) {
-    if (!q.endsWith('?')) {
-      q += '&';
-    }
-
-    const sign = p.aspectTagFilterType === 'INCLUDE' ? '' : '-';
-    q += 'aspectTags' + '=' + sign +
-        p.aspectTagFilter.join().replace(/,/g, ',' + sign);
-  }
-
-  if (p.subjectTagFilter && p.subjectTagFilter.length) {
-    if (!q.endsWith('?')) {
-      q += '&';
-    }
-
-    const sign = p.subjectTagFilterType === 'INCLUDE' ? '' : '-';
-    q += 'subjectTags' + '=' + sign +
-        p.subjectTagFilter.join().replace(/,/g, ',' + sign);
-  }
-
-  if (p.statusFilter) {
-    if (!q.endsWith('?')) {
-      q += '&';
-    }
-
-    const sign = p.statusFilterType === 'INCLUDE' ? '' : '-';
-    q += 'status' + '=' + sign +
-        p.statusFilter.join().replace(/,/g, ',' + sign);
-  }
-
-  return q;
-} // getFilterQuery
 
 /**
  * @param {String} name The key to the returned response object

--- a/view/perspective/utils.js
+++ b/view/perspective/utils.js
@@ -6,11 +6,61 @@
  * https://opensource.org/licenses/BSD-3-Clause
  */
 /**
- * view/perspective/configCreatePerspective.js
+ * view/perspective/utils.js
  *
  * JSON config for CreatePerspective.js
  * Includes all config for resources that need special treatment
  */
+
+/**
+ * Generate the filter string for the hierarchy API GET.
+ *
+ * @param {Object} p - The perspective object
+ * @returns {String} - The query string created generated based on the
+ *  perspective filters
+ */
+function getFilterQuery(p) {
+  let q = '';
+
+  if (p.aspectFilter && p.aspectFilter.length) {
+    const sign = p.aspectFilterType === 'INCLUDE' ? '' : '-';
+    q += 'aspect' + '=' + sign +
+        p.aspectFilter.join().replace(/,/g, ',' + sign);
+  }
+
+  if (p.aspectTagFilter && p.aspectTagFilter.length) {
+    if (q) {
+      q += '&';
+    }
+
+    const sign = p.aspectTagFilterType === 'INCLUDE' ? '' : '-';
+    q += 'aspectTags' + '=' + sign +
+        p.aspectTagFilter.join().replace(/,/g, ',' + sign);
+  }
+
+  if (p.subjectTagFilter && p.subjectTagFilter.length) {
+    if (q) {
+      q += '&';
+    }
+
+    const sign = p.subjectTagFilterType === 'INCLUDE' ? '' : '-';
+    q += 'subjectTags' + '=' + sign +
+        p.subjectTagFilter.join().replace(/,/g, ',' + sign);
+  }
+
+  if (p.statusFilter.length) {
+    if (q) {
+      q += '&';
+    }
+
+    const sign = p.statusFilterType === 'INCLUDE' ? '' : '-';
+    q += 'status' + '=' + sign +
+        p.statusFilter.join().replace(/,/g, ',' + sign);
+  }
+
+  return q.length ? ('?' + q) : q;
+} // getFilterQuery
+
 /**
  * Given array of objects, returns array of strings or primitives
  * of arrayOfObjects[i][field].
@@ -158,6 +208,7 @@ function getConfig(values, key, value) {
 }
 
 export {
+  getFilterQuery,
   getOptions, // for testing
   filteredArray,
   getConfig,


### PR DESCRIPTION
from the perspective app, the url to load hierarchy would contain no query string, if all the perspective filters are empty.
- renamed a file
- add tests for query builder function getFilterQuery