### PR TITLE
Update travis to use postgres 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - CXX=g++-4.8
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
   apt:
     sources:
       - ubuntu-toolchain-r-test


### PR DESCRIPTION
 (which is what we're using in production now)