### PR TITLE
Send events only for active perspectives

### DIFF
--- a/realtime/setupSocketIO.js
+++ b/realtime/setupSocketIO.js
@@ -183,12 +183,9 @@ function init(io, redisStore) {
                 }
               }); // redisClient.del
             }
-
           }); // redisClient.get
         }); // on disconnect
       } // if logEnabled
-
-      return setupNamespace(io);
     })
     .catch((err) => {
       // no realtime events :(
@@ -197,6 +194,8 @@ function init(io, redisStore) {
       return;
     });
   }); // on connect
+
+  return setupNamespace(io); // executes only on server start
 } // init
 
 module.exports = {

--- a/realtime/socketIOEmitter.js
+++ b/realtime/socketIOEmitter.js
@@ -14,7 +14,6 @@
 
 const rtUtils = require('./utils');
 const initEvent = 'refocus.internal.realtime.perspective.namespace.initialize';
-const featureToggles = require('feature-toggles');
 
 module.exports = (io, key, mssgObj) => {
   const obj = rtUtils.parseObject(mssgObj[key], key);
@@ -26,7 +25,9 @@ module.exports = (io, key, mssgObj) => {
   }
 
   for (const nsp in io.nsps) {
-    if (nsp && rtUtils.shouldIEmitThisObj(nsp, obj)) {
+    // Send events only if namespace connections > 0
+    if (nsp && (Object.keys(nsp).length > 0) &&
+     rtUtils.shouldIEmitThisObj(nsp, obj)) {
       // newObjectAsString contains { key: {new: obj }}
       io.of(nsp).emit(key, newObjectAsString);
     }


### PR DESCRIPTION
going from storing the active perspectives in redis, to storing in memory, to this. Thoughtful process and discussions finally led to only 2 lines of code change :)

I looked at tests, but the session storage in redis makes the realtime tests more complex. I will not be able to cover that in this sprint. We can probably cover it in the story we already have for realtime tests. 