### PR TITLE
Fix case sensitive bulk upsert with redis cache

### DIFF
--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -31,7 +31,7 @@ const constants = {
       'writers',
     ],
     sample: ['relatedLinks'],
-    subject: ['aspectNames'],
+    subject: ['aspectNames', 'tags', 'relatedLinks', 'geolocation'],
   },
   indexKey: {
     aspect: PFX + SEP + 'aspects',

--- a/cache/sampleStoreInit.js
+++ b/cache/sampleStoreInit.js
@@ -158,8 +158,8 @@ function populateSubjects() {
       // add the subject absoluePath to the master subject index
       cmds.push(['sadd', constants.indexKey.subject, key]);
 
-      // create a mapping of subject absolutePath to subjectId
-      cmds.push(['set', key, s.id]);
+      // create a mapping of subject absolutePath to subject object
+      cmds.push(['hmset', key, samsto.cleanSubject(s)]);
     });
 
     return redisClient.batch(cmds).execAsync()

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -312,8 +312,7 @@ module.exports = function subject(seq, dataTypes) {
            */
           if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
             redisOps.addKey(subjectType, inst.getDataValue('absolutePath'));
-            redisOps.setValue(subjectType, inst.getDataValue('absolutePath'),
-              inst.getDataValue('id'));
+            redisOps.hmSet(subjectType, inst.getDataValue('absolutePath'), inst.get());
           }
         }
 
@@ -353,6 +352,7 @@ module.exports = function subject(seq, dataTypes) {
 
             // rename entry in subject store
             redisOps.renameKey(subjectType, oldAbsPath, newAbsPath);
+            redisOps.hmSet(subjectType, newAbsPath, inst.get());
 
             /*
              * When subject absolutePath changes delete multiple possible
@@ -365,8 +365,7 @@ module.exports = function subject(seq, dataTypes) {
           } else if (inst.changed('isPublished')) {
             if (inst.isPublished) {
               redisOps.addKey(subjectType, inst.absolutePath);
-              redisOps.setValue(subjectType, inst.getDataValue('absolutePath'),
-              inst.getDataValue('id'));
+              redisOps.hmSet(subjectType, inst.absolutePath, inst.get());
             } else {
               subjectUtils.removeFromRedis(inst.absolutePath);
             }

--- a/tests/cache/models/samples/upsertBulk.js
+++ b/tests/cache/models/samples/upsertBulk.js
@@ -373,45 +373,5 @@ describe('api::redisEnabled::POST::bulkUpsert ' + path, () => {
         });
       });
     });
-
-    it('check that duplication of sample is not happening even for ' +
-    'sample name in different case', (done) => {
-      api.post(path)
-      .set('Authorization', token)
-      .send([
-        {
-          name:
-            `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`.toLowerCase(),
-          value: '6',
-        },
-      ])
-      .then(() => {
-        api.get('/v1/samples?name=' +
-          `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`)
-        .end((err, res) => {
-          if (err) {
-            done(err);
-          }
-
-          expect(res.body).to.have.length(1);
-          expect(res.body[0].name).to.equal(
-            `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`.toLowerCase()
-          );
-
-          // check that no extra samples are created as side effect
-          redisClient.keysAsync('samsto:sample:*')
-          .then((responses) => {
-            expect(responses.length).to.be.equal(2);
-            expect(responses).to.include(
-              'samsto:sample:___subject|___aspect1'
-            );
-            expect(responses).to.include(
-              'samsto:sample:___subject|___aspect2'
-            );
-            done();
-          });
-        });
-      });
-    });
   });
 });

--- a/tests/cache/models/samples/upsertBulkCaseSensitive.js
+++ b/tests/cache/models/samples/upsertBulkCaseSensitive.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2016, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/samples/upsertBulkCaseSensitive.js
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const samstoinit = require('../../../../cache/sampleStoreInit');
+const redisClient = require('../../../../cache/redisCache').client.sampleStore;
+const u = require('./utils');
+const Aspect = tu.db.Aspect;
+const Subject = tu.db.Subject;
+const Sample = tu.db.Sample;
+const path = '/v1/samples/upsert/bulk';
+const sampleName = '___Subject1.___Subject2|___Aspect1';
+
+describe('api: POST ' + path, () => {
+  let token;
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch(done);
+  });
+
+  beforeEach(rtu.populateRedis);
+  beforeEach((done) => {
+    samstoinit.eradicate()
+    .then(() => samstoinit.init())
+    .then(() => done())
+    .catch(done);
+  });
+
+  afterEach(rtu.forceDelete);
+  afterEach(rtu.flushRedis);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  it('exiting sample: different case name should NOT modify sample name', (done) => {
+    const path = '/v1/samples/upsert/bulk';
+    const sampleName = '___Subject1.___Subject2|___Aspect1';
+
+    api.post(path)
+    .set('Authorization', token)
+    .send([
+      {
+        name: sampleName.toLowerCase(),
+        value: '6',
+      },
+    ])
+    .then(() => {
+
+      /*
+       * the bulk api is asynchronous. The delay is used to give sometime for
+       * the upsert operation to complete
+       */
+      setTimeout(() => {
+        api.get('/v1/samples?name=' + sampleName)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          }
+
+          expect(res.body).to.have.length(1);
+          expect(res.body[0].name).to.equal(sampleName);
+          done();
+        });
+      }, 100);
+    });
+  });
+
+  it('new sample: different case name should NOT modify sample name', (done) => {
+    const path = '/v1/samples/upsert/bulk';
+    const sampleName = '___Subject1|___Aspect2';
+
+    api.post(path)
+    .set('Authorization', token)
+    .send([
+      {
+        name: sampleName.toLowerCase(),
+        value: '6',
+      },
+    ])
+    .then(() => {
+
+      /*
+       * the bulk api is asynchronous. The delay is used to give sometime for
+       * the upsert operation to complete
+       */
+      setTimeout(() => {
+        api.get('/v1/samples?name=' + sampleName)
+        .end((err, res) => {
+          if (err) {
+            done(err);
+          }
+
+          console.log('in res body')
+          expect(res.body).to.have.length(1);
+          expect(res.body[0].name).to.equal(sampleName);
+          done();
+        });
+      }, 100);
+    });
+  });
+});

