### PR TITLE
Two minor adjustments to the sample store init and persist

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -170,13 +170,10 @@ function cleanAddAspectToSample(sampleObj, aspectObj) {
   sampleRes = sampleStore.arrayStringsToJson(
     sampleObj, constants.fieldsToStringify.sample
   );
-
   const aspect = sampleStore.arrayStringsToJson(
     aspectObj, constants.fieldsToStringify.aspect
   );
   sampleRes.aspect = aspect;
-  sampleRes.aspectId = aspect.id;
-
   return sampleRes;
 }
 
@@ -453,6 +450,8 @@ function upsertOneSample(sampleQueryBodyObj, isBulk, userName) {
     }
 
     subjectId = subjId;
+    sampleQueryBodyObj.subjectId = subjectId;
+    sampleQueryBodyObj.aspectId = aspect.id;
     aspectObj = sampleStore.arrayStringsToJson(
       aspect, constants.fieldsToStringify.aspect
     );
@@ -483,10 +482,7 @@ function upsertOneSample(sampleQueryBodyObj, isBulk, userName) {
     ]).execAsync();
   }))
   .then(() => redisClient.hgetallAsync(sampleKey))
-  .then((updatedSamp) => {
-    updatedSamp.subjectId = subjectId;
-    return cleanAddAspectToSample(updatedSamp, aspectObj);
-  })
+  .then((updatedSamp) => cleanAddAspectToSample(updatedSamp, aspectObj))
   .catch((err) => {
     if (isBulk) {
       return err;

--- a/cache/sampleStoreInit.js
+++ b/cache/sampleStoreInit.js
@@ -244,9 +244,17 @@ function populateSamples() {
 function populate() {
   const msg = 'Populating redis sample store from db started :|';
   log.info(msg);
-
-  const promises = [populateSubjects(), populateSamples(), populateAspects()];
-  return Promise.all(promises);
+  let resp;
+  const promises = [populateSubjects(), populateAspects()];
+  return Promise.all(promises)
+  .then((retval) => {
+    resp = retval;
+    return populateSamples();
+  })
+  .then((sampresp) => {
+    resp.push(sampresp);
+    return resp;
+  });
 } // populate
 
 /**

--- a/tests/cache/sampleStoreFlagFlipFlop.js
+++ b/tests/cache/sampleStoreFlagFlipFlop.js
@@ -23,7 +23,7 @@ const Sample = tu.db.Sample;
 const initialFeatureState = featureToggles
   .isFeatureEnabled(sampleStore.constants.featureName);
 
-describe.only('sampleStore (feature off):', () => {
+describe('sampleStore (feature off):', () => {
   before(() => tu.toggleOverride(sampleStore.constants.featureName, false));
 
   after(() => tu.toggleOverride(sampleStore.constants.featureName,

--- a/tests/cache/sampleStoreFlagFlipFlop.js
+++ b/tests/cache/sampleStoreFlagFlipFlop.js
@@ -23,7 +23,7 @@ const Sample = tu.db.Sample;
 const initialFeatureState = featureToggles
   .isFeatureEnabled(sampleStore.constants.featureName);
 
-describe('sampleStore (feature off):', () => {
+describe.only('sampleStore (feature off):', () => {
   before(() => tu.toggleOverride(sampleStore.constants.featureName, false));
 
   after(() => tu.toggleOverride(sampleStore.constants.featureName,
@@ -163,6 +163,7 @@ describe('sampleStore flag flip flop:', () => {
   });
 
   it('flag from false to true: cache should be populated', (done) => {
+    let subjectIdToTest;
     samstoinit.eradicate()
     .then(() => tu.toggleOverride(sampleStore.constants.featureName, true))
     .then(() => samstoinit.init())
@@ -196,6 +197,16 @@ describe('sampleStore flag flip flop:', () => {
         .to.be.true;
       expect(res.includes('samsto:subject:___subject1.___subject3'))
         .to.be.true;
+    })
+    .then(() => redisClient.getAsync('samsto:subject:___subject1.___subject3'))
+    .then((res) => {
+      expect(res).to.not.be.null;
+      subjectIdToTest = res;
+    })
+    .then(() => redisClient
+      .hgetallAsync('samsto:sample:___subject1.___subject3|___aspect1'))
+    .then((res) => {
+      expect(res).to.have.property('subjectId', subjectIdToTest);
     })
     .then(() => done())
     .catch(done);


### PR DESCRIPTION
(1) When populating the sample store from the db populate subjects and aspects FIRST, THEN samples.
(2) When persisting the sample store from redis to db, skip samples if missing aspectId/subjectId