### PR TITLE
Add 404 page

### DIFF
--- a/public/css/perspective.css
+++ b/public/css/perspective.css
@@ -22,6 +22,10 @@ body {
     padding: 5px;
 }
 
+#errorInfo {
+    font-size: 2em;
+}
+
 #refocus_perspective_dropdown_container {
     position: relative;
     z-index: 2000;

--- a/tests/view/newPerspectives/createPerspective.js
+++ b/tests/view/newPerspectives/createPerspective.js
@@ -46,6 +46,19 @@ describe('Perspective view ', () => {
    * @returns {Object} The rendered component
    */
   function setup(valuesAddons, otherPropsObj) {
+    const PERSPECITVE_OBJECT = {
+      name: PERS_NAME,
+      lens: LENS,
+      rootSubject: DUMMY_STRING,
+      aspectFilterType: "EXCLUDE",
+      aspectFilter: [ ],
+      aspectTagFilterType: "EXCLUDE",
+      aspectTagFilter: [ ],
+      subjectTagFilterType: "EXCLUDE",
+      subjectTagFilter: [ ], // empty for testing
+      statusFilterType: "EXCLUDE",
+      statusFilter: DUMMY_ARRAY, // not empty for testing
+    };
     // simulate loading config
     const defaultProps = {
       name: PERS_NAME,
@@ -55,6 +68,7 @@ describe('Perspective view ', () => {
       sendResource: spy,
       // options or all possible values
       values: {
+        perspectives: [PERSPECITVE_OBJECT],
         subjects: [], // { name: absolutePath, id }
         aspectTagFilter: [], // { name, id }
         aspectFilter: [], // strings
@@ -65,19 +79,7 @@ describe('Perspective view ', () => {
         rootSubject: {},
         lens: {}, // includes library
         // actual values
-        perspective: {
-          name: PERS_NAME,
-          lens: LENS,
-          rootSubject: DUMMY_STRING,
-          aspectFilterType: "EXCLUDE",
-          aspectFilter: [ ],
-          aspectTagFilterType: "EXCLUDE",
-          aspectTagFilter: [ ],
-          subjectTagFilterType: "EXCLUDE",
-          subjectTagFilter: [ ], // empty for testing
-          statusFilterType: "EXCLUDE",
-          statusFilter: DUMMY_ARRAY, // not empty for testing
-        },
+        perspective: PERSPECITVE_OBJECT,
       },
     };
     // update defaultProps as needed

--- a/tests/view/newPerspectives/loadPerspectivePicker.js
+++ b/tests/view/newPerspectives/loadPerspectivePicker.js
@@ -34,6 +34,11 @@ describe('Perspective app ', () => {
   const DUMMY_FUNCTION = () => {};
   let request;
   let sandbox;
+  let accumulatorObject = {
+    handleHierarchyEvent: DUMMY_FUNCTION,
+    handleLensDomEvent: DUMMY_FUNCTION,
+    customHandleError: DUMMY_FUNCTION,
+  };
   function setup(valuePairs) {
     const defaultValuePairs = {
       '/v1/aspects': {
@@ -99,8 +104,9 @@ describe('Perspective app ', () => {
   describe('results from GET requests', () => {
     it('default fields', () => {
       setup();
-      const obj = getValuesObject(request, getNamedPerspectiveUrl,
-        DUMMY_FUNCTION, DUMMY_FUNCTION);
+      accumulatorObject.getPromiseWithUrl = request;
+      accumulatorObject.getPerspectiveUrl = getNamedPerspectiveUrl;
+      const obj = getValuesObject(accumulatorObject);
       return obj.then((obj) => {
         expect(obj.name).to.equal(DUMMY_STRING);
         expect(obj.perspective.name).to.equal(DUMMY_STRING);
@@ -132,8 +138,9 @@ describe('Perspective app ', () => {
           { name: ASPECT2, isPublished: true, tags: tags.slice(2) }],
         }
       });
-      const obj = getValuesObject(request, getNamedPerspectiveUrl,
-        DUMMY_FUNCTION, DUMMY_FUNCTION);
+      accumulatorObject.getPromiseWithUrl = request;
+      accumulatorObject.getPerspectiveUrl = getNamedPerspectiveUrl;
+      const obj = getValuesObject(accumulatorObject);
       return obj.then((obj) => {
         expect(obj.aspectTagFilter.length).to.equal(tags.length);
         expect(obj.aspectTagFilter).to.deep.equal(tags.sort())
@@ -148,8 +155,9 @@ describe('Perspective app ', () => {
           { name: ASPECT2, isPublished: true }],
         }
       });
-      const obj = getValuesObject(request, getNamedPerspectiveUrl,
-        DUMMY_FUNCTION, DUMMY_FUNCTION);
+      accumulatorObject.getPromiseWithUrl = request;
+      accumulatorObject.getPerspectiveUrl = getNamedPerspectiveUrl;
+      const obj = getValuesObject(accumulatorObject);
       return obj.then((obj) => {
         expect(obj.aspectFilter.length).to.equal(2);
         expect(obj.aspectFilter[0]).to.equal(ASPECT1);
@@ -165,8 +173,9 @@ describe('Perspective app ', () => {
           { absolutePath: SUBJECT2, isPublished: true, tags: subjectTags }],
         }
       });
-      const obj = getValuesObject(request, getNamedPerspectiveUrl,
-        DUMMY_FUNCTION, DUMMY_FUNCTION);
+      accumulatorObject.getPromiseWithUrl = request;
+      accumulatorObject.getPerspectiveUrl = getNamedPerspectiveUrl;
+      const obj = getValuesObject(accumulatorObject);
       return obj.then((obj) => {
         expect(obj.subjectTagFilter.length).to.equal(subjectTags.length);
         expect(obj.subjectTagFilter).to.deep.equal(subjectTags);
@@ -187,8 +196,9 @@ describe('Perspective app ', () => {
           }],
         }));
       });
-      const obj = getValuesObject(request, getNamedPerspectiveUrl,
-        DUMMY_FUNCTION, DUMMY_FUNCTION);
+      accumulatorObject.getPromiseWithUrl = request;
+      accumulatorObject.getPerspectiveUrl = getNamedPerspectiveUrl;
+      const obj = getValuesObject(accumulatorObject);
       return obj.then((obj) => {
         expect(obj.perspective.aspectTagFilterType).to.equal('EXCLUDE');
         expect(obj.perspective.aspectFilterType).to.equal('EXCLUDE');

--- a/view/newPerspective/CreatePerspective.js
+++ b/view/newPerspective/CreatePerspective.js
@@ -94,34 +94,48 @@ class CreatePerspective extends React.Component {
   componentDidMount() {
     const { values, name, isEditing } = this.props;
 
-    if (values) {
+    /*
+     * Possible cases:
+     * on edit: load the perspective according to name.
+     * on new: load the default object
+     */
+    let stateObject;
 
-      // use default values
-      const stateObject = (!values.perspective || !isEditing) ? {
-        name: '',
-        lenses: '',
-        subjects: '',
-        statusFilterType: 'EXCLUDE',
-        statusFilter: [],
-        subjectTagFilter: [],
-        subjectTagFilterType: 'EXCLUDE',
-        aspectTagFilter: [],
-        aspectTagFilterType: 'EXCLUDE',
-        aspectFilter: [],
-        aspectFilterType: 'EXCLUDE',
-      } : {
-        name: values.perspective.name,
-        lenses: values.perspective.lens.name,
-        subjects: values.perspective.rootSubject,
-        statusFilterType: values.perspective.statusFilterType,
-        statusFilter: values.perspective.statusFilter,
-        subjectTagFilter: values.perspective.subjectTagFilter,
-        subjectTagFilterType: values.perspective.subjectTagFilterType,
-        aspectTagFilter: values.perspective.aspectTagFilter,
-        aspectTagFilterType: values.perspective.aspectTagFilterType,
-        aspectFilter: values.perspective.aspectFilter,
-        aspectFilterType: values.perspective.aspectFilterType,
-      };
+    // wait for props values to be assigned
+    if (values) {
+      if (isEditing) {
+        const _perspective = values.perspectives
+          .filter((pers) => pers.name === name)[0];
+        console.log('editing', _perspective.lens.name)
+        stateObject = {
+          name: _perspective.name,
+          lenses: _perspective.lens.name,
+          subjects: _perspective.rootSubject,
+          statusFilterType: _perspective.statusFilterType,
+          statusFilter: _perspective.statusFilter,
+          subjectTagFilter: _perspective.subjectTagFilter,
+          subjectTagFilterType: _perspective.subjectTagFilterType,
+          aspectTagFilter: _perspective.aspectTagFilter,
+          aspectTagFilterType: _perspective.aspectTagFilterType,
+          aspectFilter: _perspective.aspectFilter,
+          aspectFilterType: _perspective.aspectFilterType,
+        };
+      } else {
+        // use default values
+        stateObject = {
+          name: '',
+          lenses: '',
+          subjects: '',
+          statusFilterType: 'EXCLUDE',
+          statusFilter: [],
+          subjectTagFilter: [],
+          subjectTagFilterType: 'EXCLUDE',
+          aspectTagFilter: [],
+          aspectTagFilterType: 'EXCLUDE',
+          aspectFilter: [],
+          aspectFilterType: 'EXCLUDE',
+        }
+      }
 
       this.setState(stateObject, () => {
         this.updateDropdownConfig();

--- a/view/newPerspective/CreatePerspective.js
+++ b/view/newPerspective/CreatePerspective.js
@@ -94,30 +94,42 @@ class CreatePerspective extends React.Component {
   componentDidMount() {
     const { values, name, isEditing } = this.props;
 
-    // operating on a named, saved perspective.
-    // if editing, use the value in perspective
-    // else use empty string or array
-    if (values && values.perspective) {
-      const perspective = values.perspective;
-      this.setState({
-        name: !isEditing ? '' : perspective.name,
-        lenses: !isEditing ? '' : perspective.lens.name || '',
-        subjects: !isEditing ? '' : perspective.rootSubject || '',
-        statusFilterType: !isEditing ? 'EXCLUDE' : perspective.statusFilterType,
-        statusFilter: !isEditing ? [] : perspective.statusFilter || [],
-        subjectTagFilter: !isEditing ? [] : perspective.subjectTagFilter || [],
-        subjectTagFilterType: !isEditing ? 'EXCLUDE' : perspective.subjectTagFilterType,
-        aspectTagFilter: !isEditing ? [] : perspective.aspectTagFilter || [],
-        aspectTagFilterType: !isEditing ? 'EXCLUDE' : perspective.aspectTagFilterType,
-        aspectFilter: !isEditing ? [] : perspective.aspectFilter || [],
-        aspectFilterType: !isEditing ? 'EXCLUDE' : perspective.aspectFilterType,
-      }, () => {
-        this.updateDropdownConfig(perspective);
+    if (values) {
+
+      // use default values
+      const stateObject = (!values.perspective || !isEditing) ? {
+        name: '',
+        lenses: '',
+        subjects: '',
+        statusFilterType: 'EXCLUDE',
+        statusFilter: [],
+        subjectTagFilter: [],
+        subjectTagFilterType: 'EXCLUDE',
+        aspectTagFilter: [],
+        aspectTagFilterType: 'EXCLUDE',
+        aspectFilter: [],
+        aspectFilterType: 'EXCLUDE',
+      } : {
+        name: values.perspective.name,
+        lenses: values.perspective.lens.name,
+        subjects: values.perspective.rootSubject,
+        statusFilterType: values.perspective.statusFilterType,
+        statusFilter: values.perspective.statusFilter,
+        subjectTagFilter: values.perspective.subjectTagFilter,
+        subjectTagFilterType: values.perspective.subjectTagFilterType,
+        aspectTagFilter: values.perspective.aspectTagFilter,
+        aspectTagFilterType: values.perspective.aspectTagFilterType,
+        aspectFilter: values.perspective.aspectFilter,
+        aspectFilterType: values.perspective.aspectFilterType,
+      };
+
+      this.setState(stateObject, () => {
+        this.updateDropdownConfig();
       });
     }
   }
 
-  updateDropdownConfig(perspective) {
+  updateDropdownConfig() {
 
     // attach config to keys, keys to dropdownConfig
     const { dropdownConfig } = this.state;

--- a/view/newPerspective/CreatePerspective.js
+++ b/view/newPerspective/CreatePerspective.js
@@ -106,7 +106,6 @@ class CreatePerspective extends React.Component {
       if (isEditing) {
         const _perspective = values.perspectives
           .filter((pers) => pers.name === name)[0];
-        console.log('editing', _perspective.lens.name)
         stateObject = {
           name: _perspective.name,
           lenses: _perspective.lens.name,

--- a/view/newPerspective/app.js
+++ b/view/newPerspective/app.js
@@ -312,13 +312,13 @@ function handleLensDomEvent(library, hierarchyLoadEvent) {
 } // handleLensDomEvent
 
 /**
- * Figure out which url to load the perspective.
- * If the perspective name is in url, also change the document title to
- * have the name of the perspective.
- * Otherwise return the default perspctive URL.
+ * Returns the default url if page url ends with /perspectives
+ * Else the perspective name is in url:
+ * - change the document title to the name of the perspective.
+ * - return nothing
  *
- * @returns {Object} which url to load the perspective, and whether the
- * perspective is named or not.
+ * @returns {String} if on/perspectives page, return default url.
+ * Else returns nothing
  */
 function getPerspectiveUrl() {
   let h = window.location.pathname;

--- a/view/newPerspective/app.js
+++ b/view/newPerspective/app.js
@@ -84,16 +84,19 @@ const _io = io; // eslint-disable-line no-undef
 
 /**
  * Add error message to the errorInfo div in the page.
+ * Remove the spinner.
  *
  * @param {Object} err - The error object
  */
 function handleError(err) {
+  console.log(err)
   let msg = DEFAULT_ERROR_MESSAGE;
   if (err.response.body.errors[ZERO].description) {
     msg = err.response.body.errors[ZERO].description;
   }
 
   ERROR_INFO_DIV.innerHTML = msg;
+  removeSpinner();
 } // handleError
 
 /**
@@ -276,6 +279,11 @@ function handleHierarchyEvent(rootSubject, gotLens) {
   return hierarchyLoadEvent;
 }
 
+function removeSpinner() {
+  const spinner = document.getElementById('lens_loading_spinner');
+  spinner.parentNode.removeChild(spinner);
+}
+
 /**
  * On receiving the lens, load the lens.
  * Load the hierarchy if hierarchy event is passed in.
@@ -288,10 +296,9 @@ function handleLensDomEvent(library, hierarchyLoadEvent) {
   // inject lens library files in perspective view.
   handleLibraryFiles(library);
 
-  // remove spinner and load lens
-  const spinner = document.getElementById('lens_loading_spinner');
-  spinner.parentNode.removeChild(spinner);
+  removeSpinner();
 
+  // load lens
   const lensLoadEvent = new CustomEvent('refocus.lens.load');
   LENS_DIV.dispatchEvent(lensLoadEvent);
 
@@ -331,7 +338,15 @@ function getPerspectiveUrl() {
 } // whichPerspective
 
 window.onload = () => {
-  getValuesObject(getPromiseWithUrl, getPerspectiveUrl, handleHierarchyEvent, handleLensDomEvent, handleError)
+  const accumulatorObject = {
+    getPromiseWithUrl,
+    getPerspectiveUrl,
+    handleHierarchyEvent,
+    handleLensDomEvent,
+    handleError,
+  };
+
+  getValuesObject(accumulatorObject)
   .then(loadController)
   .catch((error) => {
     document.getElementById('errorInfo').innerHTML = error;

--- a/view/newPerspective/app.js
+++ b/view/newPerspective/app.js
@@ -89,7 +89,6 @@ const _io = io; // eslint-disable-line no-undef
  * @param {Object} err - The error object
  */
 function handleError(err) {
-  console.log(err)
   let msg = DEFAULT_ERROR_MESSAGE;
   if (err.response.body.errors[ZERO].description) {
     msg = err.response.body.errors[ZERO].description;
@@ -343,7 +342,10 @@ window.onload = () => {
     getPerspectiveUrl,
     handleHierarchyEvent,
     handleLensDomEvent,
-    handleError,
+    customHandleError: (msg) => {
+        ERROR_INFO_DIV.innerHTML = msg;
+      removeSpinner();
+    },
   };
 
   getValuesObject(accumulatorObject)

--- a/view/newPerspective/app.js
+++ b/view/newPerspective/app.js
@@ -331,10 +331,10 @@ function getPerspectiveUrl() {
 } // whichPerspective
 
 window.onload = () => {
-  getValuesObject(getPromiseWithUrl, getPerspectiveUrl, handleHierarchyEvent, handleLensDomEvent)
+  getValuesObject(getPromiseWithUrl, getPerspectiveUrl, handleHierarchyEvent, handleLensDomEvent, handleError)
   .then(loadController)
   .catch((error) => {
-    document.getElementById('errorInfo').innerHTML += error;
+    document.getElementById('errorInfo').innerHTML = error;
   });
 };
 

--- a/view/newPerspective/utils.js
+++ b/view/newPerspective/utils.js
@@ -241,7 +241,7 @@ function getValuesObject(accumulatorObject) {
     getPerspectiveUrl,
     handleHierarchyEvent,
     handleLensDomEvent,
-    handleError,
+    customHandleError,
   } = accumulatorObject;
   const constants = require('../../api/v1/constants');
   const httpStatus = constants.httpStatus;
@@ -270,18 +270,7 @@ function getValuesObject(accumulatorObject) {
   // get the perspectives and the named/default perspective
   const arr = [getPromiseWithUrl('/v1/perspectives?fields=name'),
     getPromiseWithUrl(url)
-    .catch((err) => {
-
-      // if default perspective is not found,
-      // do not throw error. After the perspectives resolves
-      // GET the first perspective
-      if (!named && err.status === httpStatus.NOT_FOUND) {
-        return Promise.resolve();
-      }
-
-      // either named perspective or another error.
-      // throw err;
-    })
+    .catch(console.log)
   ];
 
   return Promise.all(arr)
@@ -306,10 +295,16 @@ function getValuesObject(accumulatorObject) {
       // won't be executed.
       window.location.href = '/perspectives/' + valuesObj.name;
     } else {
-
-      // no perspectives exist
       valuesObj.perspective = null;
-      // throw new Error('no perspectives exist.');
+
+      if (named) {
+        customHandleError('Sorry. Perspective ' + url.split('/').pop() + ' not found.');
+      } else {
+
+        // un named perspectives and perspectives === [];
+        // no perspectives exist
+        customHandleError('no perspectives exist.');
+      }
     }
 
     // valuesObj.perspective have been assigned.

--- a/view/newPerspective/utils.js
+++ b/view/newPerspective/utils.js
@@ -301,7 +301,7 @@ function getValuesObject(accumulatorObject) {
        // when hierarchy is resolved in getHierarchy
       gotLens = true;
 
-      valuesObj.lens = res.bpdy;
+      valuesObj.lens = res.body;
     });
 
     const filterString  = getFilterQuery(perspective);

--- a/view/newPerspective/utils.js
+++ b/view/newPerspective/utils.js
@@ -360,7 +360,9 @@ function getValuesObject(accumulatorObject) {
 
         // named perspective does not exist
         const name = url.split('/').pop();
-        customHandleError('Sorry. Perspective ' + name + ' not found.');
+        customHandleError('Sorry, but the perspective you were trying ' +
+          'to load, ' + name + ', does not exist. Please select a ' +
+          'perspective from the dropdown.');
       } else {
 
         // default perspective does NOT exist.

--- a/view/newPerspective/utils.js
+++ b/view/newPerspective/utils.js
@@ -232,10 +232,17 @@ function getPublishedFromArr(arr) {
  * Accumulates information to load the perspective dropdown,
  * and the edit/create perspective modal
  *
- * @param {Object} request Use supertest or superagent
+ * @param {Object} accumulatorObject
  * @returns {Object} The accumulated values
  */
-function getValuesObject(request, getPerspectiveUrl, handleHierarchyEvent, handleLensDomEvent) {
+function getValuesObject(accumulatorObject) {
+  const {
+    getPromiseWithUrl,
+    getPerspectiveUrl,
+    handleHierarchyEvent,
+    handleLensDomEvent,
+    handleError,
+  } = accumulatorObject;
   const constants = require('../../api/v1/constants');
   const httpStatus = constants.httpStatus;
   const statuses = constants.statuses;
@@ -261,8 +268,8 @@ function getValuesObject(request, getPerspectiveUrl, handleHierarchyEvent, handl
   const { url, named } = getPerspectiveUrl();
 
   // get the perspectives and the named/default perspective
-  const arr = [request('/v1/perspectives?fields=name'),
-    request(url)
+  const arr = [getPromiseWithUrl('/v1/perspectives?fields=name'),
+    getPromiseWithUrl(url)
     .catch((err) => {
 
       // if default perspective is not found,
@@ -307,9 +314,9 @@ function getValuesObject(request, getPerspectiveUrl, handleHierarchyEvent, handl
 
     // valuesObj.perspective have been assigned.
     const promisesArr = [
-      request('/v1/lenses?fields=isPublished,name'),
-      request('/v1/subjects?fields=isPublished,absolutePath,tags'),
-      request('/v1/aspects?fields=isPublished,name,tags'),
+      getPromiseWithUrl('/v1/lenses?fields=isPublished,name'),
+      getPromiseWithUrl('/v1/subjects?fields=isPublished,absolutePath,tags'),
+      getPromiseWithUrl('/v1/aspects?fields=isPublished,name,tags'),
     ];
 
     if (valuesObj.perspective) {
@@ -334,7 +341,7 @@ function getValuesObject(request, getPerspectiveUrl, handleHierarchyEvent, handl
        * lensLoadEvent is dispatched. Since hierarchyLoadEvent is truthy,
        * it is also dispatched.
        */
-      const getLens = request('/v1/lenses/' + valuesObj.perspective.lensId)
+      const getLens = getPromiseWithUrl('/v1/lenses/' + valuesObj.perspective.lensId)
       .then((res) => {
 
         // hierarchyLoadEvent can be undefined or a custom event
@@ -349,7 +356,7 @@ function getValuesObject(request, getPerspectiveUrl, handleHierarchyEvent, handl
       });
 
       const filterString  = getFilterQuery(valuesObj.perspective);
-      const getHierarchy = request('/v1/subjects/' +
+      const getHierarchy = getPromiseWithUrl('/v1/subjects/' +
         valuesObj.perspective.rootSubject + '/hierarchy' + filterString)
       .then((res) => {
 


### PR DESCRIPTION
on 404 error:
- remove spinner
- large text appears: "Sorry. Perspective [perspective_name] not found."
- perspective picker is loaded the same way as under normal circumstances

this PR also includes the fix:
previously, on edit, the perspective loaded into modal is the CURRENT perspective, 
not necessarily the perspective in the same row as the pencil icon.
The fix necessitated GETting all the perspectives on page load. Thus the dropdown shows up later
than previously