### PR TITLE
create docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+Dockerfile
+docker-compose.yml
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:6.10.3
+
+RUN useradd -U -d /opt/refocus refocus 
+ENV HOME=/opt/refocus
+COPY . $HOME 
+RUN chown -R refocus:refocus $HOME
+
+USER refocus
+WORKDIR $HOME
+RUN npm install 
+
+# sleep is to support pause during startup for deploys in kubernetes - delays start of refocus container to let pg and redis containers to start within the same pod.
+ENV SLEEP=0
+ENV PGHOST=pg
+ENV REDIS_URL=//redis:6379
+
+EXPOSE 3000
+
+CMD [ "/bin/sh", "-c", "sleep $SLEEP; npm start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  refocus:
+    image: "dbabenko/refocus"
+    ports:
+     - "3000:3000"
+    depends_on:
+     - "redis"
+     - "pg"
+  redis:
+    image: "redis:3.2.8"
+    expose:
+       - 6379
+  pg:
+    image: "postgres:9.6.2"
+    expose:
+       - 5432

--- a/docs/docs/01-quickstart.md
+++ b/docs/docs/01-quickstart.md
@@ -83,6 +83,8 @@ You have two ways to deploy Refocus. Select the one that best meets your needs.
 
 - I want [one-click Heroku deployment](./03-quickstartheroku.html)
 - I want to [download and build and deploy locally](./04-quickstartlocal.html)
+- I want to [run Refocus locally with docker container](./05-quickstartlocaldocker.html)
+
 
 Refocus requires that both Redis and PostgreSQL are running. After Refocus is deployed, create an account and sign in.
 

--- a/docs/docs/05-quickstartlocaldocker.md
+++ b/docs/docs/05-quickstartlocaldocker.md
@@ -1,0 +1,12 @@
+---
+layout: docs
+title: Quick Start with Local Docker
+---
+
+# QuickStart with Local Docker
+# Prerequisites
+1. Install docker and docker-compose [docker-for-mac](https://docs.docker.com/docker-for-mac/install/).
+# Start Refocus
+1. Clone this git repository.
+1. Run `cd refocus`.
+1. Run `docker-compose up`. 


### PR DESCRIPTION
Sharing my docker config in case you decide it can be useful for other users of Refocus who want to get refocus running in their local environments.

* added Dockerfile  to create docker image with Refocus app
* added docker-compose.yml file to start refocus app locally (along with postgresql and redis). 
     - right now it references image from my public repo so users don't need to build their own image and only need to run "docker-compose up" to get local refocus app running. But we can change publish image to any other repo of your choice.  
* doc changes - updated only *.md files. Did not generate html files.