--- a/tests/cache/models/samples/upsertWithoutPerms.js
+++ b/tests/cache/models/samples/upsertWithoutPerms.js
@@ -46,9 +46,7 @@ describe('api: upsert samples without perms', () => {
     tu.toggleOverride('enforceWritePermission', true);
     tu.toggleOverride('enableRedisSampleStore', true);
     tu.createToken()
-    .then(() => {
-      done();
-    })
+    .then(() => done())
     .catch(done);
   });
 
@@ -76,8 +74,9 @@ describe('api: upsert samples without perms', () => {
     .then((_usr) => tu.createTokenFromUserName(_usr.name))
     .then((tkn) => {
       otherValidToken = tkn;
-      return samstoinit.populate();
     })
+    .then(() => samstoinit.eradicate())
+    .then(() => samstoinit.populate())
     .then(() => done())
     .catch(done);
   });

--- a/tests/cache/sampleStore.js
+++ b/tests/cache/sampleStore.js
@@ -164,6 +164,33 @@ describe('sampleStore (feature on):', () => {
     .catch(done);
   });
 
+  it('subject is populated', (done) => {
+    const absolutePath = '___subject1.___subject2';
+    samstoinit.eradicate()
+    .then(() => redisClient.keysAsync(sampleStore.constants.prefix + '*'))
+    .then((res) => expect(res.length).to.eql(0))
+    .then(() => samstoinit.populate())
+    .then(() => redisClient
+      .smembersAsync(sampleStore.constants.indexKey.subject))
+    .then((res) => {
+      expect(res.includes('samsto:subject:' + absolutePath))
+        .to.be.true;
+      expect(res.includes('samsto:subject:___subject1.___subject3'))
+        .to.be.true;
+    })
+    .then(() => redisClient.hgetallAsync('samsto:subject:' + absolutePath))
+    .then((subject) => {
+
+      // the absolutePath in the key is lowercase
+      expect(subject.absolutePath.toLowerCase()).to.equal(absolutePath)
+    })
+    .then(() => samstoinit.init())
+    .then((res) => expect(res).to.not.be.false)
+    .then(() => done())
+    .catch(done);
+  });
+
+
   it('eradicate and populate', (done) => {
     samstoinit.eradicate()
     .then(() => redisClient.keysAsync(sampleStore.constants.prefix + '*'))

--- a/tests/cache/sampleStoreFlagFlipFlop.js
+++ b/tests/cache/sampleStoreFlagFlipFlop.js
@@ -198,10 +198,10 @@ describe('sampleStore flag flip flop:', () => {
       expect(res.includes('samsto:subject:___subject1.___subject3'))
         .to.be.true;
     })
-    .then(() => redisClient.getAsync('samsto:subject:___subject1.___subject3'))
+    .then(() => redisClient.hgetallAsync('samsto:subject:___subject1.___subject3'))
     .then((res) => {
       expect(res).to.not.be.null;
-      subjectIdToTest = res;
+      subjectIdToTest = res.id;
     })
     .then(() => redisClient
       .hgetallAsync('samsto:sample:___subject1.___subject3|___aspect1'))


### PR DESCRIPTION
- problem: with cache turned on, the upserted sample name is set based on the request body
- sample name should be set according to subject absolutePath and aspect name
- for upsert/bulk upsert for both update and create, the sample name should not be updated
- change the redis cache: subjectAbsPath -> subjectId mapping to subjectAbsPath -> subject, to retrieve proper case subjectAbsPath on sample upsert
