### PR TITLE
shrink real time event message size

### DIFF
--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -88,7 +88,8 @@ function attachSamples(res) {
     });
 
     return redisClient.batch(cmds).execAsync();
-  }).then((saArray) => {
+  })
+  .then((saArray) => {
     for (let i = 0; i < saArray.length; i += TWO) {
       const sample = saArray[i];
       const asp = saArray[i + ONE];
@@ -96,10 +97,11 @@ function attachSamples(res) {
 
         // parse the array fields to JSON before adding them to the sample list
         sampleStore.arrayStringsToJson(sample,
-                                    constants.fieldsToStringify.sample);
-        sampleStore.arrayStringsToJson(asp, constants.fieldsToStringify.aspect);
-
+          constants.fieldsToStringify.sample);
+        sampleStore.arrayStringsToJson(asp,
+          constants.fieldsToStringify.aspect);
         sample.aspect = asp;
+        delete sample.apiLinks;
         res.samples.push(sample);
       }
     }
@@ -122,7 +124,8 @@ function attachSamples(res) {
     !filters.aspectTags.includes && !filters.status.includes)));
 
     return Promise.resolve(isFiltered);
-  }).catch((err) => {
+  })
+  .catch((err) => {
     throw err;
   });
 } // attachSamples
@@ -163,8 +166,8 @@ function traverseHierarchy(res) {
 } // traverseHierarchy
 
 /**
- *  When passed a partial subject hierarchy without samples, the subject
- *  hierarchy is completed by attaching samples to it.
+ * When passed a partial subject hierarchy without samples, the subject
+ * hierarchy is completed by attaching samples to it.
  *
  * @param {ServerResponse} res - The subject response containing the samples
  *  and children as an array

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -89,8 +89,9 @@ function publishObject(inst, event, changedKeys, ignoreAttributes) {
 
 /**
  * The sample object needs to be attached its subject object and it also needs
- * a absolutePath field added to it before the sample is published to the redis
- * channel.
+ * an absolutePath field added to it before the sample is published to the
+ * redis channel.
+ *
  * @param  {Object} sampleInst - The sample instance to be published
  * @param  {Model} subjectModel - The subject model to get the related
  * subject instance
@@ -126,8 +127,8 @@ function publishSample(sampleInst, subjectModel, event, aspectModel) {
     if (sub) {
 
       /*
-       *pass the sample instance to the publishObject function only if the
-       *aspect and subject are published
+       * pass the sample instance to the publishObject function only if the
+       * aspect and subject are published
        */
       if (sample.aspect && sample.aspect.isPublished && sub.isPublished) {
         // attach subject to the sample
@@ -135,7 +136,7 @@ function publishSample(sampleInst, subjectModel, event, aspectModel) {
 
         // attach absolutePath field to the sample
         sample.absolutePath = subName;
-        publishObject(sample, eventType);
+        publishObject(sample, eventType, ['apiLinks']);
       }
     }
 


### PR DESCRIPTION
don’t include sample.apiLinks for hierarchy query; don’t publish sample.apiLinks to send over socket.io