### PR TITLE
Get subject from cache

### DIFF
--- a/api/v1/controllers/subjects.js
+++ b/api/v1/controllers/subjects.js
@@ -241,7 +241,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   getSubject(req, res, next) {
-   if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName) &&
+    if (featureToggles.isFeatureEnabled(sampleStoreConstants.featureName) &&
     featureToggles.isFeatureEnabled('getSubjectFromCache')) {
       const resultObj = { reqStartTime: new Date() }; // for logging
       redisSubjectModel.getSubject(req, res, resultObj)

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -13,6 +13,7 @@
 
 const helper = require('../../api/v1/helpers/nouns/samples');
 const u = require('../../api/v1/helpers/verbs/utils');
+const modelUtils = require('./utils');
 const sampleStore = require('../sampleStore');
 const redisClient = require('../redisCache').client.sampleStore;
 const constants = sampleStore.constants;
@@ -90,81 +91,6 @@ function checkWritePermission(aspect, sample, userName, isBulk) {
 } // checkWritePermission
 
 /**
- * Sort by appending all fields value in a string and then comparing them.
- * If first fields starts with -, sort order is descending.
- * @param  {Array} sampArr - Sample objs array
- * @param  {Array} propArr - Fields array
- * @returns {Array} - Sorted array
- */
-function sortByOrder(sampArr, propArr) {
-  const isDescending = propArr[ZERO].startsWith('-');
-  return sampArr.sort((a, b) => {
-    let strA = '';
-    let strB = '';
-    propArr.forEach((field) => {
-      strA += a[field];
-      strB += b[field];
-    });
-
-    if (strA < strB) {
-      return isDescending ? ONE : MINUS_ONE;
-    }
-
-    if (strA > strB) {
-      return isDescending ? MINUS_ONE : ONE;
-    }
-
-    return ZERO;
-  });
-}
-
-/**
- * Get option fields from requesr parameters. An example:
- * { attributes: [ 'name', 'status', 'value', 'id' ],
-    order: [ '-value', 'status' ],
-    limit: 5,
-    offset: 1,
-    filter: { name: '___Subject1.___Subject2*' } }
- * @param  {Object} params - Request query parameters
- * @returns {Object} - Filter object
- */
-function getOptionsFromReq(params) {
-  // eg. ?fields=x,y,z. Adds as opts.attributes = [array of fields]
-  // id is always included
-  const opts = u.buildFieldList(params);
-
-  // Specify the sort order. If defaultOrder is defined in props or sort value
-  // then update sort order otherwise take value from model defination
-  if ((params.sort && params.sort.value) || helper.defaultOrder) {
-    opts.order = params.sort.value || helper.defaultOrder;
-  }
-
-  // handle limit
-  if (params.limit && params.limit.value) {
-    opts.limit = parseInt(params.limit.value, defaults.limit);
-  }
-
-  // handle offset
-  if (params.offset && params.offset.value) {
-    opts.offset = parseInt(params.offset.value, defaults.offset);
-  }
-
-  const filter = {};
-  const keys = Object.keys(params);
-
-  for (let i = ZERO; i < keys.length; i++) {
-    const key = keys[i];
-    const isFilterField = apiConstants.NOT_FILTER_FIELDS.indexOf(key) < ZERO;
-    if (isFilterField && params[key].value !== undefined) {
-      filter[key] = params[key].value;
-    }
-  }
-
-  opts.filter = filter;
-  return opts;
-}
-
-/**
  * Convert array strings to Json for sample and aspect, then attach aspect to
  * sample. Then add add api links and return complete sample object.
  * @param  {Object} sampleObj - Sample object from redis
@@ -184,141 +110,6 @@ function cleanAddAspectToSample(sampleObj, aspectObj) {
 }
 
 /**
- * Apply limit and offset filter to sample array
- * @param  {Object} opts - Filter options
- * @param  {Array} sampArr - Array of sample keys or objects
- * @returns {Array} - Sliced array
- */
-function applyLimitAndOffset(opts, sampArr) {
-  let startIndex = 0;
-  let endIndex = sampArr.length;
-  if (opts.offset) {
-    startIndex = opts.offset;
-  }
-
-  if (opts.limit) {
-    endIndex = startIndex + opts.limit;
-  }
-
-  // apply limit and offset, default 0 to length
-  return sampArr.slice(startIndex, endIndex);
-}
-
-/**
- * Apply wildcard filter on sample array of keys or objects. For each entry,
- * if given property exists for sample, apply regex to the property value,
- * else if, the property is 'name', then the function was called before getting
- * obj, hence apply regex filter on sample name.
- * @param  {Array}  sampArr - Array of sample keys or sample objects
- * @param  {String}  prop  - Property name
- * @param  {String} propExpr - Wildcard expression
- * @returns {Array} - Filtered array
- */
-function filterByFieldWildCardExpr(sampArr, prop, propExpr) {
-  // regex to match wildcard expr, i option means case insensitive
-  const escapedExp = propExpr.split('_').join('\\_')
-                      .split('|').join('\\|').split('.').join('\\.');
-
-  const re = new RegExp('^' + escapedExp.split('*').join('.*') + '$', 'i');
-  return sampArr.filter((sampEntry) => {
-    if (sampEntry[prop]) { // sample object
-      return re.test(sampEntry[prop]);
-    } else if (prop === sampFields.NAME) { // sample key
-      const sampName = sampleStore.getNameFromKey(sampEntry);
-      return re.test(sampName);
-    }
-
-    return false;
-  });
-}
-
-/**
- * Apply filters on sample keys list
- * @param  {Array} sampKeysArr - Sample key names array
- * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample keys array
- */
-function applyFiltersOnSampKeys(sampKeysArr, opts) {
-  let resArr = sampKeysArr;
-
-  // apply limit and offset if no sort order defined
-  if (!opts.order) {
-    resArr = applyLimitAndOffset(opts, sampKeysArr);
-  }
-
-  // apply wildcard expr on name, if specified
-  if (opts.filter && opts.filter.name) {
-    const filteredKeys = filterByFieldWildCardExpr(
-      resArr, sampFields.NAME, opts.filter.name
-    );
-    resArr = filteredKeys;
-  }
-
-  return resArr;
-}
-
-/**
- * Apply field list filter.
- * @param  {Object} sample - Sample object
- * @param  {Array} attributes - Sample fields array
- */
-function applyFieldListFilter(sample, attributes) {
-  // apply field list filter
-  Object.keys(sample).forEach((sampField) => {
-    if (!attributes.includes(sampField)) {
-      delete sample[sampField];
-    }
-  });
-}
-
-/**
- * Apply filters on sample array list
- * @param  {Array} sampObjArray - Sample objects array
- * @param  {Object} opts - Filter options
- * @returns {Array} - Filtered sample objects array
- */
-function applyFiltersOnSampObjs(sampObjArray, opts) {
-  let filteredSamples = sampObjArray;
-
-  // apply wildcard expr if other than name because
-  // name filter was applied before redis call
-  if (opts.filter) {
-    const filterOptions = opts.filter;
-    Object.keys(filterOptions).forEach((field) => {
-      if (field !== sampFields.NAME) {
-        const filteredKeys = filterByFieldWildCardExpr(
-          sampObjArray, field, filterOptions[field]
-        );
-        filteredSamples = filteredKeys;
-      }
-    });
-  }
-
-  // sort and apply limits to samples
-  if (opts.order) {
-    const sortedSamples = sortByOrder(filteredSamples, opts.order);
-    filteredSamples = sortedSamples;
-
-    const slicedSampObjs = applyLimitAndOffset(opts, filteredSamples);
-    filteredSamples = slicedSampObjs;
-  }
-
-  return filteredSamples;
-}
-
-/**
- * Remove extra fields from query body object.
- * @param  {Object} qbObj - Query body object
- */
-function cleanQueryBodyObj(qbObj) {
-  Object.keys(qbObj).forEach((qbField) => {
-    if (!sampleFieldsArr.includes(qbField)) {
-      delete qbObj[qbField];
-    }
-  });
-}
-
-/**
  * Create properties array having and fields and values need to be set to
  * update/create sample. Value is empty string if new object being created.
  * If some value, then calculate status. Update status, previous status and
@@ -329,7 +120,7 @@ function cleanQueryBodyObj(qbObj) {
  * @param  {Object} aspectObj - Aspect object
  */
 function createSampHsetCommand(qbObj, sampObj, aspectObj) {
-  cleanQueryBodyObj(qbObj); // remove extra fields
+  modelUtils.cleanQueryBodyObj(qbObj, sampleFieldsArr); // remove extra fields
   let value;
   if (qbObj[sampFields.VALUE]) {
     value = qbObj[sampFields.VALUE];
@@ -705,7 +496,7 @@ module.exports = {
         });
       }
 
-      cleanQueryBodyObj(reqBody);
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr);
       aspectObj = sampleStore.arrayStringsToJson(
         aspObj, constants.fieldsToStringify.aspect
       );
