### PR TITLE
clean up samples tests

### DIFF
--- a/api/v1/helpers/authUtils.js
+++ b/api/v1/helpers/authUtils.js
@@ -29,9 +29,7 @@ function getUser(req) {
     } else if (req.headers.authorization) { // use the token
       jwtUtil.getTokenDetailsFromRequest(req)
       .then((resObj) => User.findOne({ where: { name: resObj.username } }))
-      .then((user) => {
-        resolve(user);
-      })
+      .then((user) => resolve(user))
       .catch(reject);
     } else {
       reject(new apiErrors.ForbiddenError({

--- a/tests/api/v1/samples/deleteWithoutPerms.js
+++ b/tests/api/v1/samples/deleteWithoutPerms.js
@@ -61,6 +61,7 @@ describe('api: DELETE Sample without permission', () => {
 
   after(u.forceDelete);
   after(tu.forceDeleteUser);
+  after(() => tu.toggleOverride('enforceWritePermission', false));
 
   it('deleting sample without permission should return 403', (done) => {
     api.delete(`${path}/${sampleName}`)

--- a/tests/api/v1/samples/patchWithoutPerms.js
+++ b/tests/api/v1/samples/patchWithoutPerms.js
@@ -58,6 +58,7 @@ describe(`api: PATCH ${path} without permission`, () => {
 
   after(u.forceDelete);
   after(tu.forceDeleteUser);
+  after(() => tu.toggleOverride('enforceWritePermission', false));
 
   describe('Patch without permission should fail', () => {
     it('single related link', (done) => {

--- a/tests/api/v1/samples/postWithoutPerms.js
+++ b/tests/api/v1/samples/postWithoutPerms.js
@@ -63,7 +63,7 @@ describe('api: post samples without perms', () => {
 
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
-
+  after(() => tu.toggleOverride('enforceWritePermission', false));
 
   it('sample write permission should be ' +
     'tied to permission on aspect', (done) => {

--- a/tests/api/v1/samples/upsertBulk.js
+++ b/tests/api/v1/samples/upsertBulk.js
@@ -250,7 +250,7 @@ describe('api: POST ' + path, () => {
           expect(res.body[1].value).to.equal('10');
           return done();
         });
-      }, 500);
+      }, 100);
     });
   });
 

--- a/tests/api/v1/samples/upsertWithoutPerms.js
+++ b/tests/api/v1/samples/upsertWithoutPerms.js
@@ -62,6 +62,7 @@ describe('api: upsert samples without perms', () => {
 
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
+  after(() => tu.toggleOverride('enforceWritePermission', false));
 
 
   it('upsert should fail when upserting a sample ' +

--- a/tests/cache/jobQueue/getBulkUpsertStatus.js
+++ b/tests/cache/jobQueue/getBulkUpsertStatus.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * tests/cache/jobQueue/v1/getBulkUpsertStatus.js
+ * tests/cache/jobQueue/getBulkUpsertStatus.js
  */
 'use strict'; // eslint-disable-line strict
 

--- a/tests/cache/models/samples/upsert.js
+++ b/tests/cache/models/samples/upsert.js
@@ -44,7 +44,6 @@ describe(`api::redisEnabled::POST::upsert ${path}`, () => {
 
   before((done) => {
     tu.toggleOverride('enableRedisSampleStore', true);
-    tu.toggleOverride('enforceWritePermission', false);
     tu.createToken()
     .then((returnedToken) => {
       token = returnedToken;

--- a/tests/tokenNotReq/sampleUpsertBulk.js
+++ b/tests/tokenNotReq/sampleUpsertBulk.js
@@ -20,7 +20,7 @@ const Aspect = tu.db.Aspect;
 const Subject = tu.db.Subject;
 const path = '/v1/samples/upsert/bulk';
 
-describe('api: POST ' + path, () => {
+describe('token not required api: POST ' + path, () => {
   before((done) => {
     Aspect.create({
       isPublished: true,
@@ -58,9 +58,9 @@ describe('api: POST ' + path, () => {
       },
     ])
     .expect(200)
-    .end((err, res) => {
+    .end((err /* , res */) => {
       if (err) {
-        return done(err);
+        done(err);
       }
 
       done();

--- a/tests/tokenNotReq/subjectGetHierarchy.js
+++ b/tests/tokenNotReq/subjectGetHierarchy.js
@@ -20,7 +20,7 @@ const Subject = tu.db.Subject;
 const path = '/v1/subjects/{key}/hierarchy';
 const expect = require('chai').expect;
 
-describe(`api: GET ${path}`, () => {
+describe(`token not required api: GET ${path}`, () => {
   const par = { name: `${tu.namePrefix}NorthAmerica`, isPublished: true };
   const chi = { name: `${tu.namePrefix}Canada`, isPublished: true };
   const grn = { name: `${tu.namePrefix}Quebec`, isPublished: true };


### PR DESCRIPTION
- move out the samples test changes unrelated to #381 to its own PR
- re-phrase the string in the describe, so tests are unique
- lint changes
- toggle permission to be false in the after block, if they were true in the before block