### PR TITLE
Get subject from cache

### DIFF
--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -215,7 +215,6 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   findSubjects(req, res, next) {
-    console.log('about to go in cache', featureToggles.isFeatureEnabled('getSubjectFromCache'))
     validateTags(null, req.swagger.params);
     if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName) &&
       featureToggles.isFeatureEnabled('getSubjectFromCache')) {

--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -215,8 +215,10 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   findSubjects(req, res, next) {
+    console.log('about to go in cache', featureToggles.isFeatureEnabled('getSubjectFromCache'))
     validateTags(null, req.swagger.params);
-    if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName)) {
+    if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName) &&
+      featureToggles.isFeatureEnabled('getSubjectFromCache')) {
       const resultObj = { reqStartTime: new Date() }; // for logging
       redisSubjectModel.findSubjects(req, res, resultObj)
       .then((response) => {

--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -32,8 +32,9 @@ const u = require('../helpers/verbs/utils');
 const httpStatus = require('../constants').httpStatus;
 const apiErrors = require('../apiErrors');
 const redisSubjectModel = require('../../../cache/models/subject');
-const sampleStoreFeature =
-                  require('../../../cache/sampleStore').constants.featureName;
+const sampleStore = require('../../../cache/sampleStore');
+const sampleStoreConstants = sampleStore.constants;
+const sampleStoreFeature = sampleStoreConstants.featureName;
 const jobType = require('../../../jobQueue/setup').jobType;
 const jobWrapper = require('../../../jobQueue/jobWrapper');
 const jobSetup = require('../../../jobQueue/setup');
@@ -215,7 +216,24 @@ module.exports = {
    */
   findSubjects(req, res, next) {
     validateTags(null, req.swagger.params);
-    doFind(req, res, next, helper);
+    if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName)) {
+      const resultObj = { reqStartTime: new Date() }; // for logging
+      redisSubjectModel.findSubjects(req, res, resultObj)
+      .then((response) => {
+        // loop through remove values to delete property
+        if (helper.fieldsToExclude) {
+          for (let i = response.length - 1; i >= 0; i--) {
+            u.removeFieldsFromResponse(helper.fieldsToExclude, response[i]);
+          }
+        }
+
+        u.logAPI(req, resultObj, response); // audit log
+        res.status(httpStatus.OK).json(response);
+      })
+      .catch((err) => u.handleError(next, err, helper.modelName));
+    } else {
+      doFind(req, res, next, helper);
+    }
   },
 
   /**

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -74,120 +74,6 @@ function cleanAddAspectToSample(sampleObj, aspectObj) {
 }
 
 /**
- * Apply wildcard filter on sample array of keys or objects. For each entry,
- * if given property exists for sample, apply regex to the property value,
- * else if, the property is 'name', then the function was called before getting
- * obj, hence apply regex filter on sample name.
- * @param  {Array}  sampArr - Array of sample keys or sample objects
- * @param  {String}  prop  - Property name
- * @param  {String} propExpr - Wildcard expression
- * @returns {Array} - Filtered array
- */
-function filterByFieldWildCardExpr(sampArr, prop, propExpr) {
-  // regex to match wildcard expr, i option means case insensitive
-  const escapedExp = propExpr.split('_').join('\\_')
-                      .split('|').join('\\|').split('.').join('\\.');
-
-  const re = new RegExp('^' + escapedExp.split('*').join('.*') + '$', 'i');
-  return sampArr.filter((sampEntry) => {
-    if (sampEntry[prop]) { // sample object
-      return re.test(sampEntry[prop]);
-    } else if (prop === sampFields.NAME) { // sample key
-      const sampName = sampleStore.getNameFromKey(sampEntry);
-      return re.test(sampName);
-    }
-
-    return false;
-  });
-}
-
-/**
- * Apply filters on sample keys list
- * @param  {Array} sampKeysArr - Sample key names array
- * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample keys array
- */
-function applyFiltersOnSampKeys(sampKeysArr, opts) {
-  let resArr = sampKeysArr;
-
-  // apply limit and offset if no sort order defined
-  if (!opts.order) {
-    resArr = modelUtils.applyLimitAndOffset(opts, sampKeysArr);
-  }
-
-  // apply wildcard expr on name, if specified
-  if (opts.filter && opts.filter.name) {
-    const filteredKeys = filterByFieldWildCardExpr(
-      resArr, sampFields.NAME, opts.filter.name
-    );
-    resArr = filteredKeys;
-  }
-
-  return resArr;
-}
-
-/**
- * Apply field list filter.
- * @param  {Object} sample - Sample object
- * @param  {Array} attributes - Sample fields array
- */
-function applyFieldListFilter(sample, attributes) {
-  // apply field list filter
-  Object.keys(sample).forEach((sampField) => {
-    if (!attributes.includes(sampField)) {
-      delete sample[sampField];
-    }
-  });
-}
-
-/**
- * Apply filters on sample array list
- * @param  {Array} sampObjArray - Sample objects array
- * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample objects array
- */
-function applyFiltersOnSampObjs(sampObjArray, opts) {
-  let filteredSamples = sampObjArray;
-
-  // apply wildcard expr if other than name because
-  // name filter was applied before redis call
-  if (opts.filter) {
-    const filterOptions = opts.filter;
-    Object.keys(filterOptions).forEach((field) => {
-      if (field !== sampFields.NAME) {
-        const filteredKeys = filterByFieldWildCardExpr(
-          sampObjArray, field, filterOptions[field]
-        );
-        filteredSamples = filteredKeys;
-      }
-    });
-  }
-
-  // sort and apply limits to samples
-  if (opts.order) {
-    const sortedSamples = modelUtils.sortByOrder(filteredSamples, opts.order);
-    filteredSamples = sortedSamples;
-
-    const slicedSampObjs = modelUtils.applyLimitAndOffset(opts, filteredSamples);
-    filteredSamples = slicedSampObjs;
-  }
-
-  return filteredSamples;
-}
-
-/**
- * Remove extra fields from query body object.
- * @param  {Object} qbObj - Query body object
- */
-function cleanQueryBodyObj(qbObj) {
-  Object.keys(qbObj).forEach((qbField) => {
-    if (!sampleFieldsArr.includes(qbField)) {
-      delete qbObj[qbField];
-    }
-  });
-}
-
-/**
  * Create properties array having and fields and values need to be set to
  * update/create sample. Value is empty string if new object being created.
  * If some value, then calculate status. Update status, previous status and
@@ -198,7 +84,7 @@ function cleanQueryBodyObj(qbObj) {
  * @param  {Object} aspectObj - Aspect object
  */
 function createSampHsetCommand(qbObj, sampObj, aspectObj) {
-  cleanQueryBodyObj(qbObj); // remove extra fields
+  modelUtils.cleanQueryBodyObj(qbObj, sampleFieldsArr); // remove extra fields
   let value;
   if (qbObj[sampFields.VALUE]) {
     value = qbObj[sampFields.VALUE];
@@ -565,7 +451,7 @@ module.exports = {
         });
       }
 
-      cleanQueryBodyObj(reqBody);
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr);
       aspectObj = sampleStore.arrayStringsToJson(
         aspObj, constants.fieldsToStringify.aspect
       );
@@ -657,7 +543,7 @@ module.exports = {
         });
       }
 
