### PR TITLE
request_id

### DIFF
--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -20,6 +20,7 @@ module.exports = {
       method: 'None', // one of HTTP verbs
       recordCount: 0,
       requestBytes: 0,
+      request_id: 'None',
       responseBytes: 0,
       token: 'None',
       totalTime: '0ms',
@@ -61,6 +62,7 @@ module.exports = {
       queueTime: 'None',
       queueResponseTime: 'None',
       recordCount: 0,
+      request_id: 'None',
       token: 'None',
       totalTime: 'None',
       user: 'None',

--- a/utils/apiLog.js
+++ b/utils/apiLog.js
@@ -105,7 +105,6 @@ function logAPI(req, resultObj, retval, recordCountOverride) {
     };
 
     // Add "request_id" if header is set by heroku.
-    console.log(req.headers);
     if (req.headers && req.headers['x-request-id']) {
       logObject.request_id = req.headers['x-request-id'];
     }

--- a/utils/apiLog.js
+++ b/utils/apiLog.js
@@ -105,6 +105,7 @@ function logAPI(req, resultObj, retval, recordCountOverride) {
     };
 
     // Add "request_id" if header is set by heroku.
+    console.log(req.headers);
     if (req.headers && req.headers['x-request-id']) {
       logObject.request_id = req.headers['x-request-id'];
     }


### PR DESCRIPTION
Adding the request_id field to the log line definitions for activity=api and activity=worker. Confirmed it is behaving as intended in devbox.