### PR TITLE
toSequelizeWildcards - use regex...

### DIFF
--- a/api/v1/constants.js
+++ b/api/v1/constants.js
@@ -37,7 +37,7 @@ module.exports = {
   OFFSET_EQ: 'offset=',
   POSTGRES_UUID_RE:
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-  QUERY_PARAM_WILDCARD: '*',
+  QUERY_PARAM_REPLACE_ALL_REGEX: /\*/g,
   SEQ_DEFAULT_SCOPE: 'defaultScope',
   SEQ_DESC: 'DESC',
   SEQ_LIKE: '$iLike',

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -56,10 +56,8 @@ function escapeUnderscoreLiterals(val) {
  * @returns {String} the transformed value
  */
 function toSequelizeWildcards(val) {
-  const chars = val.split(constants.EMPTY_STRING);
-  const arr = chars.map((ch) =>
-    (ch === constants.QUERY_PARAM_WILDCARD ? constants.SEQ_WILDCARD : ch));
-  return arr.join(constants.EMPTY_STRING);
+  return val.replace(constants.QUERY_PARAM_REPLACE_ALL_REGEX,
+    constants.SEQ_WILDCARD);
 } // toSequelizeWildcards
 
 /**
@@ -353,4 +351,5 @@ module.exports = {
   getNextUrl,
   options,
   filterArrFromArr, // for testing
+  toSequelizeWildcards, // for testing
 }; // exports

--- a/tests/api/v1/helpers/findUtils.js
+++ b/tests/api/v1/helpers/findUtils.js
@@ -132,4 +132,14 @@ describe('build options object: ', () => {
     opts.where.name.$iLike = '%n\\%am\\_e%';
     expect(options(params, props)).to.deep.equal(opts);
   });
+
+  it.only('toSequelizeWildcards', (done) => {
+    expect(fu.toSequelizeWildcards('abc')).to.be.equal('abc');
+    expect(fu.toSequelizeWildcards('*abc')).to.be.equal('%abc');
+    expect(fu.toSequelizeWildcards('abc*')).to.be.equal('abc%');
+    expect(fu.toSequelizeWildcards('*a*b*c*')).to.be.equal('%a%b%c%');
+    expect(fu.toSequelizeWildcards('***a')).to.be.equal('%%%a');
+    done();
+  });
 });
+


### PR DESCRIPTION
 instead of splitting string into array, iterating, replacing, and rejoining