-      cleanQueryBodyObj(reqBody); // remove extra fields
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr); // remove extra fields
       reqBody.name = sampleName; // set name
 
       let value = '';
@@ -754,7 +640,7 @@ module.exports = {
       return modelUtils.checkWritePermission(aspectObj, currSampObj, userName);
     })
     .then(() => {
-      cleanQueryBodyObj(reqBody);
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr);
       let value = '';
       if (reqBody.value) {
         value = reqBody.value;
@@ -846,7 +732,7 @@ module.exports = {
 
       // apply fields list filter
       if (opts.attributes) {
-        applyFieldListFilter(sample, opts.attributes);
+        modelUtils.applyFieldListFilter(sample, opts.attributes);
       }
 
       // clean and attach aspect to sample, add api links as well
@@ -884,7 +770,8 @@ module.exports = {
     return redisClient.sortAsync(constants.indexKey.sample, 'alpha')
     .then((allSampKeys) => {
       const commands = [];
-      const filteredSampKeys = applyFiltersOnSampKeys(allSampKeys, opts);
+      const filteredSampKeys = modelUtils
+        .applyFiltersOnSampKeys(allSampKeys, opts);
 
       // add to commands
       filteredSampKeys.forEach((sampKey) => {
@@ -909,12 +796,12 @@ module.exports = {
         sampAspectMap[redisResponses[num].name] = redisResponses[num + ONE];
       }
 
-      const filteredSamples = applyFiltersOnSampObjs(samples, opts);
+      const filteredSamples = modelUtils.applyFiltersOnSampObjs(samples, opts);
       filteredSamples.forEach((sample) => {
 
         const sampName = sample.name;
         if (opts.attributes) { // delete sample fields, hence no return obj
-          applyFieldListFilter(sample, opts.attributes);
+          modelUtils.applyFieldListFilter(sample, opts.attributes);
         }
 
         // attach aspect to sample

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -221,13 +221,8 @@ module.exports = {
       const filteredSubjectKeys = modelUtils
         .applyFiltersOnSampKeys(allSubjectKeys, opts);
 
-      // add to commands
       filteredSubjectKeys.forEach((subjectKey) => {
-        commands.push(['hgetall', subjectKey]); // get subject
-        // commands.push(
-        //   ['hgetall',
-        //    sampleStore.toKey(constants.objectType.aspect, aspectName),
-        //   ]);
+        commands.push(['hgetall', subjectKey]);
       });
 
       return redisClient.batch(commands).execAsync();

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -167,6 +167,16 @@ function traverseHierarchy(res) {
 } // traverseHierarchy
 
 /**
+ * Given a string, get the substring after the last period.
+ *
+ * @param {String} absolutePath: Subject absolutePath.
+ * @returns {String} name The subject name.
+ */
+function getNameFromAbsolutePath(absolutePath) {
+  return absolutePath.split('.').pop();
+}
+
+/**
  *  When passed a partial subject hierarchy without samples, the subject
  *  hierarchy is completed by attaching samples to it.
  *
@@ -219,7 +229,7 @@ module.exports = {
     .then((allSubjectKeys) => {
       const commands = [];
       const filteredSubjectKeys = modelUtils
-        .applyFiltersOnSampKeys(allSubjectKeys, opts);
+        .applyFiltersOnResourceKeys(allSubjectKeys, opts, getNameFromAbsolutePath);
 
       filteredSubjectKeys.forEach((subjectKey) => {
         commands.push(['hgetall', subjectKey]);
@@ -229,7 +239,7 @@ module.exports = {
     })
     .then((subjects) => {
       logObject.dbTime = new Date() - logObject.reqStartTime; // log db time
-      const filteredSubjects = modelUtils.applyFiltersOnSampObjs(subjects, opts);
+      const filteredSubjects = modelUtils.applyFiltersOnResourceObjs(subjects, opts);
       filteredSubjects.forEach((subject) => {
 
         // convert the time fields to appropriate format
@@ -244,7 +254,7 @@ module.exports = {
         subject.apiLinks = utils.getApiLinks(
           subject.name, helper, req.method
         );
-        response.push(subject); // add sample to response
+        response.push(subject); // add subject to response
       });
 
       return response;

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -247,6 +247,10 @@ module.exports = {
           modelUtils.applyFieldListFilter(subject, opts.attributes);
         }
 
+        // convert the time fields to appropriate format
+        subject.createdAt = new Date(subject.createdAt).toISOString();
+        subject.updatedAt = new Date(subject.updatedAt).toISOString();
+
         // add api links
         subject.apiLinks = utils.getApiLinks(
           subject.name, helper, req.method

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -12,6 +12,7 @@
 'use strict'; // eslint-disable-line strict
 
 const helper = require('../../api/v1/helpers/nouns/subjects');
+const utils = require('../../api/v1/helpers/verbs/utils');
 const sampleStore = require('../sampleStore');
 const constants = sampleStore.constants;
 const redisClient = require('../redisCache').client.sampleStore;
@@ -232,10 +233,13 @@ module.exports = {
 
       return redisClient.batch(commands).execAsync();
     })
-    .then((redisResponses) => { // subjects and aspects
+    .then((subjects) => {
+        console.log(subjects)
+
       logObject.dbTime = new Date() - logObject.reqStartTime; // log db time
-      const subjects = [];
       const filteredSubjects = modelUtils.applyFiltersOnSampObjs(subjects, opts);
+        console.log(filteredSubjects)
+
       filteredSubjects.forEach((subject) => {
 
         const sampName = subject.name;
@@ -244,7 +248,7 @@ module.exports = {
         }
 
         // add api links
-        subject.apiLinks = u.getApiLinks(
+        subject.apiLinks = utils.getApiLinks(
           subject.name, helper, req.method
         );
         response.push(subject); // add sample to response

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -222,8 +222,6 @@ module.exports = {
 
       // add to commands
       filteredSubjectKeys.forEach((subjectKey) => {
-        console.log(subjectKey)
-        // not sure if the keys are already in key format
         commands.push(['hgetall', subjectKey]); // get subject
         // commands.push(
         //   ['hgetall',
@@ -234,12 +232,8 @@ module.exports = {
       return redisClient.batch(commands).execAsync();
     })
     .then((subjects) => {
-        console.log(subjects)
-
       logObject.dbTime = new Date() - logObject.reqStartTime; // log db time
       const filteredSubjects = modelUtils.applyFiltersOnSampObjs(subjects, opts);
-        console.log(filteredSubjects)
-
       filteredSubjects.forEach((subject) => {
 
         const sampName = subject.name;

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -12,6 +12,7 @@
 'use strict'; // eslint-disable-line strict
 
 const helper = require('../../api/v1/helpers/nouns/subjects');
+const fu = require('../../api/v1/helpers/verbs/findUtils.js');
 const utils = require('../../api/v1/helpers/verbs/utils');
 const sampleStore = require('../sampleStore');
 const constants = sampleStore.constants;
@@ -236,14 +237,13 @@ module.exports = {
       const filteredSubjects = modelUtils.applyFiltersOnSampObjs(subjects, opts);
       filteredSubjects.forEach((subject) => {
 
-        const sampName = subject.name;
-        if (opts.attributes) { // delete subject fields, hence no return obj
-          modelUtils.applyFieldListFilter(subject, opts.attributes);
-        }
-
         // convert the time fields to appropriate format
         subject.createdAt = new Date(subject.createdAt).toISOString();
         subject.updatedAt = new Date(subject.updatedAt).toISOString();
+
+        if (opts.attributes) { // delete subject fields, hence no return obj
+          modelUtils.applyFieldListFilter(subject, opts.attributes);
+        }
 
         // add api links
         subject.apiLinks = utils.getApiLinks(

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -200,30 +200,24 @@ function checkWritePermission(aspect, sample, userName, isBulk) {
  */
 function sortByOrder(arr, propArr) {
   const isDescending = propArr[ZERO].startsWith('-');
-  console.log('is descending', isDescending, propArr)
-
   return arr.sort((a, b) => {
-    // console.log('a is', a)
-    // console.log('b is', b)
     let strA = '';
     let strB = '';
     propArr.forEach((field) => {
-      strA += a[field];
-      strB += b[field];
+
+      // remove leading minus sign
+      const _field = isDescending ? field.substr(1): field;
+      strA += a[_field];
+      strB += b[_field];
     });
-    // console.log('A is', strA)
-    // console.log('B is', strB)
 
     if (strA < strB) {
-      console.log('returning one?', isDescending ? ONE : MINUS_ONE)
       return isDescending ? ONE : MINUS_ONE;
     }
 
     if (strA > strB) {
-      console.log('returning - one?', isDescending ? MINUS_ONE : ONE)
       return isDescending ? MINUS_ONE : ONE;
     }
-      console.log('returning 0')
 
     return ZERO;
   });

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -47,7 +47,7 @@ function applyFiltersOnSampObjs(resourceObjArray, opts) {
   if (opts.filter) {
     const filterOptions = opts.filter;
     Object.keys(filterOptions).forEach((field) => {
-      if (field !== 'name') {
+      if (field !== 'name' || field !== 'absolutePath') {
         const filteredKeys = filterByFieldWildCardExpr(
           resourceObjArray, field, filterOptions[field]
         );
@@ -58,7 +58,9 @@ function applyFiltersOnSampObjs(resourceObjArray, opts) {
 
   // sort and apply limits to samples
   if (opts.order) {
+    console.log(opts.order)
     const sortedSamples = sortByOrder(filteredResources, opts.order);
+    console.log('output', sortedSamples)
     filteredResources = sortedSamples;
 
     const slicedSampObjs = applyLimitAndOffset(opts, filteredResources);
@@ -201,16 +203,16 @@ function sortByOrder(arr, propArr) {
   console.log('is descending', isDescending, propArr)
 
   return arr.sort((a, b) => {
-    console.log('a is', a)
-    console.log('b is', b)
+    // console.log('a is', a)
+    // console.log('b is', b)
     let strA = '';
     let strB = '';
     propArr.forEach((field) => {
       strA += a[field];
       strB += b[field];
     });
-    console.log('A is', strA)
-    console.log('B is', strB)
+    // console.log('A is', strA)
+    // console.log('B is', strB)
 
     if (strA < strB) {
       console.log('returning one?', isDescending ? ONE : MINUS_ONE)

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -116,7 +116,6 @@ function applyFiltersOnResourceKeys(keysArr, opts, getNameFunc) {
   return resArr;
 }
 
-
 /**
  * Remove extra fields from query body object.
  * @param  {Object} qbObj - Query body object
@@ -156,7 +155,7 @@ function filterByFieldWildCardExpr(arr, prop, propExpr, getNameFunc) {
       const _name = sampleStore.getNameFromKey(entry);
 
       // keys may need processing to become names
-      const name = getNameFunc ? getNameFunc(_name): name;
+      const name = getNameFunc ? getNameFunc(_name) : name;
       return re.test(name);
     }
 
@@ -179,7 +178,7 @@ function sortByOrder(arr, propArr) {
     propArr.forEach((field) => {
 
       // remove leading minus sign
-      const _field = isDescending ? field.substr(1): field;
+      const _field = isDescending ? field.substr(1) : field;
       strA += a[_field];
       strB += b[_field];
     });
@@ -252,4 +251,4 @@ module.exports = {
   applyLimitAndOffset,
   getOptionsFromReq,
   sortByOrder,
-}
+};

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * cache/models/utils.js
+ */
+const apiConstants = require('../../api/v1/constants');
+const defaults = require('../../config').api.defaults;
+const u = require('../../api/v1/helpers/verbs/utils');
+const featureToggles = require('feature-toggles');
+const redisErrors = require('../redisErrors');
+const MINUS_ONE = -1;
+const ONE = 1;
+const ZERO = 0;
+/**
+ * Checks if the user has the permission to perform the write operation on the
+ * sample or not
+ * @param  {String}  aspect - Aspect object
+ * @param  {String}  sample - Sample object
+ * @param  {String}  userName -  User performing the operation
+ * @param  {Boolean} isBulk   - Flag to indicate if the action is a bulk
+ * operation or not
+ * @returns {Promise} - which resolves to true if the user has write permission
+ */
+function checkWritePermission(aspect, sample, userName, isBulk) {
+  let isWritable = true;
+  if (aspect.writers && aspect.writers.length) {
+    isWritable = featureToggles
+                        .isFeatureEnabled('enforceWritePermission') ?
+                        aspect.writers.includes(userName) : true;
+  }
+
+  if (!isWritable) {
+    const err = new redisErrors.UpdateDeleteForbidden({
+      explanation: `The user: ${userName}, does not have write permission` +
+        ` on the sample: ${sample.name}`,
+    });
+    if (isBulk) {
+      return Promise.reject({ isFailed: true, explanation: err });
+    }
+
+    return Promise.reject(err);
+  }
+
+  return Promise.resolve(true);
+} // checkWritePermission
+
+/**
+ * Sort by appending all fields value in a string and then comparing them.
+ * If first fields starts with -, sort order is descending.
+ * @param  {Array} arr - Resource objs array
+ * @param  {Array} propArr - Fields array
+ * @returns {Array} - Sorted array
+ */
+function sortByOrder(arr, propArr) {
+  const isDescending = propArr[ZERO].startsWith('-');
+  return arr.sort((a, b) => {
+    let strA = '';
+    let strB = '';
+    propArr.forEach((field) => {
+      strA += a[field];
+      strB += b[field];
+    });
+
+    if (strA < strB) {
+      return isDescending ? ONE : MINUS_ONE;
+    }
+
+    if (strA > strB) {
+      return isDescending ? MINUS_ONE : ONE;
+    }
+
+    return ZERO;
+  });
+}
+
+/**
+ * Get option fields from requesr parameters. An example:
+ * { attributes: [ 'name', 'status', 'value', 'id' ],
+    order: [ '-value', 'status' ],
+    limit: 5,
+    offset: 1,
+    filter: { name: '___Subject1.___Subject2*' } }
+ * @param  {Object} params - Request query parameters
+ * @param  {Object} helper - The resource's properties.
+ * @returns {Object} - Filter object
+ */
+function getOptionsFromReq(params, helper) {
+  // eg. ?fields=x,y,z. Adds as opts.attributes = [array of fields]
+  // id is always included
+  const opts = u.buildFieldList(params);
+
+  // Specify the sort order. If defaultOrder is defined in props or sort value
+  // then update sort order otherwise take value from model defination
+  if ((params.sort && params.sort.value) || helper.defaultOrder) {
+    opts.order = params.sort.value || helper.defaultOrder;
+  }
+
+  // handle limit
+  if (params.limit && params.limit.value) {
+    opts.limit = parseInt(params.limit.value, defaults.limit);
+  }
+
+  // handle offset
+  if (params.offset && params.offset.value) {
+    opts.offset = parseInt(params.offset.value, defaults.offset);
+  }
+
+  const filter = {};
+  const keys = Object.keys(params);
+
+  for (let i = ZERO; i < keys.length; i++) {
+    const key = keys[i];
+    const isFilterField = apiConstants.NOT_FILTER_FIELDS.indexOf(key) < ZERO;
+    if (isFilterField && params[key].value !== undefined) {
+      filter[key] = params[key].value;
+    }
+  }
+
+  opts.filter = filter;
+  return opts;
+}
+
+
+/**
+ * Apply limit and offset filter to resource array
+ * @param  {Object} opts - Filter options
+ * @param  {Array} arr - Array of resource keys or objects
+ * @returns {Array} - Sliced array
+ */
+function applyLimitAndOffset(opts, arr) {
+  let startIndex = 0;
+  let endIndex = arr.length;
+  if (opts.offset) {
+    startIndex = opts.offset;
+  }
+
+  if (opts.limit) {
+    endIndex = startIndex + opts.limit;
+  }
+
+  // apply limit and offset, default 0 to length
+  return arr.slice(startIndex, endIndex);
+}
+
+module.exports = {
+  applyLimitAndOffset,
+  checkWritePermission,
+  getOptionsFromReq,
+  sortByOrder,
+}

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -21,23 +21,23 @@ const ZERO = 0;
 
 /**
  * Apply field list filter.
- * @param  {Object} sample - Sample object
+ * @param  {Object} resource - The resource object
  * @param  {Array} attributes - Sample fields array
  */
-function applyFieldListFilter(sample, attributes) {
+function applyFieldListFilter(resource, attributes) {
   // apply field list filter
-  Object.keys(sample).forEach((sampField) => {
-    if (!attributes.includes(sampField)) {
-      delete sample[sampField];
+  Object.keys(resource).forEach((field) => {
+    if (!attributes.includes(field)) {
+      delete resource[field];
     }
   });
 }
 
 /**
- * Apply filters on sample array list
+ * Apply filters on resource array list
  * @param  {Array} resourceObjArray - Sample objects array
  * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample objects array
+ * @returns {Array} - Filtered resource objects array
  */
 function applyFiltersOnSampObjs(resourceObjArray, opts) {
   let filteredResources = resourceObjArray;
@@ -56,7 +56,7 @@ function applyFiltersOnSampObjs(resourceObjArray, opts) {
     });
   }
 
-  // sort and apply limits to samples
+  // sort and apply limits to resources
   if (opts.order) {
     const sortedSamples = sortByOrder(filteredResources, opts.order);
     filteredResources = sortedSamples;
@@ -157,39 +157,6 @@ function filterByFieldWildCardExpr(arr, prop, propExpr) {
 }
 
 /**
- * Checks if the user has the permission to perform the write operation on the
- * sample or not
- * @param  {String}  aspect - Aspect object
- * @param  {String}  sample - Sample object
- * @param  {String}  userName -  User performing the operation
- * @param  {Boolean} isBulk   - Flag to indicate if the action is a bulk
- * operation or not
- * @returns {Promise} - which resolves to true if the user has write permission
- */
-function checkWritePermission(aspect, sample, userName, isBulk) {
-  let isWritable = true;
-  if (aspect.writers && aspect.writers.length) {
-    isWritable = featureToggles
-                        .isFeatureEnabled('enforceWritePermission') ?
-                        aspect.writers.includes(userName) : true;
-  }
-
-  if (!isWritable) {
-    const err = new redisErrors.UpdateDeleteForbidden({
-      explanation: `The user: ${userName}, does not have write permission` +
-        ` on the sample: ${sample.name}`,
-    });
-    if (isBulk) {
-      return Promise.reject({ isFailed: true, explanation: err });
-    }
-
-    return Promise.reject(err);
-  }
-
-  return Promise.resolve(true);
-} // checkWritePermission
-
-/**
  * Sort by appending all fields value in a string and then comparing them.
  * If first fields starts with -, sort order is descending.
  * @param  {Array} arr - Resource objs array
@@ -275,7 +242,6 @@ module.exports = {
   applyFieldListFilter,
   applyFiltersOnSampKeys,
   applyLimitAndOffset,
-  checkWritePermission,
   getOptionsFromReq,
   sortByOrder,
 }

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -35,12 +35,12 @@ function applyFieldListFilter(sample, attributes) {
 
 /**
  * Apply filters on sample array list
- * @param  {Array} sampObjArray - Sample objects array
+ * @param  {Array} resourceObjArray - Sample objects array
  * @param  {Object} opts - Filter options
  * @returns {Array} - Filtered sample objects array
  */
-function applyFiltersOnSampObjs(sampObjArray, opts) {
-  let filteredSamples = sampObjArray;
+function applyFiltersOnSampObjs(resourceObjArray, opts) {
+  let filteredResources = resourceObjArray;
 
   // apply wildcard expr if other than name because
   // name filter was applied before redis call
@@ -49,23 +49,23 @@ function applyFiltersOnSampObjs(sampObjArray, opts) {
     Object.keys(filterOptions).forEach((field) => {
       if (field !== 'name') {
         const filteredKeys = filterByFieldWildCardExpr(
-          sampObjArray, field, filterOptions[field]
+          resourceObjArray, field, filterOptions[field]
         );
-        filteredSamples = filteredKeys;
+        filteredResources = filteredKeys;
       }
     });
   }
 
   // sort and apply limits to samples
   if (opts.order) {
-    const sortedSamples = sortByOrder(filteredSamples, opts.order);
-    filteredSamples = sortedSamples;
+    const sortedSamples = sortByOrder(filteredResources, opts.order);
+    filteredResources = sortedSamples;
 
-    const slicedSampObjs = applyLimitAndOffset(opts, filteredSamples);
-    filteredSamples = slicedSampObjs;
+    const slicedSampObjs = applyLimitAndOffset(opts, filteredResources);
+    filteredResources = slicedSampObjs;
   }
 
-  return filteredSamples;
+  return filteredResources;
 }
 
 /**
@@ -198,21 +198,30 @@ function checkWritePermission(aspect, sample, userName, isBulk) {
  */
 function sortByOrder(arr, propArr) {
   const isDescending = propArr[ZERO].startsWith('-');
+  console.log('is descending', isDescending, propArr)
+
   return arr.sort((a, b) => {
+    console.log('a is', a)
+    console.log('b is', b)
     let strA = '';
     let strB = '';
     propArr.forEach((field) => {
       strA += a[field];
       strB += b[field];
     });
+    console.log('A is', strA)
+    console.log('B is', strB)
 
     if (strA < strB) {
+      console.log('returning one?', isDescending ? ONE : MINUS_ONE)
       return isDescending ? ONE : MINUS_ONE;
     }
 
     if (strA > strB) {
+      console.log('returning - one?', isDescending ? MINUS_ONE : ONE)
       return isDescending ? MINUS_ONE : ONE;
     }
+      console.log('returning 0')
 
     return ZERO;
   });

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -58,9 +58,7 @@ function applyFiltersOnSampObjs(resourceObjArray, opts) {
 
   // sort and apply limits to samples
   if (opts.order) {
-    console.log(opts.order)
     const sortedSamples = sortByOrder(filteredResources, opts.order);
-    console.log('output', sortedSamples)
     filteredResources = sortedSamples;
 
     const slicedSampObjs = applyLimitAndOffset(opts, filteredResources);
@@ -92,17 +90,17 @@ function applyLimitAndOffset(opts, arr) {
 }
 
 /**
- * Apply filters on sample keys list
- * @param  {Array} sampKeysArr - Sample key names array
+ * Apply filters on resource keys list
+ * @param  {Array} keysArr - Resource key names array
  * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample keys array
+ * @returns {Array} - Filtered resource keys array
  */
-function applyFiltersOnSampKeys(sampKeysArr, opts) {
-  let resArr = sampKeysArr;
+function applyFiltersOnSampKeys(keysArr, opts) {
+  let resArr = keysArr;
 
   // apply limit and offset if no sort order defined
   if (!opts.order) {
-    resArr = applyLimitAndOffset(opts, sampKeysArr);
+    resArr = applyLimitAndOffset(opts, keysArr);
   }
 
   // apply wildcard expr on name, if specified
@@ -131,27 +129,27 @@ function cleanQueryBodyObj(qbObj, fieldsArr) {
 }
 
 /**
- * Apply wildcard filter on sample array of keys or objects. For each entry,
- * if given property exists for sample, apply regex to the property value,
+ * Apply wildcard filter on resource array of keys or objects. For each entry,
+ * if given property exists for resource, apply regex to the property value,
  * else if, the property is 'name', then the function was called before getting
- * obj, hence apply regex filter on sample name.
- * @param  {Array}  sampArr - Array of sample keys or sample objects
+ * obj, hence apply regex filter on resource name.
+ * @param  {Array}  arr - Array of resource keys or resource objects
  * @param  {String}  prop  - Property name
  * @param  {String} propExpr - Wildcard expression
  * @returns {Array} - Filtered array
  */
-function filterByFieldWildCardExpr(sampArr, prop, propExpr) {
+function filterByFieldWildCardExpr(arr, prop, propExpr) {
   // regex to match wildcard expr, i option means case insensitive
   const escapedExp = propExpr.split('_').join('\\_')
                       .split('|').join('\\|').split('.').join('\\.');
 
   const re = new RegExp('^' + escapedExp.split('*').join('.*') + '$', 'i');
-  return sampArr.filter((sampEntry) => {
-    if (sampEntry[prop]) { // sample object
-      return re.test(sampEntry[prop]);
-    } else if (prop === 'name') { // sample key
-      const sampName = sampleStore.getNameFromKey(sampEntry);
-      return re.test(sampName);
+  return arr.filter((entry) => {
+    if (entry[prop]) { // resource object
+      return re.test(entry[prop]);
+    } else if (prop === 'name') { // resource key
+      const name = sampleStore.getNameFromKey(entry);
+      return re.test(name);
     }
 
     return false;

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -110,6 +110,10 @@ const longTermToggles = {
  */
 const shortTermToggles = {
 
+  // Enable GET from cache for /v1/subjects, /v1/subjects/{key}
+  getSubjectFromCache: environmentVariableTrue(pe,
+    'GET_SUBJECT_FROM_CACHE'),
+
   // Enable caching for GET /v1/perspectives/{key}?
   enableCachePerspective: environmentVariableTrue(pe,
     'ENABLE_CACHE_PERSPECTIVE'),

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -23,6 +23,7 @@ describe('api::redisEnabled::GET specific subject', () => {
   const name = '___Subject1';
 
   before((done) => {
+    tu.toggleOverride('getSubjectFromCache', true);
     tu.toggleOverride('enableRedisSampleStore', true);
     tu.createToken()
     .then((returnedToken) => {
@@ -36,6 +37,7 @@ describe('api::redisEnabled::GET specific subject', () => {
   after(rtu.forceDelete);
   after(rtu.flushRedis);
   after(() => tu.toggleOverride('enableRedisSampleStore', false));
+  after(() => tu.toggleOverride('getSubjectFromCache', false));
 
   it('createdAt and updatedAt fields have the expected format', (done) => {
     api.get(`${path}/${name}`)
@@ -107,6 +109,7 @@ describe('api::redisEnabled::GET specific subject', () => {
 
       expect(res.body.name).to.be.equal(name);
       expect(res.body.absolutePath).to.equal(name);
+      expect(Object.keys(res.body)).to.contain('name', 'absolutePath', 'id', 'apiLinks');
       done();
     });
   });

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/get.js
+ */
+'use strict'; // eslint-disable-line strict
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const path = '/v1/subjects';
+const expect = require('chai').expect;
+
+describe(`api::redisEnabled::GET specific subject`, () => {
+  let token;
+  const name = '___Subject1';
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  before(rtu.populateRedis);
+  after(rtu.forceDelete);
+  after(rtu.flushRedis);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  it('createdAt and updatedAt fields have the expected format', (done) => {
+    const sampleName = s1s3a1;
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      const { updatedAt, createdAt } = res.body;
+      expect(updatedAt).to.equal(new Date(updatedAt).toISOString());
+      expect(createdAt).to.equal(new Date(createdAt).toISOString());
+      done();
+    });
+  });
+
+  it('on the attached aspect, time fields have the expected format', (done) => {
+    const sampleName = s1s3a1;
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      const { aspect } = res.body;
+      expect(aspect.updatedAt).to.equal(new Date(aspect.updatedAt).toISOString());
+      expect(aspect.createdAt).to.equal(new Date(aspect.createdAt).toISOString());
+      done();
+    });
+  });
+
+  it('basic get by name, OK', (done) => {
+    const sampleName = s1s3a1;
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(s1s3a1);
+      expect(res.body.status).to.be.equal('Invalid');
+      expect(res.body.value).to.be.equal('5');
+      expect(res.body.relatedLinks).to.be.eql([
+        { name: 'Salesforce', value: 'http://www.salesforce.com' },
+      ]);
+      expect(res.body.apiLinks).to.be.eql([
+        { href: '/v1/samples/___Subject1.___Subject3|___Aspect1',
+          method: 'DELETE',
+          rel: 'Delete this sample',
+        },
+        { href: '/v1/samples/___Subject1.___Subject3|___Aspect1',
+          method: 'GET',
+          rel: 'Retrieve this sample',
+        },
+        { href: '/v1/samples/___Subject1.___Subject3|___Aspect1',
+          method: 'PATCH',
+          rel: 'Update selected attributes of this sample',
+        },
+        { href: '/v1/samples',
+          method: 'POST',
+          rel: 'Create a new sample',
+        },
+        { href: '/v1/samples/___Subject1.___Subject3|___Aspect1',
+          method: 'PUT',
+          rel: 'Overwrite all attributes of this sample',
+        },
+      ]);
+      expect(res.body.aspect.name).to.be.equal('___Aspect1');
+      expect(res.body.aspect.relatedLinks).to.be.eql([
+        { name: 'Google', value: 'http://www.google.com' },
+        { name: 'Yahoo', value: 'http://www.yahoo.com' },
+      ]);
+      expect(res.body.aspect.criticalRange).to.be.eql([0, 1]);
+      done();
+    });
+  });
+
+  it('get by name is case in-sensitive', (done) => {
+    const sampleName = '___subject1.___SUBJECT3|___AspECT1';
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.equal(s1s3a1);
+      done();
+    });
+  });
+
+  it('get by name, wrong name', (done) => {
+    const sampleName = 'abc';
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.NOT_FOUND)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].description).to.be.equal('Incorrect sample name.');
+      return done();
+    });
+  });
+
+  it('get by name, sample not found', (done) => {
+    const sampleName = 'abc|xyz';
+    api.get(`${path}/${sampleName}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.NOT_FOUND)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.errors[0].description).to.be.equal('Sample/Aspect not found.');
+      return done();
+    });
+  });
+
+  it('get by name, with fields filter', (done) => {
+    const sampleName = s1s3a1;
+    api.get(`${path}/${sampleName}?fields=name,value`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(s1s3a1);
+      expect(res.body.status).to.be.undefined;
+      expect(res.body.value).to.be.equal('5');
+      expect(res.body.relatedLinks).to.be.undefined;
+      expect(res.body).to.have.property('apiLinks').that.is.an('array');
+      expect(res.body.aspect.name).to.be.equal('___Aspect1');
+      expect(res.body.aspect.relatedLinks).to.be.eql([
+        { name: 'Google', value: 'http://www.google.com' },
+        { name: 'Yahoo', value: 'http://www.yahoo.com' },
+      ]);
+      expect(res.body.aspect.criticalRange).to.be.eql([0, 1]);
+      done();
+    });
+  });
+
+  it('get by name with incorrect fields filter gives error', (done) => {
+    const sampleName = s1s3a1;
+    api.get(`${path}/${sampleName}?fields=name,y`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      return done();
+    });
+  });
+});

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -26,6 +26,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
   const subject3 = '___Subject1.___Subject3';
 
   before((done) => {
+    tu.toggleOverride('getSubjectFromCache', true);
     tu.toggleOverride('enableRedisSampleStore', true);
     tu.createToken()
     .then((returnedToken) => {
@@ -39,6 +40,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
   after(rtu.forceDelete);
   after(rtu.flushRedis);
   after(() => tu.toggleOverride('enableRedisSampleStore', false));
+  after(() => tu.toggleOverride('getSubjectFromCache', false));
 
   it('updatedAt and createdAt fields have the expected format', (done) => {
     api.get(path)

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -59,7 +59,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('basic get all, sorted lexicographically by default', (done) => {
+  it('sorted lexicographically by default', (done) => {
     api.get(path)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -76,7 +76,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with sort option, default asc', (done) => {
+  it('sort option asc', (done) => {
     api.get(`${path}?sort=absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -93,7 +93,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with sort option, default desc', (done) => {
+  it('sort option desc', (done) => {
     api.get(`${path}?sort=-absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -110,7 +110,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all with fields filter returns in the asc order', (done) => {
+  it('fields filter returns in the asc order', (done) => {
     api.get(`${path}?fields=name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -129,7 +129,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all with fields filter returns expected number of keys', (done) => {
+  it('fields filter returns expected number of keys', (done) => {
     api.get(`${path}?fields=name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -145,7 +145,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all with fields filter returns apiLinks', (done) => {
+  it('fields filter returns apiLinks', (done) => {
     api.get(`${path}?fields=name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -162,7 +162,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with limit filter', (done) => {
+  it('limit filter', (done) => {
     api.get(`${path}?limit=1`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -177,7 +177,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with offset filter', (done) => {
+  it('offset filter', (done) => {
     api.get(`${path}?offset=1`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -193,7 +193,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with name filter', (done) => {
+  it('name filter', (done) => {
     api.get(`${path}?name=___Subject1`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -209,7 +209,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with combined filters', (done) => {
+  it('combined filters', (done) => {
     const filterstr = 'limit=2&offset=1&name=___*&' +
     'sort=-name&fields=name,absolutePath';
     api.get(`${path}?${filterstr}`)

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/getAll.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const path = '/v1/subjects';
+const expect = require('chai').expect;
+
+describe(`api::redisEnabled::GET ${path}`, () => {
+  let token;
+  const name = '___Subject1';
+
+  before((done) => {
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  before(rtu.populateRedis);
+  after(rtu.forceDelete);
+  after(rtu.flushRedis);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+
+  it.only('updatedAt and createdAt fields have the expected format', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    // .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      console.log(res.error)
+      if (err) {
+        done(err);
+      }
+
+      for (let i = res.body.length - 1; i >= 0; i--) {
+        const { updatedAt, createdAt } = res.body[i];
+        expect(createdAt).to.equal(new Date(createdAt).toISOString());
+        expect(updatedAt).to.equal(new Date(updatedAt).toISOString());
+      }
+      done();
+    });
+  });
+
+  // need create more subjects
+  it.skip('basic get all, sorted lexicographically by default', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      done();
+    });
+  });
+
+  it.skip('get all, with sort option, default asc', (done) => {
+    api.get(`${path}?sort=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      done();
+    });
+  });
+
+  it.skip('get all, with sort option, default desc', (done) => {
+    api.get(`${path}?sort=-name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+    });
+  });
+
+  it.skip('get all with fields filter', (done) => {
+    api.get(`${path}?fields=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      done();
+    });
+  });
+
+  it.skip('get all, with limit filter', (done) => {
+    api.get(`${path}?limit=1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(1);
+      done();
+    });
+  });
+
+  it.skip('get all, with offset filter', (done) => {
+    api.get(`${path}?offset=1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(2);
+      done();
+    });
+  });
+
+  it.skip('get all, with name filter', (done) => {
+    api.get(`${path}?name=___Subject1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(1);
+      done();
+    });
+  });
+
+  it.skip('get all, with combined filters', (done) => {
+    const filterstr = 'limit=5&offset=1&name=___Subject1.___Subject2*&' +
+    'sort=-value,status&fields=name,status,value';
+    api.get(`${path}?${filterstr}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(1);
+      expect(res.body[0].name).to.be.equal(s1s2a1);
+      expect(res.body[0].status).to.be.equal('Critical');
+      expect(res.body[0].aspect.name).to.be.equal('___Aspect1');
+      expect(res.body[0].relatedLinks).to.be.undefined;
+      expect(res.body[0].value).to.be.equal('0');
+      done();
+    });
+  });
+
+  it.skip('trailing asterisk is treated as "starts with"', (done) => {
+    api.get(path + '?name=' + tu.namePrefix + '*')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      expect(res.body.length).to.equal(3);
+      res.body.map((sample) => {
+        expect(sample.name.slice(0, 3)).to.equal(tu.namePrefix);
+      });
+    })
+    .end((err /* , res */) => done(err));
+  });
+
+  it.skip('leading asterisk is treated as "ends with"', (done) => {
+    api.get(path + '?name=*___Aspect1')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      expect(res.body.length).to.equal(2);
+      res.body.map((sample) => {
+        expect(sample.name.slice(-10)).to.equal('___Aspect1');
+      });
+    })
+    .end((err /* , res */) => done(err));
+  });
+
+  it.skip('leading and trailing asterisks are treated as "contains"', (done) => {
+    api.get(path + '?name=*Subject2*')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .expect((res) => {
+      res.body.map((sample) => {
+        expect(sample.name).to.contain('Subject2');
+      });
+    })
+    .end((err /* , res */) => done(err));
+  });
+});

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -19,7 +19,7 @@ const rtu = require('../redisTestUtil');
 const path = '/v1/subjects';
 const expect = require('chai').expect;
 
-describe.only(`api::redisEnabled::GET ${path}`, () => {
+describe(`api::redisEnabled::GET ${path}`, () => {
   let token;
   const subject1 = '___Subject1';
   const subject2 = '___Subject1.___Subject2';
@@ -77,7 +77,7 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
   });
 
   it('get all, with sort option, default asc', (done) => {
-    api.get(`${path}?sort=name`)
+    api.get(`${path}?sort=absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
@@ -94,7 +94,7 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
   });
 
   it.skip('get all, with sort option, default desc', (done) => {
-    api.get(`${path}?sort=-name`)
+    api.get(`${path}?sort=-absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -40,7 +40,7 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
   after(rtu.flushRedis);
   after(() => tu.toggleOverride('enableRedisSampleStore', false));
 
-  it.only('updatedAt and createdAt fields have the expected format', (done) => {
+  it('updatedAt and createdAt fields have the expected format', (done) => {
     api.get(path)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -59,7 +59,6 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  // need create more subjects
   it('basic get all, sorted lexicographically by default', (done) => {
     api.get(path)
     .set('Authorization', token)
@@ -70,14 +69,14 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
-      expect(res.body[0].name).to.be.equal(subject1);
-      expect(res.body[1].name).to.be.equal(subject2);
-      expect(res.body[2].name).to.be.equal(subject3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
       done();
     });
   });
 
-  it.skip('get all, with sort option, default asc', (done) => {
+  it('get all, with sort option, default asc', (done) => {
     api.get(`${path}?sort=name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -87,11 +86,14 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
       done();
     });
   });
 
-  it.skip('get all, with sort option, default desc', (done) => {
+  it('get all, with sort option, default desc', (done) => {
     api.get(`${path}?sort=-name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -101,6 +103,9 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject3);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject1);
     });
   });
 

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -19,9 +19,11 @@ const rtu = require('../redisTestUtil');
 const path = '/v1/subjects';
 const expect = require('chai').expect;
 
-describe(`api::redisEnabled::GET ${path}`, () => {
+describe.only(`api::redisEnabled::GET ${path}`, () => {
   let token;
-  const name = '___Subject1';
+  const subject1 = '___Subject1';
+  const subject2 = '___Subject1.___Subject2';
+  const subject3 = '___Subject1.___Subject3';
 
   before((done) => {
     tu.toggleOverride('enableRedisSampleStore', true);
@@ -41,13 +43,13 @@ describe(`api::redisEnabled::GET ${path}`, () => {
   it.only('updatedAt and createdAt fields have the expected format', (done) => {
     api.get(path)
     .set('Authorization', token)
-    // .expect(constants.httpStatus.OK)
+    .expect(constants.httpStatus.OK)
     .end((err, res) => {
-      console.log(res.error)
       if (err) {
         done(err);
       }
 
+      expect(res.body.length).to.be.equal(3);
       for (let i = res.body.length - 1; i >= 0; i--) {
         const { updatedAt, createdAt } = res.body[i];
         expect(createdAt).to.equal(new Date(createdAt).toISOString());
@@ -58,7 +60,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
   });
 
   // need create more subjects
-  it.skip('basic get all, sorted lexicographically by default', (done) => {
+  it('basic get all, sorted lexicographically by default', (done) => {
     api.get(path)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -68,6 +70,9 @@ describe(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].name).to.be.equal(subject1);
+      expect(res.body[1].name).to.be.equal(subject2);
+      expect(res.body[2].name).to.be.equal(subject3);
       done();
     });
   });

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -93,7 +93,7 @@ describe.only(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('get all, with sort option, default desc', (done) => {
+  it.skip('get all, with sort option, default desc', (done) => {
     api.get(`${path}?sort=-name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/utils.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const expect = require('chai').expect;
+const utils = require('../../../cache/models/utils');
+
+describe('cache utils test', () => {
+  it('asc');
+  it('desc');
+  // const result = utils.sortByOrder(arr, propArr);
+  // expect()
+});

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -15,9 +15,58 @@ const supertest = require('supertest');
 const expect = require('chai').expect;
 const utils = require('../../../cache/models/utils');
 
-describe('cache utils test', () => {
-  it('asc');
-  it('desc');
-  // const result = utils.sortByOrder(arr, propArr);
-  // expect()
+describe.only('cache utils test', () => {
+  const ascArr = [
+    { name: '___Subject1', absolutePath: '___Subject1' },
+    { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+    { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+  ];
+
+  // deep copy before reverse. Otherwise will also reverse original array
+  const descArr = JSON.parse(JSON.stringify(ascArr)).reverse();
+  console.log(ascArr[0], descArr[0])
+
+  describe('given asc input', () => {
+    it('asc name', () => {
+      const result = utils.sortByOrder(ascArr, ['name']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc name', () => {
+      const result = utils.sortByOrder(ascArr, ['-name']);
+      expect(result).to.deep.equal(descArr);
+    });
+
+    it('asc absolutePath', () => {
+      const result = utils.sortByOrder(ascArr, ['absolutePath']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc absolutePath', () => {
+      const result = utils.sortByOrder(ascArr, ['-absolutePath']);
+      expect(result).to.deep.equal(descArr);
+    });
+  });
+
+  describe('given desc input', () => {
+    it('asc name', () => {
+      const result = utils.sortByOrder(descArr, ['name']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc name', () => {
+      const result = utils.sortByOrder(descArr, ['-name']);
+      expect(result).to.deep.equal(descArr);
+    });
+
+    it('asc absolutePath', () => {
+      const result = utils.sortByOrder(descArr, ['absolutePath']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc absolutePath', () => {
+      const result = utils.sortByOrder(descArr, ['-absolutePath']);
+      expect(result).to.deep.equal(descArr);
+    });
+  });
 });

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -16,17 +16,18 @@ const expect = require('chai').expect;
 const utils = require('../../../cache/models/utils');
 
 describe.only('cache utils test', () => {
-  const ascArr = [
-    { name: '___Subject1', absolutePath: '___Subject1' },
-    { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
-    { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
-  ];
-
-  // deep copy before reverse. Otherwise will also reverse original array
-  const descArr = JSON.parse(JSON.stringify(ascArr)).reverse();
-  console.log(ascArr[0], descArr[0])
-
   describe('given asc input', () => {
+    let ascArr;
+
+    // sort is in-place. Hence need reset array for test independence.
+    beforeEach(() => {
+      ascArr = [
+        { name: '___Subject1', absolutePath: '___Subject1' },
+        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+        { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+      ];
+    });
+
     it('asc name', () => {
       const result = utils.sortByOrder(ascArr, ['name']);
       expect(result).to.deep.equal(ascArr);
@@ -34,7 +35,7 @@ describe.only('cache utils test', () => {
 
     it('desc name', () => {
       const result = utils.sortByOrder(ascArr, ['-name']);
-      expect(result).to.deep.equal(descArr);
+      expect(result).to.deep.equal(ascArr.reverse());
     });
 
     it('asc absolutePath', () => {
@@ -44,14 +45,25 @@ describe.only('cache utils test', () => {
 
     it('desc absolutePath', () => {
       const result = utils.sortByOrder(ascArr, ['-absolutePath']);
-      expect(result).to.deep.equal(descArr);
+      expect(result).to.deep.equal(ascArr.reverse());
     });
   });
 
   describe('given desc input', () => {
+    let descArr;
+
+    // sort is in-place. Hence need reset array for test independence.
+    beforeEach(() => {
+      descArr = [
+        { name: '___Subject1', absolutePath: '___Subject1' },
+        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+        { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+      ];
+    });
+
     it('asc name', () => {
       const result = utils.sortByOrder(descArr, ['name']);
-      expect(result).to.deep.equal(ascArr);
+      expect(result).to.deep.equal(descArr.reverse());
     });
 
     it('desc name', () => {
@@ -61,7 +73,7 @@ describe.only('cache utils test', () => {
 
     it('asc absolutePath', () => {
       const result = utils.sortByOrder(descArr, ['absolutePath']);
-      expect(result).to.deep.equal(ascArr);
+      expect(result).to.deep.equal(descArr.reverse());
     });
 
     it('desc absolutePath', () => {

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -15,7 +15,7 @@ const supertest = require('supertest');
 const expect = require('chai').expect;
 const utils = require('../../../cache/models/utils');
 
-describe.only('cache utils test', () => {
+describe('cache utils test', () => {
   describe('given asc input', () => {
     let ascArr;
 


### PR DESCRIPTION
- extracted filter, limit, and offset functions from /cache/models/samples.js
- tested locally. GETs published subjects due to the limitation on populateSubjects in sampleStoreInit
- add tests to /cache/models/subjects
- does NOT include the change to perspectives to GET from subjects cache