@@ -797,7 +588,7 @@ module.exports = {
         });
       }
 
-      cleanQueryBodyObj(reqBody); // remove extra fields
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr); // remove extra fields
       reqBody.name = sampleName; // set name
 
       let value = '';
@@ -894,7 +685,7 @@ module.exports = {
       return checkWritePermission(aspectObj, currSampObj, userName);
     })
     .then(() => {
-      cleanQueryBodyObj(reqBody);
+      modelUtils.cleanQueryBodyObj(reqBody, sampleFieldsArr);
       let value = '';
       if (reqBody.value) {
         value = reqBody.value;
@@ -982,11 +773,11 @@ module.exports = {
         });
       }
 
-      const opts = getOptionsFromReq(params);
+      const opts = modelUtils.getOptionsFromReq(params, helper);
 
       // apply fields list filter
       if (opts.attributes) {
-        applyFieldListFilter(sample, opts.attributes);
+        modelUtils.applyFieldListFilter(sample, opts.attributes);
       }
 
       // clean and attach aspect to sample, add api links as well
@@ -1010,7 +801,7 @@ module.exports = {
    * @returns {Promise} - Resolves to a list of all samples objects
    */
   findSamples(req, res, logObject) {
-    const opts = getOptionsFromReq(req.swagger.params);
+    const opts = modelUtils.getOptionsFromReq(req.swagger.params, helper);
     const response = [];
 
     if (opts.limit || opts.offset) {
@@ -1024,7 +815,8 @@ module.exports = {
     return redisClient.sortAsync(constants.indexKey.sample, 'alpha')
     .then((allSampKeys) => {
       const commands = [];
-      const filteredSampKeys = applyFiltersOnSampKeys(allSampKeys, opts);
+      const filteredSampKeys = modelUtils
+        .applyFiltersOnSampKeys(allSampKeys, opts);
 
       // add to commands
       filteredSampKeys.forEach((sampKey) => {
@@ -1049,12 +841,12 @@ module.exports = {
         sampAspectMap[redisResponses[num].name] = redisResponses[num + ONE];
       }
 
-      const filteredSamples = applyFiltersOnSampObjs(samples, opts);
+      const filteredSamples = modelUtils.applyFiltersOnSampObjs(samples, opts);
       filteredSamples.forEach((sample) => {
 
         const sampName = sample.name;
         if (opts.attributes) { // delete sample fields, hence no return obj
-          applyFieldListFilter(sample, opts.attributes);
+          modelUtils.applyFieldListFilter(sample, opts.attributes);
         }
 
         // attach aspect to sample

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -816,7 +816,7 @@ module.exports = {
     .then((allSampKeys) => {
       const commands = [];
       const filteredSampKeys = modelUtils
-        .applyFiltersOnSampKeys(allSampKeys, opts);
+        .applyFiltersOnResourceKeys(allSampKeys, opts);
 
       // add to commands
       filteredSampKeys.forEach((sampKey) => {
@@ -841,7 +841,7 @@ module.exports = {
         sampAspectMap[redisResponses[num].name] = redisResponses[num + ONE];
       }
 
-      const filteredSamples = modelUtils.applyFiltersOnSampObjs(samples, opts);
+      const filteredSamples = modelUtils.applyFiltersOnResourceObjs(samples, opts);
       filteredSamples.forEach((sample) => {
 
         const sampName = sample.name;

--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -199,6 +199,25 @@ function completeSubjectHierarchy(res, params) {
   });
 } // completeSubjectHierarchy
 
+/**
+ * Turns fields numeric fields turned into ints.
+ *
+ * Also adds a parentAbsolutePath field, if it was not there previously.
+ * @param {Object} subject
+ * @returns {Object} Object with parentAbsolutePath field and numeric fields.
+ */
+function convertStringsToNumbersAndAddParentAbsolutePath(subject) {
+  // add parentAbsolutePath
+  if (subject.parentAbsolutePath === undefined) {
+    subject.parentAbsolutePath = '';
+  }
+
+  // convert the strings into numbers
+  subject.childCount = parseInt(subject.childCount, 10) || 0;
+  subject.hierarchyLevel = parseInt(subject.hierarchyLevel, 10);
+  return subject;
+}
+
 module.exports = {
   completeSubjectHierarchy,
 
@@ -220,14 +239,7 @@ module.exports = {
         });
       }
 
-      // add parentAbsolutePath
-      if (subject.parentAbsolutePath === undefined) {
-        subject.parentAbsolutePath = '';
-      }
-
-      // convert the strings into numbers
-      subject.childCount = parseInt(subject.childCount, 10) || 0;
-      subject.hierarchyLevel = parseInt(subject.hierarchyLevel, 10);
+      subject = convertStringsToNumbersAndAddParentAbsolutePath(subject);
 
       logObject.dbTime = new Date() - logObject.reqStartTime; // log db time
 
@@ -292,6 +304,7 @@ module.exports = {
       logObject.dbTime = new Date() - logObject.reqStartTime; // log db time
       const filteredSubjects = modelUtils.applyFiltersOnResourceObjs(subjects, opts);
       filteredSubjects.forEach((subject) => {
+        subject = convertStringsToNumbersAndAddParentAbsolutePath(subject);
 
         // convert the time fields to appropriate format
         subject.createdAt = new Date(subject.createdAt).toISOString();

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * cache/models/utils.js
+ */
+const apiConstants = require('../../api/v1/constants');
+const defaults = require('../../config').api.defaults;
+const sampleStore = require('../sampleStore');
+const u = require('../../api/v1/helpers/verbs/utils');
+const featureToggles = require('feature-toggles');
+const redisErrors = require('../redisErrors');
+const MINUS_ONE = -1;
+const ONE = 1;
+const ZERO = 0;
+
+/**
+ * Apply field list filter.
+ * @param  {Object} resource - The resource object
+ * @param  {Array} attributes - Resource fields array
+ */
+function applyFieldListFilter(resource, attributes) {
+  // apply field list filter
+  Object.keys(resource).forEach((field) => {
+    if (!attributes.includes(field)) {
+      delete resource[field];
+    }
+  });
+}
+
+/**
+ * Apply filters on resource array list
+ * @param  {Array} resourceObjArray - Resource objects array
+ * @param  {Object} opts - Filter options
+ * @returns {Array} - Filtered resource objects array
+ */
+function applyFiltersOnResourceObjs(resourceObjArray, opts) {
+  let filteredResources = resourceObjArray;
+
+  // apply wildcard expr if other than name because
+  // name filter was applied before redis call
+  if (opts.filter) {
+    const filterOptions = opts.filter;
+    Object.keys(filterOptions).forEach((field) => {
+      if (field !== 'name') {
+        const filteredKeys = filterByFieldWildCardExpr(
+          resourceObjArray, field, filterOptions[field]
+        );
+        filteredResources = filteredKeys;
+      }
+    });
+  }
+
+  // sort and apply limits to resources
+  if (opts.order) {
+    const sortedResources = sortByOrder(filteredResources, opts.order);
+    filteredResources = sortedResources;
+
+    const slicedResourceObjs = applyLimitAndOffset(opts, filteredResources);
+    filteredResources = slicedResourceObjs;
+  }
+
+  return filteredResources;
+}
+
+/**
+ * Apply limit and offset filter to resource array
+ * @param  {Object} opts - Filter options
+ * @param  {Array} arr - Array of resource keys or objects
+ * @returns {Array} - Sliced array
+ */
+function applyLimitAndOffset(opts, arr) {
+  let startIndex = 0;
+  let endIndex = arr.length;
+  if (opts.offset) {
+    startIndex = opts.offset;
+  }
+
+  if (opts.limit) {
+    endIndex = startIndex + opts.limit;
+  }
+
+  // apply limit and offset, default 0 to length
+  return arr.slice(startIndex, endIndex);
+}
+
+/**
+ * Apply filters on resource keys list
+ * @param  {Array} keysArr - Resource key names array
+ * @param  {Object} opts - Filter options
+ * @param  {Function} getNameFunc - For filter on name, any processing
+ *  on keys to get the resource name.
+ * @returns {Array} - Filtered resource keys array
+ */
+function applyFiltersOnResourceKeys(keysArr, opts, getNameFunc) {
+  let resArr = keysArr;
+
+  // apply limit and offset if no sort order defined
+  if (!opts.order) {
+    resArr = applyLimitAndOffset(opts, keysArr);
+  }
+
+  // apply wildcard expr on name, if specified
+  if (opts.filter && opts.filter.name) {
+    const filteredKeys = filterByFieldWildCardExpr(
+      resArr, 'name', opts.filter.name, getNameFunc
+    );
+    resArr = filteredKeys;
+  }
+
+  return resArr;
+}
+
+/**
+ * Remove extra fields from query body object.
+ * @param  {Object} qbObj - Query body object
+ * @param  {Array} fieldsArr - Array of field names
+ */
+function cleanQueryBodyObj(qbObj, fieldsArr) {
+  Object.keys(qbObj).forEach((qbField) => {
+    if (!fieldsArr.includes(qbField)) {
+      delete qbObj[qbField];
+    }
+  });
+}
+
+/**
+ * Apply wildcard filter on resource array of keys or objects. For each entry,
+ * if given property exists for resource, apply regex to the property value,
+ * else if, the property is 'name', then the function was called before getting
+ * obj, hence apply regex filter on resource name.
+ * @param  {Array}  arr - Array of resource keys or resource objects
+ * @param  {String}  prop  - Property name
+ * @param  {String} propExpr - Wildcard expression
+ * @param  {Function} getNameFunc - For filter on name, any processing
+ *  on keys to get the resource name.
+ * @returns {Array} - Filtered array
+ */
+function filterByFieldWildCardExpr(arr, prop, propExpr, getNameFunc) {
+
+  // regex to match wildcard expr, i option means case insensitive
+  const escapedExp = propExpr.split('_').join('\\_')
+                      .split('|').join('\\|').split('.').join('\\.');
+
+  const re = new RegExp('^' + escapedExp.split('*').join('.*') + '$', 'i');
+  return arr.filter((entry) => {
+    if (entry[prop]) { // resource object
+      return re.test(entry[prop]);
+    } else if (prop === 'name') { // resource key
+      const _name = sampleStore.getNameFromKey(entry);
+
+      // keys may need processing to become names
+      const name = getNameFunc ? getNameFunc(_name) : name;
+      return re.test(name);
+    }
+
+    return false;
+  });
+}
+
+/**
+ * Sort by appending all fields value in a string and then comparing them.
+ * If first fields starts with -, sort order is descending.
+ * @param  {Array} arr - Resource objs array
+ * @param  {Array} propArr - Fields array
+ * @returns {Array} - Sorted array
+ */
+function sortByOrder(arr, propArr) {
+  const isDescending = propArr[ZERO].startsWith('-');
+  return arr.sort((a, b) => {
+    let strA = '';
+    let strB = '';
+    propArr.forEach((field) => {
+
+      // remove leading minus sign
+      const _field = isDescending ? field.substr(1) : field;
+      strA += a[_field];
+      strB += b[_field];
+    });
+
+    if (strA < strB) {
+      return isDescending ? ONE : MINUS_ONE;
+    }
+
+    if (strA > strB) {
+      return isDescending ? MINUS_ONE : ONE;
+    }
+
+    return ZERO;
+  });
+}
+
+/**
+ * Get option fields from requesr parameters. An example:
+ * { attributes: [ 'name', 'status', 'value', 'id' ],
+    order: [ '-value', 'status' ],
+    limit: 5,
+    offset: 1,
+    filter: { name: '___Subject1.___Subject2*' } }
+ * @param  {Object} params - Request query parameters
+ * @param  {Object} helper - The resource's properties.
+ * @returns {Object} - Filter object
+ */
+function getOptionsFromReq(params, helper) {
+  // eg. ?fields=x,y,z. Adds as opts.attributes = [array of fields]
+  // id is always included
+  const opts = u.buildFieldList(params);
+
+  // Specify the sort order. If defaultOrder is defined in props or sort value
+  // then update sort order otherwise take value from model defination
+  if ((params.sort && params.sort.value) || helper.defaultOrder) {
+    opts.order = params.sort.value || helper.defaultOrder;
+  }
+
+  // handle limit
+  if (params.limit && params.limit.value) {
+    opts.limit = parseInt(params.limit.value, defaults.limit);
+  }
+
+  // handle offset
+  if (params.offset && params.offset.value) {
+    opts.offset = parseInt(params.offset.value, defaults.offset);
+  }
+
+  const filter = {};
+  const keys = Object.keys(params);
+
+  for (let i = ZERO; i < keys.length; i++) {
+    const key = keys[i];
+    const isFilterField = apiConstants.NOT_FILTER_FIELDS.indexOf(key) < ZERO;
+    if (isFilterField && params[key].value !== undefined) {
+      filter[key] = params[key].value;
+    }
+  }
+
+  opts.filter = filter;
+  return opts;
+}
+
+module.exports = {
+  applyFiltersOnResourceObjs,
+  cleanQueryBodyObj,
+  filterByFieldWildCardExpr,
+  applyFieldListFilter,
+  applyFiltersOnResourceKeys,
+  applyLimitAndOffset,
+  getOptionsFromReq,
+  sortByOrder,
+};

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -155,7 +155,7 @@ function filterByFieldWildCardExpr(arr, prop, propExpr, getNameFunc) {
       const _name = sampleStore.getNameFromKey(entry);
 
       // keys may need processing to become names
-      const name = getNameFunc ? getNameFunc(_name) : name;
+      const name = getNameFunc ? getNameFunc(_name) : _name;
       return re.test(name);
     }
 

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -110,6 +110,10 @@ const longTermToggles = {
  */
 const shortTermToggles = {
 
+  // Enable GET from cache for /v1/subjects, /v1/subjects/{key}
+  getSubjectFromCache: environmentVariableTrue(pe,
+    'GET_SUBJECT_FROM_CACHE'),
+
   // Enable caching for GET /v1/perspectives/{key}?
   enableCachePerspective: environmentVariableTrue(pe,
     'ENABLE_CACHE_PERSPECTIVE'),

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/get.js
+ */
+'use strict'; // eslint-disable-line strict
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const path = '/v1/subjects';
+const expect = require('chai').expect;
+
+describe('api::redisEnabled::GET specific subject', () => {
+  let token;
+  const name = '___Subject1';
+
+  before((done) => {
+    tu.toggleOverride('getSubjectFromCache', true);
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  before(rtu.populateRedis);
+  after(rtu.forceDelete);
+  after(rtu.flushRedis);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+  after(() => tu.toggleOverride('getSubjectFromCache', false));
+
+  it('createdAt and updatedAt fields have the expected format', (done) => {
+    api.get(`${path}/${name}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      const { updatedAt, createdAt } = res.body;
+      expect(updatedAt).to.equal(new Date(updatedAt).toISOString());
+      expect(createdAt).to.equal(new Date(createdAt).toISOString());
+      done();
+    });
+  });
+
+  it('basic get by name, OK', (done) => {
+    api.get(`${path}/${name}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(name);
+      expect(res.body.childCount).to.be.above(0);
+      expect(res.body.hierarchyLevel).to.be.above(0);
+      expect(res.body.apiLinks.length).to.be.above(0);
+      expect(Array.isArray(res.body.tags)).to.be.true;
+      expect(Array.isArray(res.body.relatedLinks)).to.be.true;
+      done();
+    });
+  });
+
+  it('get by name is case in-sensitive', (done) => {
+    api.get(`${path}/${name.toLowerCase()}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.equal(name);
+      done();
+    });
+  });
+
+  it('get by name, wrong name', (done) => {
+    api.get(path + '/abc')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.NOT_FOUND)
+    .end((err, res) => {
+      expect(res.body.errors[0].type).to.equal('ResourceNotFoundError');
+      done();
+    });
+  });
+
+  it('get by name, with fields filter', (done) => {
+    api.get(`${path}/${name}?fields=name,absolutePath`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(name);
+      expect(res.body.absolutePath).to.equal(name);
+      expect(Object.keys(res.body)).to.contain('name', 'absolutePath', 'id', 'apiLinks');
+      done();
+    });
+  });
+
+  it('get by name with incorrect fields filter gives error', (done) => {
+    api.get(`${path}/${name}?fields=name,y`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      expect(res.body.errors[0].message).to.contain('Request validation failed');
+      done();
+    });
+  });
+});

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -55,6 +55,28 @@ describe('api::redisEnabled::GET specific subject', () => {
     });
   });
 
+  it('get by name: limit, offset and sort does not affect result', (done) => {
+    api.get(`${path}/${name}?limit=1&offset=2&sort=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(name);
+      expect(res.body.childCount).to.be.above(0);
+      expect(res.body.hierarchyLevel).to.be.above(0);
+
+      // 5 for [DELETE, GET, PATH, POST, PUT]
+      expect(res.body.apiLinks.length).to.equal(5);
+      expect(Array.isArray(res.body.tags)).to.be.true;
+      expect(Array.isArray(res.body.relatedLinks)).to.be.true;
+      expect(Array.isArray(res.body.relatedLinks)).to.be.true;
+      done();
+    });
+  });
+
   it('basic get by name, OK', (done) => {
     api.get(`${path}/${name}`)
     .set('Authorization', token)
@@ -67,7 +89,9 @@ describe('api::redisEnabled::GET specific subject', () => {
       expect(res.body.name).to.be.equal(name);
       expect(res.body.childCount).to.be.above(0);
       expect(res.body.hierarchyLevel).to.be.above(0);
-      expect(res.body.apiLinks.length).to.be.above(0);
+
+      // 5 for [DELETE, GET, PATH, POST, PUT]
+      expect(res.body.apiLinks.length).to.equal(5);
       expect(Array.isArray(res.body.tags)).to.be.true;
       expect(Array.isArray(res.body.relatedLinks)).to.be.true;
       done();
@@ -98,7 +122,7 @@ describe('api::redisEnabled::GET specific subject', () => {
     });
   });
 
-  it('get by name, with fields filter', (done) => {
+  it('get by name with fields filter: two fields', (done) => {
     api.get(`${path}/${name}?fields=name,absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -109,7 +133,24 @@ describe('api::redisEnabled::GET specific subject', () => {
 
       expect(res.body.name).to.be.equal(name);
       expect(res.body.absolutePath).to.equal(name);
+      expect((Object.keys(res.body)).length).to.equal(4);
       expect(Object.keys(res.body)).to.contain('name', 'absolutePath', 'id', 'apiLinks');
+      done();
+    });
+  });
+
+  it('get by name with fields filter: one field', (done) => {
+    api.get(`${path}/${name}?fields=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.name).to.be.equal(name);
+      expect((Object.keys(res.body)).length).to.equal(3);
+      expect(Object.keys(res.body)).to.contain('name', 'id', 'apiLinks');
       done();
     });
   });

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -21,6 +21,7 @@ const expect = require('chai').expect;
 describe('api::redisEnabled::GET specific subject', () => {
   let token;
   const name = '___Subject1';
+  const childAbsolutePath = '___Subject1.___Subject3';
 
   before((done) => {
     tu.toggleOverride('getSubjectFromCache', true);
@@ -87,8 +88,8 @@ describe('api::redisEnabled::GET specific subject', () => {
       }
 
       expect(res.body.name).to.be.equal(name);
-      expect(res.body.childCount).to.be.above(0);
-      expect(res.body.hierarchyLevel).to.be.above(0);
+      expect(res.body.childCount).to.be.an('number');
+      expect(res.body.hierarchyLevel).to.be.an('number');
 
       // 5 for [DELETE, GET, PATH, POST, PUT]
       expect(res.body.apiLinks.length).to.equal(5);
@@ -122,8 +123,8 @@ describe('api::redisEnabled::GET specific subject', () => {
     });
   });
 
-  it('get by name with fields filter: two fields', (done) => {
-    api.get(`${path}/${name}?fields=name,absolutePath`)
+  it('get child by name with fields filter: two fields', (done) => {
+    api.get(`${path}/${childAbsolutePath}?fields=name,absolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
@@ -131,13 +132,29 @@ describe('api::redisEnabled::GET specific subject', () => {
         done(err);
       }
 
-      expect(res.body.name).to.be.equal(name);
-      expect(res.body.absolutePath).to.equal(name);
+      expect(res.body.absolutePath).to.be.equal(childAbsolutePath);
       expect((Object.keys(res.body)).length).to.equal(4);
       expect(Object.keys(res.body)).to.contain('name', 'absolutePath', 'id', 'apiLinks');
       done();
     });
   });
+
+  it('get child by name returns defined childCount, hierarchyLevel', (done) => {
+    api.get(`${path}/${childAbsolutePath}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.absolutePath).to.be.equal(childAbsolutePath);
+      expect(res.body.childCount).to.be.an('number');
+      expect(res.body.hierarchyLevel).to.be.an('number');
+      done();
+    });
+  });
+
 
   it('get by name with fields filter: one field', (done) => {
     api.get(`${path}/${name}?fields=parentAbsolutePath`)

--- a/tests/cache/models/subjects/get.js
+++ b/tests/cache/models/subjects/get.js
@@ -140,7 +140,7 @@ describe('api::redisEnabled::GET specific subject', () => {
   });
 
   it('get by name with fields filter: one field', (done) => {
-    api.get(`${path}/${name}?fields=name`)
+    api.get(`${path}/${name}?fields=parentAbsolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
@@ -148,9 +148,9 @@ describe('api::redisEnabled::GET specific subject', () => {
         done(err);
       }
 
-      expect(res.body.name).to.be.equal(name);
+      expect(res.body.parentAbsolutePath).to.equal('');
       expect((Object.keys(res.body)).length).to.equal(3);
-      expect(Object.keys(res.body)).to.contain('name', 'id', 'apiLinks');
+      expect(Object.keys(res.body)).to.contain('parentAbsolutePath', 'id', 'apiLinks');
       done();
     });
   });

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -95,8 +95,8 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('sort option asc with absolutePath', (done) => {
-    api.get(`${path}?sort=absolutePath`)
+  it('sort option asc with parentAbsolutePath', (done) => {
+    api.get(`${path}?sort=parentAbsolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
@@ -105,9 +105,9 @@ describe(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
-      expect(res.body[0].absolutePath).to.be.equal(subject1);
-      expect(res.body[1].absolutePath).to.be.equal(subject2);
-      expect(res.body[2].absolutePath).to.be.equal(subject3);
+      expect(res.body[0].parentAbsolutePath).to.be.equal(subject1);
+      expect(res.body[1].parentAbsolutePath).to.be.equal(subject1);
+      expect(res.body[2].parentAbsolutePath).to.be.undefined;
       done();
     });
   });
@@ -129,8 +129,8 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('sort option desc with absolutePath', (done) => {
-    api.get(`${path}?sort=-name`)
+  it('sort option desc with parentAbsolutePath', (done) => {
+    api.get(`${path}?sort=-parentAbsolutePath`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
@@ -139,9 +139,9 @@ describe(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
-      expect(res.body[0].absolutePath).to.be.contain(subject3);
-      expect(res.body[1].absolutePath).to.be.equal(subject2);
-      expect(res.body[2].absolutePath).to.be.equal(subject1);
+      expect(res.body[0].parentAbsolutePath).to.be.undefined;
+      expect(res.body[1].parentAbsolutePath).to.be.equal(subject1);
+      expect(res.body[2].parentAbsolutePath).to.be.equal(subject1);
       done();
     });
   });

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -95,6 +95,23 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
+  it('sort option asc with absolutePath', (done) => {
+    api.get(`${path}?sort=absolutePath`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
+      done();
+    });
+  });
+
   it('sort option desc', (done) => {
     api.get(`${path}?sort=-absolutePath`)
     .set('Authorization', token)
@@ -106,6 +123,23 @@ describe(`api::redisEnabled::GET ${path}`, () => {
 
       expect(res.body.length).to.be.equal(3);
       expect(res.body[0].absolutePath).to.be.equal(subject3);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('sort option desc with absolutePath', (done) => {
+    api.get(`${path}?sort=-name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.contain(subject3);
       expect(res.body[1].absolutePath).to.be.equal(subject2);
       expect(res.body[2].absolutePath).to.be.equal(subject1);
       done();
@@ -247,8 +281,23 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('leading asterisk is treated as "ends with"', (done) => {
+  it('leading asterisk is treated as "ends with" for name', (done) => {
     api.get(path + '?name=*___Subject1')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.equal(1);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('leading asterisk is treated as "ends with" for absolutePath', (done) => {
+    api.get(path + '?absolutePath=*___Subject1')
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -42,7 +42,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
   after(() => tu.toggleOverride('enableRedisSampleStore', false));
   after(() => tu.toggleOverride('getSubjectFromCache', false));
 
-  it('updatedAt and createdAt fields have the expected format', (done) => {
+  it('date and numeric fields have the expected format', (done) => {
     api.get(path)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -53,7 +53,10 @@ describe(`api::redisEnabled::GET ${path}`, () => {
 
       expect(res.body.length).to.be.equal(3);
       for (let i = res.body.length - 1; i >= 0; i--) {
-        const { updatedAt, createdAt } = res.body[i];
+        const { updatedAt, createdAt, childCount, hierarchyLevel } = res.body[i];
+
+        expect(childCount).to.be.an('number');
+        expect(hierarchyLevel).to.be.an('number');
         expect(createdAt).to.equal(new Date(createdAt).toISOString());
         expect(updatedAt).to.equal(new Date(updatedAt).toISOString());
       }
@@ -107,7 +110,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
       expect(res.body.length).to.be.equal(3);
       expect(res.body[0].parentAbsolutePath).to.be.equal(subject1);
       expect(res.body[1].parentAbsolutePath).to.be.equal(subject1);
-      expect(res.body[2].parentAbsolutePath).to.be.undefined;
+      expect(res.body[2].parentAbsolutePath).to.equal('');
       done();
     });
   });
@@ -139,7 +142,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
       }
 
       expect(res.body.length).to.be.equal(3);
-      expect(res.body[0].parentAbsolutePath).to.be.undefined;
+      expect(res.body[0].parentAbsolutePath).to.equal('');
       expect(res.body[1].parentAbsolutePath).to.be.equal(subject1);
       expect(res.body[2].parentAbsolutePath).to.be.equal(subject1);
       done();

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/subjects/getAll.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const rtu = require('../redisTestUtil');
+const path = '/v1/subjects';
+const expect = require('chai').expect;
+
+describe(`api::redisEnabled::GET ${path}`, () => {
+  let token;
+  const subject1 = '___Subject1';
+  const subject2 = '___Subject1.___Subject2';
+  const subject3 = '___Subject1.___Subject3';
+
+  before((done) => {
+    tu.toggleOverride('getSubjectFromCache', true);
+    tu.toggleOverride('enableRedisSampleStore', true);
+    tu.createToken()
+    .then((returnedToken) => {
+      token = returnedToken;
+      done();
+    })
+    .catch((err) => done(err));
+  });
+
+  before(rtu.populateRedis);
+  after(rtu.forceDelete);
+  after(rtu.flushRedis);
+  after(() => tu.toggleOverride('enableRedisSampleStore', false));
+  after(() => tu.toggleOverride('getSubjectFromCache', false));
+
+  it('updatedAt and createdAt fields have the expected format', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      for (let i = res.body.length - 1; i >= 0; i--) {
+        const { updatedAt, createdAt } = res.body[i];
+        expect(createdAt).to.equal(new Date(createdAt).toISOString());
+        expect(updatedAt).to.equal(new Date(updatedAt).toISOString());
+      }
+      done();
+    });
+  });
+
+  it('sorted lexicographically by default', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
+      done();
+    });
+  });
+
+  it('sort option asc', (done) => {
+    api.get(`${path}?sort=absolutePath`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
+      done();
+    });
+  });
+
+  it('sort option desc', (done) => {
+    api.get(`${path}?sort=-absolutePath`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject3);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('fields filter returns in the asc order', (done) => {
+    api.get(`${path}?fields=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(res.body[0].name).to.be.equal(subject1);
+
+      // name is in absolutePath
+      expect(res.body[1].name).to.be.equal(subject2.substr(subject1.length + 1));
+      expect(res.body[2].name).to.be.equal(subject3.substr(subject1.length + 1));
+      done();
+    });
+  });
+
+  it('fields filter returns expected number of keys', (done) => {
+    api.get(`${path}?fields=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(Object.keys(res.body[0]).length).to.equal(3);
+      expect(Object.keys(res.body[1])).to.contain('id', 'name', 'apiLinks');
+      done();
+    });
+  });
+
+  it('fields filter returns apiLinks', (done) => {
+    api.get(`${path}?fields=name`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(3);
+      expect(Array.isArray(res.body[0].apiLinks)).to.be.true;
+      expect(Array.isArray(res.body[1].apiLinks)).to.be.true;
+      expect(Array.isArray(res.body[2].apiLinks)).to.be.true;
+      done();
+    });
+  });
+
+  it('limit filter', (done) => {
+    api.get(`${path}?limit=1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(1);
+      expect(res.body[0].name).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('offset filter', (done) => {
+    api.get(`${path}?offset=1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(2);
+      expect(res.body[0].absolutePath).to.be.equal(subject2);
+      expect(res.body[1].absolutePath).to.be.equal(subject3);
+      done();
+    });
+  });
+
+  it('name filter', (done) => {
+    api.get(`${path}?name=___Subject1`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(1);
+      expect(res.body[0].name).to.be.equal(subject1);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('combined filters', (done) => {
+    const filterstr = 'limit=2&offset=1&name=___*&' +
+    'sort=-name&fields=name,absolutePath';
+    api.get(`${path}?${filterstr}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.be.equal(2);
+      expect(res.body[0].absolutePath).to.be.equal(subject2);
+      expect(res.body[1].absolutePath).to.be.equal(subject1);
+      expect(Object.keys(res.body[1])).to.contain('name', 'absolutePath');
+      done();
+    });
+  });
+
+  it('trailing asterisk is treated as "starts with"', (done) => {
+    api.get(path + '?name=' + tu.namePrefix + '*')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.equal(3);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      expect(res.body[1].absolutePath).to.be.equal(subject2);
+      expect(res.body[2].absolutePath).to.be.equal(subject3);
+      done();
+    });
+  });
+
+  it('leading asterisk is treated as "ends with"', (done) => {
+    api.get(path + '?name=*___Subject1')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.equal(1);
+      expect(res.body[0].absolutePath).to.be.equal(subject1);
+      done();
+    });
+  });
+
+  it('leading and trailing asterisks are treated as "contains"', (done) => {
+    api.get(path + '?name=*2*')
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        done(err);
+      }
+
+      expect(res.body.length).to.equal(1);
+      expect(res.body[0].absolutePath).to.be.equal(subject2);
+      done();
+    });
+  });
+});

--- a/tests/cache/models/subjects/getAll.js
+++ b/tests/cache/models/subjects/getAll.js
@@ -61,7 +61,7 @@ describe(`api::redisEnabled::GET ${path}`, () => {
     });
   });
 
-  it('sorted lexicographically by default', (done) => {
+  it('sorted lexicographically by absolutePath by default', (done) => {
     api.get(path)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/utils.js
+ */
+'use strict'; // eslint-disable-line strict
+
+const supertest = require('supertest');
+const expect = require('chai').expect;
+const utils = require('../../../cache/models/utils');
+
+describe('cache utils test', () => {
+  describe('given asc input', () => {
+    let ascArr;
+
+    // sort is in-place. Hence need reset array for test independence.
+    beforeEach(() => {
+      ascArr = [
+        { name: '___Subject1', absolutePath: '___Subject1' },
+        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+        { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+      ];
+    });
+
+    it('asc name', () => {
+      const result = utils.sortByOrder(ascArr, ['name']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc name', () => {
+      const result = utils.sortByOrder(ascArr, ['-name']);
+      expect(result).to.deep.equal(ascArr.reverse());
+    });
+
+    it('asc absolutePath', () => {
+      const result = utils.sortByOrder(ascArr, ['absolutePath']);
+      expect(result).to.deep.equal(ascArr);
+    });
+
+    it('desc absolutePath', () => {
+      const result = utils.sortByOrder(ascArr, ['-absolutePath']);
+      expect(result).to.deep.equal(ascArr.reverse());
+    });
+  });
+
+  describe('given desc input', () => {
+    let descArr;
+
+    // sort is in-place. Hence need reset array for test independence.
+    beforeEach(() => {
+      descArr = [
+        { name: '___Subject1', absolutePath: '___Subject1' },
+        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+        { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+      ];
+    });
+
+    it('asc name', () => {
+      const result = utils.sortByOrder(descArr, ['name']);
+      expect(result).to.deep.equal(descArr.reverse());
+    });
+
+    it('desc name', () => {
+      const result = utils.sortByOrder(descArr, ['-name']);
+      expect(result).to.deep.equal(descArr);
+    });
+
+    it('asc absolutePath', () => {
+      const result = utils.sortByOrder(descArr, ['absolutePath']);
+      expect(result).to.deep.equal(descArr.reverse());
+    });
+
+    it('desc absolutePath', () => {
+      const result = utils.sortByOrder(descArr, ['-absolutePath']);
+      expect(result).to.deep.equal(descArr);
+    });
+  });
+});

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -11,7 +11,6 @@
  */
 'use strict'; // eslint-disable-line strict
 
-const supertest = require('supertest');
 const expect = require('chai').expect;
 const utils = require('../../../cache/models/utils');
 
@@ -30,22 +29,34 @@ describe('cache utils test', () => {
 
     it('asc name', () => {
       const result = utils.sortByOrder(ascArr, ['name']);
-      expect(result).to.deep.equal(ascArr);
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(1)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(3)).to.be.true;
     });
 
     it('desc name', () => {
       const result = utils.sortByOrder(ascArr, ['-name']);
-      expect(result).to.deep.equal(ascArr.reverse());
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(3)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(1)).to.be.true;
     });
 
     it('asc absolutePath', () => {
       const result = utils.sortByOrder(ascArr, ['absolutePath']);
-      expect(result).to.deep.equal(ascArr);
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(1)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(3)).to.be.true;
     });
 
     it('desc absolutePath', () => {
       const result = utils.sortByOrder(ascArr, ['-absolutePath']);
-      expect(result).to.deep.equal(ascArr.reverse());
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(3)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(1)).to.be.true;
     });
   });
 
@@ -63,22 +74,34 @@ describe('cache utils test', () => {
 
     it('asc name', () => {
       const result = utils.sortByOrder(descArr, ['name']);
-      expect(result).to.deep.equal(descArr.reverse());
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(1)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(3)).to.be.true;
     });
 
     it('desc name', () => {
       const result = utils.sortByOrder(descArr, ['-name']);
-      expect(result).to.deep.equal(descArr);
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(3)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(1)).to.be.true;
     });
 
     it('asc absolutePath', () => {
       const result = utils.sortByOrder(descArr, ['absolutePath']);
-      expect(result).to.deep.equal(descArr.reverse());
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(1)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(3)).to.be.true;
     });
 
     it('desc absolutePath', () => {
       const result = utils.sortByOrder(descArr, ['-absolutePath']);
-      expect(result).to.deep.equal(descArr);
+      expect(result.length).to.equal(3);
+      expect(result[0].name.endsWith(3)).to.be.true;
+      expect(result[1].name.endsWith(2)).to.be.true;
+      expect(result[2].name.endsWith(1)).to.be.true;
     });
   });
 });

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -55,9 +55,9 @@ describe('cache utils test', () => {
     // sort is in-place. Hence need reset array for test independence.
     beforeEach(() => {
       descArr = [
-        { name: '___Subject1', absolutePath: '___Subject1' },
-        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
         { name: '___Subject3', absolutePath: '___Subject1.___Subject3' },
+        { name: '___Subject2', 'absolutePath': '___Subject1.___Subject2' },
+        { name: '___Subject1', absolutePath: '___Subject1' },
       ];
     });
 


### PR DESCRIPTION
- this feature is behind a short term toggle
- extract filter, limit, and offset from cache/models/sample
- add tests for when cache is on: GET subjects filter, limit, and offset
- does NOT include the changing perspectives to get subjects from cache