### PR TITLE
Compress samples

### DIFF
--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -57,13 +57,6 @@ function prepareToPublish(inst, changedKeys, ignoreAttributes) {
 
   return null;
 } // prepareToPublish
-function getBinarySize(string, enconding) {
-    return Buffer.byteLength(string, enconding || 'utf8');
-}
-
-function byteCount(s) {
-    return encodeURI(s).split(/%..|./).length - 1;
-}
 
 /**
  * This function publishes an created, updated or a deleted model instance to
@@ -92,14 +85,11 @@ function publishObject(inst, event, changedKeys, ignoreAttributes) {
   }
 
   if (obj[event]) {
-    const str = JSON.stringify(obj); // 68
-    const notCompressedBuffer = new Buffer.from(str);
-
-    zlib.deflate(notCompressedBuffer, function (error, result) {
-       if (error) throw error;
-       const compressedStr = result.toString('base64');
-        console.log('Compressed buffer size', result.byteLength, getBinarySize(compressedStr, 'base64'), byteCount(compressedStr)); // 1141
-        pub.publish(channelName, compressedStr);
+    const notCompressedBuffer = Buffer.from(JSON.stringify(obj));
+    zlib.deflate(notCompressedBuffer, (error, result) => {
+      if (error) throw error;
+      const compressedStr = result.toString('base64');
+      pub.publish(channelName, compressedStr);
     });
   }
 

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -23,7 +23,7 @@ const zlib = require('zlib');
 module.exports = (io) => {
   sub.on('message', (channel, compressedBuffer) => {
     zlib.inflate(Buffer.from(compressedBuffer, 'base64'), (_error, original) => {
-     if (_error) throw _error;
+      if (_error) throw _error;
 
       // message object to be sent to the clients
       const mssgObj = JSON.parse(original.toString());

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -22,20 +22,18 @@ const zlib = require('zlib');
  */
 module.exports = (io) => {
   sub.on('message', (channel, compressedBuffer) => {
-    zlib.inflate(new Buffer(compressedBuffer, 'base64'), function (_error, original) {
-       if (_error) throw _error;
-        console.log('original buffer size', original.byteLength); // 1141
-        console.log('original string', original.toString()); // 1141
+    zlib.inflate(Buffer.from(compressedBuffer, 'base64'), (_error, original) => {
+     if (_error) throw _error;
 
-        // message object to be sent to the clients
-        const mssgObj = JSON.parse(original.toString());
-        const key = Object.keys(mssgObj)[0];
+      // message object to be sent to the clients
+      const mssgObj = JSON.parse(original.toString());
+      const key = Object.keys(mssgObj)[0];
 
-        /*
-         * pass on the message received through the redis subscriber to the socket
-         * io emitter to send data to the browser clients.
-         */
-        emitter(io, key, mssgObj);
+      /*
+       * pass on the message received through the redis subscriber to the socket
+       * io emitter to send data to the browser clients.
+       */
+      emitter(io, key, mssgObj);
     });
   });
 };


### PR DESCRIPTION
- using base64 encoded string in publish. This is more memory efficient than hex (aka base 16).
- uncompressed buffer bytes: 1400/sample. 
- base 64 encoded string (from compressed buffer bytes) : around 850/sample. 
- hex encoded string (from compressed buffer bytes) : around 1250/sample. 
It is worth considering ascii, which is supposed to be more space efficient.
However computation to encode might be more taxing.