### PR TITLE
Fix case sensitive bulk upsert non cache

### DIFF
--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -201,6 +201,11 @@ module.exports = function sample(seq, dataTypes) {
             if (o === null) {
               return Sample.create(toUpsert);
             }
+
+            // DO NOT update the name
+            // for existing samples
+            delete toUpsert.name;
+
             /*
              * set value changed to true during updates to avoid timeouts.
              * Adding this to the before update hook does

--- a/tests/api/v1/samples/upsert.js
+++ b/tests/api/v1/samples/upsert.js
@@ -208,6 +208,26 @@ describe(`api: POST ${path}`, () => {
       });
     });
 
+    it('case-incorrect name becomes a combination of subject absolutePath' +
+      ' and aspect name', (done) => {
+      const sampleName = `${subject.absolutePath}|${aspect.name}`;
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: sampleName.toLowerCase(),
+        value: '2',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+
+        expect(res.body.name).to.equal(sampleName);
+        done();
+      });
+    });
+
     it('id is not returned', (done) => {
       api.post(path)
       .set('Authorization', token)
@@ -339,6 +359,26 @@ describe(`api: POST ${path}`, () => {
       })
       .then(() => done())
       .catch(done);
+    });
+
+    it('case-incorrect name becomes a combination of subject absolutePath' +
+      ' and aspect name', (done) => {
+      const sampleName = `${subject.absolutePath}|${aspect.name}`;
+      api.post(path)
+      .set('Authorization', token)
+      .send({
+        name: sampleName.toLowerCase(),
+        value: '2',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+
+        expect(res.body.name).to.equal(sampleName);
+        done();
+      });
     });
 
     it('id is not returned', (done) => {
@@ -502,40 +542,6 @@ describe(`api: POST ${path}`, () => {
           .contain('You cannot modify the read-only field: createdAt');
           return done();
         });
-      });
-    });
-  });
-
-  describe('on case insensitive upsert', () => {
-    beforeEach((done) => {
-      Sample.create({
-        name: `${subject.absolutePath}|${aspect.name}`,
-        value: '1',
-        aspectId: aspect.id,
-        subjectId: subject.id,
-      })
-      .then(() => api.post(path)
-      .set('Authorization', token)
-      .send({
-        // updates the name to use lowercase
-        name: `${subject.absolutePath}|${aspect.name}`.toLowerCase(),
-        value: '2',
-      }))
-      .then(() => done())
-      .catch(done);
-    });
-
-    it('existing sample is not duplicated', (done) => {
-      api.get('/v1/samples?name=' + `${subject.absolutePath}|${aspect.name}`)
-      .end((err, res) => {
-        if (err) {
-          done(err);
-        }
-
-        expect(res.body).to.have.length(1);
-        expect(res.body[0].name)
-        .to.equal(`${subject.absolutePath}|${aspect.name}`.toLowerCase());
-        done();
       });
     });
   });

--- a/tests/api/v1/samples/upsertBulkCaseSensitive.js
+++ b/tests/api/v1/samples/upsertBulkCaseSensitive.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/samples/upsertBulkCaseSensitive.js
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const Aspect = tu.db.Aspect;
+const Subject = tu.db.Subject;
+const Sample = tu.db.Sample;
+const path = '/v1/samples/upsert/bulk';
+
+describe('api: POST ' + path, () => {
+  const sampleName = `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`;
+  let token;
+  let subjectId = '';
+  let aspectId = '';
+
+  before((done) => {
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch(done);
+  });
+
+  beforeEach((done) => {
+    Aspect.create({
+      isPublished: true,
+      name: `${tu.namePrefix}Aspect1`,
+      timeout: '30s',
+      valueType: 'NUMERIC',
+      criticalRange: [0, 1],
+    })
+    .then((aspectOne) => {
+      aspectId = aspectOne.id;
+      return Subject.create({
+        isPublished: true,
+        name: `${tu.namePrefix}Subject`,
+      });
+    })
+    .then((subject) => {
+      subjectId = subject.id;
+      done();
+    })
+    .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+  after(tu.forceDeleteUser);
+
+  describe('when sample EXISTS', () => {
+    beforeEach((done) => {
+      Sample.create({
+        subjectId,
+        aspectId: aspectId,
+      })
+      .then(() => done())
+      .catch(done)
+    });
+
+    it('different case name should NOT modify sample name', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send([
+        {
+          name: sampleName.toLowerCase(),
+          value: '6',
+        },
+      ])
+      .then(() => {
+        setTimeout(() => {
+          api.get('/v1/samples?name=' + sampleName)
+          .end((err, res) => {
+            if (err) {
+              done(err);
+            }
+
+            expect(res.body).to.have.length(1);
+            expect(res.body[0].name)
+            .to.equal(sampleName);
+            done();
+          });
+        }, 100);
+      });
+    });
+  });
+
+  describe('when sample DOES NOT exist', () => {
+    it('different case name should NOT modify sample name', (done) => {
+      api.post(path)
+      .set('Authorization', token)
+      .send([
+        {
+          name: sampleName.toLowerCase(),
+          value: '6',
+        },
+      ])
+      .then(() => {
+
+        /*
+         * the bulk api is asynchronous. The delay is used to give sometime for
+         * the upsert operation to complete
+         */
+        setTimeout(() => {
+          api.get('/v1/samples?name=' + sampleName)
+          .end((err, res) => {
+            if (err) {
+              done(err);
+            }
+
+            expect(res.body).to.have.length(1);
+            expect(res.body[0].name)
+            .to.equal(sampleName);
+            done();
+          });
+        }, 100);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- problem: user is able to update the sample name by bulk upsert
- solution: remove the sample name from the update sample object in db model.