### PR TITLE
Fix kuestats activity logging

### DIFF
--- a/clock/scheduledJobs/kueStatsActivityLogs.js
+++ b/clock/scheduledJobs/kueStatsActivityLogs.js
@@ -48,13 +48,11 @@ function generateLogObject() {
     ];
     Promise.all(promises)
     .then((res) => {
-      console.log('res', res);
       obj.activeCount = res[0];
       obj.completeCount = res[1];
       obj.failedCount = res[2];
       obj.inactiveCount = res[3];
       obj.workTimeMillis = res[4];
-      console.log('obj', obj);
       resolve(obj);
     });
   });

--- a/tests/clock/kueStatsActivityLogs.js
+++ b/tests/clock/kueStatsActivityLogs.js
@@ -19,14 +19,16 @@ const client = redis.client.realtimeLogging;
 
 describe('kueStatsActivityLogs', () => {
   it('generateLogObject', (done) => {
-    const obj = k.generateLogObject();
-    expect(obj).to.be.an('object');
-    expect(obj).to.have.property('activity', 'kueStats');
-    expect(obj).to.have.property('activeCount');
-    expect(obj).to.have.property('completeCount');
-    expect(obj).to.have.property('failedCount');
-    expect(obj).to.have.property('inactiveCount');
-    expect(obj).to.have.property('workTimeMillis');
-    done();
+    k.generateLogObject()
+    .then((obj) => {
+        expect(obj).to.be.an('object');
+        expect(obj).to.have.property('activity', 'kueStats');
+        expect(obj).to.have.property('activeCount');
+        expect(obj).to.have.property('completeCount');
+        expect(obj).to.have.property('failedCount');
+        expect(obj).to.have.property('inactiveCount');
+        expect(obj).to.have.property('workTimeMillis');
+        done();
+    })
   });
 });


### PR DESCRIPTION
Previous version of this was returning obj before any of the jobQueue callbacks had run... so wrapped in promises and generate the log object only after all of those calls have returned the value.