### PR TITLE
Profile PUT Tests

### DIFF
--- a/tests/api/v1/profiles/put.js
+++ b/tests/api/v1/profiles/put.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/profiles/put.js
+ */
+'use strict';
+
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const constants = require('../../../../api/v1/constants');
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const path = '/v1/profiles';
+const expect = require('chai').expect;
+const jwtUtil = require('../../../../utils/jwtUtil');
+const adminProfile = require('../../../../config').db.adminProfile;
+const adminUser = require('../../../../config').db.adminUser;
+const Profile = tu.db.Profile;
+
+describe(`api: PUT ${path}`, () => {
+  const ZERO = 0;
+  const pname = `${tu.namePrefix}testProfile`;
+  const newName = pname + '2';
+  // out of the box admin user token
+  const predefinedAdminUserToken = jwtUtil.createToken(
+    adminUser.name, adminUser.name
+  );
+
+  beforeEach((done) => {
+    // Create profile __testProfile
+    Profile.create({
+      name: pname,
+    })
+    .then(() => done())
+    .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  describe('PUT profile', () => {
+    it('Pass, PUT name & subjectAccess of an ordinary profile', (done) => {
+      api.put(path + '/' + pname)
+      .set('Authorization', predefinedAdminUserToken)
+      .send({
+        name: newName,
+        subjectAccess: 'rw',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        expect(res.body.name).to.equal(newName);
+        done();
+      });
+    });
+
+    it('Fail, name is a required field of PUT Profile', (done) => {
+      api.put(path + '/' + pname)
+      .set('Authorization', predefinedAdminUserToken)
+      .send({
+        subjectAccess: 'r',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        expect(res.body.errors[ZERO].type).to
+        .contain('SCHEMA_VALIDATION_FAILED');
+        done();
+      });
+    });
+  });
+});

--- a/tests/api/v1/profiles/put.js
+++ b/tests/api/v1/profiles/put.js
@@ -61,6 +61,24 @@ describe(`api: PUT ${path}`, () => {
       });
     });
 
+    it('Fail, Admin update forbidden', (done) => {
+      api.put(path + '/' + adminProfile.name)
+      .set('Authorization', predefinedAdminUserToken)
+      .send({
+        name: adminProfile.name,
+        aspectAccess: 'r',
+      })
+      .expect(constants.httpStatus.FORBIDDEN)
+      .end((err, res) => {
+        if (err) {
+          done(err);
+        }
+        expect(res.body.errors[ZERO].type).to
+        .equal('AdminUpdateDeleteForbidden');
+        done();
+      });
+    });
+
     it('Fail, name is a required field of PUT Profile', (done) => {
       api.put(path + '/' + pname)
       .set('Authorization', predefinedAdminUserToken)


### PR DESCRIPTION
Tests for DELETE to v1/profiles.. Used the predefined Admin User token instead of normal user token because soon only an Admin Profile will have access to PUT profiles.. 