### PR TITLE
Compress samples

### DIFF
--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -88,7 +88,7 @@ function publishObject(inst, event, changedKeys, ignoreAttributes) {
     const objectAsString = JSON.stringify(obj);
     zlib.deflate(objectAsString, (err, zippedValue) => {
       if (err) {
-        console.log('Error deflating!');
+        console.log('Error deflating!', err);
         return;
       }
 

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -22,7 +22,7 @@ const zlib = require('zlib');
  */
 module.exports = (io) => {
   sub.on('message', (channel, mssgStr) => {
-    zlib.unzip(mssgStr, (err, uncompressedBuffer) => {
+    zlib.unzip(Buffer.from(mssgStr, 'base64'), (err, uncompressedBuffer) => {
       if (err) {
         console.log('Error inflating!', err);
         return;

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -22,15 +22,15 @@ const zlib = require('zlib');
  */
 module.exports = (io) => {
   sub.on('message', (channel, mssgStr) => {
-    // console.log('mssgStr is', mssgStr);
-    zlib.inflate(new Buffer.from(mssgStr, 'base64'), (err, redisValue) => {
+    zlib.inflate(new Buffer.from(mssgStr, 'base64'),
+      (err, uncompressedBuffer) => {
       if (err) {
         console.log('Error inflating!', err);
         return;
       }
 
       // message object to be sent to the clients
-      const mssgObj = JSON.parse(redisValue);
+      const mssgObj = JSON.parse(uncompressedBuffer);
       const key = Object.keys(mssgObj)[0];
 
       /*

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -22,8 +22,7 @@ const zlib = require('zlib');
  */
 module.exports = (io) => {
   sub.on('message', (channel, mssgStr) => {
-    zlib.inflate(new Buffer.from(mssgStr, 'base64'),
-      (err, uncompressedBuffer) => {
+    zlib.unzip(mssgStr, (err, uncompressedBuffer) => {
       if (err) {
         console.log('Error inflating!', err);
         return;


### PR DESCRIPTION
- using base 64 encoding for strings
- publish stringified compressed samples
- Memory savings: 
- Compressed stringified samples size: 850 bytes vs uncompressed stringified samples:  1250 bytes
- Compressed buffer size around 340. uncompressedBuffer size around 550
