### PR TITLE
publish sample test

### DIFF
--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -11,6 +11,8 @@
  */
 'use strict'; // eslint-disable-line strict
 
+const redisStore = require('../cache/sampleStore');
+const redisClient = require('../cache/redisCache').client.sampleStore;
 const pub = require('../cache/redisCache').client.pub;
 const channelName = require('../config').redis.channelName;
 const sampleEvent = require('./constants').events.sample;
@@ -124,12 +126,12 @@ function publishSample(sampleInst, subjectModel, event, aspectModel) {
   };
   const getAspect = aspectModel ? aspectModel.findOne(aspOpts) :
                             Promise.resolve(sample.aspect);
-  return getAspect
-  .then((asp) => {
+  return Promise.all([getAspect, subjectModel.findOne(subOpts)])
+  .then((responses) => {
+    const asp = responses[0];
+    const sub = responses[1];
+
     sample.aspect = asp.get ? asp.get() : asp;
-    return subjectModel.findOne(subOpts);
-  })
-  .then((sub) => {
     if (sub) {
 
       /*

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -123,7 +123,8 @@ function publishSample(sampleInst, subjectModel, event, aspectModel) {
     const subKey = redisStore.toKey('subject', subName);
     promisesArr = [
       redisClient.hgetallAsync(aspKey),
-      redisClient.hgetallAsync(subKey)];
+      redisClient.hgetallAsync(subKey),
+    ];
   } else {
     const subOpts = {
       where: {


### PR DESCRIPTION
- if cache is enabled, in publish sample, get aspect and subject from cache
- previously was fetching  aspect and subject from db
- primary aim of this PR is to see if there's performance improvement: with redis cache on,
the web dyno should be able to take more samples.

How to test locally:
tab 1: refocus:  `ENABLE_REDIS_SAMPLE_STORE=true node .`
tab 2: refocus-client-example: `node samples.js` with this as the last line in samples.js file:
Repeat(upsertSamples).every(2, 'ms').for(15, 'seconds').start.in(2, 'sec');
This does not err. While the same setup with master branch errs out in the tab 2
with errors:
{ RequestError: Error: getaddrinfo ENOTFOUND localhost localhost:3000
...
   { Error: socket hang up
...
