### PR TITLE
Refactor redis config

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@
 require('./config/toggles'); // Loads the feature toggles
 const featureToggles = require('feature-toggles');
 const configUtil = require('./config/configUtil');
+const redisConfig = require('./config/redisConfig');
 const defaultPort = 3000;
 const defaultPostgresPort = 5432;
 const pe = process.env; // eslint-disable-line no-process-env
@@ -30,7 +31,6 @@ const pghost = pe.PGHOST || 'localhost';
 const pgport = pe.PGPORT || defaultPostgresPort;
 const defaultDbUrl = 'postgres://' + pguser + ':' + pgpass + '@' + pghost +
   ':' + pgport + '/' + pgdatabase;
-const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
 const DEFAULT_DB_CONNECTION_POOL = { // sequelize defaults
   max: 5,
   min: 0,
@@ -109,27 +109,6 @@ const JOB_QUEUE_TTL_SECONDS_SYNC = pe.TTL_KUE_JOBS_SYNC
 // set time interval for enableQueueStatsActivityLogs
 const queueStatsActivityLogsInterval = 60000;
 
-/*
- * Assigns each of the different redis uses cases to a particular redis
- * instance, if configured, or falls back to the primary redis instance.
- */
-const redisUrls = {
-  cache: pe.REDIS_CACHE && pe[pe.REDIS_CACHE] ?
-    pe[pe.REDIS_CACHE] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  limiter: pe.REDIS_LIMITER && pe[pe.REDIS_LIMITER] ?
-    pe[pe.REDIS_LIMITER] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  pubsub: pe.REDIS_PUBSUB && pe[pe.REDIS_PUBSUB] ?
-    pe[pe.REDIS_PUBSUB] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  queue: pe.REDIS_QUEUE && pe[pe.REDIS_QUEUE] ?
-    pe[pe.REDIS_QUEUE] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  realtimeLogging: pe.REDIS_REALTIME_LOGGING && pe[pe.REDIS_REALTIME_LOGGING] ?
-    pe[pe.REDIS_REALTIME_LOGGING] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  sampleStore: pe.REDIS_SAMPLE_STORE && pe[pe.REDIS_SAMPLE_STORE] ?
-    pe[pe.REDIS_SAMPLE_STORE] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-  session: pe.REDIS_SESSION && pe[pe.REDIS_SESSION] ?
-    pe[pe.REDIS_SESSION] : (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL),
-};
-
 module.exports = {
   api: {
     defaults: {
@@ -175,18 +154,7 @@ module.exports = {
     modelDirName: 'model',
     passwordHashSaltNumRounds: 8,
   },
-  redis: {
-    channelName: 'focus',
-    instanceUrl: {
-      cache: redisUrls.cache,
-      limiter: redisUrls.limiter,
-      pubsub: redisUrls.pubsub,
-      queue: redisUrls.queue,
-      realtimeLogging: redisUrls.realtimeLogging,
-      sampleStore: redisUrls.sampleStore,
-      session: redisUrls.session,
-    },
-  },
+  redis: redisConfig,
 
   // When adding new environment, consider adding it to /config/migrationConfig
   // as well to enable database migraton in the environment.

--- a/config/redisConfig.js
+++ b/config/redisConfig.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * ./config/redisConfig.js
+ *
+ * Assigns each of the different redis uses cases to a particular redis
+ * instance, if configured, or falls back to the primary redis instance.
+ */
+'use strict'; // eslint-disable-line strict
+const pe = process.env; // eslint-disable-line no-process-env
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+const PRIMARY_REDIS = (pe.REDIS_URL || DEFAULT_LOCAL_REDIS_URL);
+const channelName = 'focus';
+
+module.exports = {
+  channelName,
+  instanceUrl: {
+    /*
+     * Cache perspectives, lenses, etc.
+     */
+    cache: pe.REDIS_CACHE && pe[pe.REDIS_CACHE] ?
+      pe[pe.REDIS_CACHE] : PRIMARY_REDIS,
+
+    /*
+     * Keys for tracking rate limiter activity
+     */
+    limiter: pe.REDIS_LIMITER && pe[pe.REDIS_LIMITER] ?
+      pe[pe.REDIS_LIMITER] : PRIMARY_REDIS,
+
+    /*
+     * PubSub for real-time events.
+     */
+    pubsub: pe.REDIS_PUBSUB && pe[pe.REDIS_PUBSUB] ?
+      pe[pe.REDIS_PUBSUB] : PRIMARY_REDIS,
+
+    /*
+     * Kue job queue for work being delegated to worker dynos.
+     */
+    queue: pe.REDIS_QUEUE && pe[pe.REDIS_QUEUE] ?
+      pe[pe.REDIS_QUEUE] : PRIMARY_REDIS,
+
+    /*
+     * Transient data about socket connections from browsers with an open
+     * perspective, for logging activity=realtime.
+     */
+    realtimeLogging: pe.REDIS_REALTIME_LOGGING &&
+      pe[pe.REDIS_REALTIME_LOGGING] ? pe[pe.REDIS_REALTIME_LOGGING] :
+      PRIMARY_REDIS,
+
+    /*
+     * SampleStore is the primary persistent store for samples, and an active
+     * cache for aspects and subjects.
+     */
+    sampleStore: pe.REDIS_SAMPLE_STORE && pe[pe.REDIS_SAMPLE_STORE] ?
+      pe[pe.REDIS_SAMPLE_STORE] : PRIMARY_REDIS,
+
+    /*
+     * Active browser sessions.
+     */
+    session: pe.REDIS_SESSION && pe[pe.REDIS_SESSION] ?
+      pe[pe.REDIS_SESSION] : PRIMARY_REDIS,
+  },
+};


### PR DESCRIPTION
The main config file is too big and cluttered and hard to read. Pull all the redis instance configuration out into a separate config file.