### PR TITLE
RoomType Migration Typo

### DIFF
--- a/migrations/20170731100411-settings-array-to-object.js
+++ b/migrations/20170731100411-settings-array-to-object.js
@@ -7,6 +7,7 @@
  */
 'use strict';
 const u = require('../db/helpers/roomTypeUtils');
+const TBL = 'RoomTypes';
 
 module.exports = {
   up: function (qi, Sequelize) {
@@ -17,7 +18,7 @@ module.exports = {
       Example:
       return queryInterface.createTable('users', { id: Sequelize.INTEGER });
     */
-    return qi.changeColumn('RoomType', 'settings', {
+    return qi.changeColumn(TBL, 'settings', {
       type: Sequelize.JSON,
       allowNull: true,
     });
@@ -32,7 +33,7 @@ module.exports = {
       return queryInterface.dropTable('users');
     */
 
-    return qi.changeColumn('RoomType', 'settings', {
+    return qi.changeColumn(TBL, 'settings', {
       type: Sequelize.ARRAY(Sequelize.JSONB),
       allowNull: true,
       validate: {


### PR DESCRIPTION
The migration referenced "RoomType" when the tables name is "RoomTypes"