### PR TITLE
Publish partial sample

### DIFF
--- a/config/toggles.js
+++ b/config/toggles.js
@@ -126,7 +126,12 @@ const shortTermToggles = {
 
   returnUser: environmentVariableTrue(pe, 'RETURN_CREATEDBY_ON_TOKEN_INPUT'),
 
-  fastFailDuplicateSubject: environmentVariableTrue(pe, 'FAST_FAIL_DUPLICATE_SUBJECT'),
+  fastFailDuplicateSubject: environmentVariableTrue(pe,
+    'FAST_FAIL_DUPLICATE_SUBJECT'),
+
+  // publish partial sample to the subscribers
+  publishPartialSample: environmentVariableTrue(pe, 'PUBLISH_PARTIAL_SAMPLE'),
+
 
 }; // shortTermToggles
 

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -132,7 +132,6 @@ const shortTermToggles = {
   // publish partial sample to the subscribers
   publishPartialSample: environmentVariableTrue(pe, 'PUBLISH_PARTIAL_SAMPLE'),
 
-
 }; // shortTermToggles
 
 featureToggles.load(Object.assign({}, longTermToggles, shortTermToggles));

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -98,6 +98,7 @@ function publishObject(inst, event, changedKeys, ignoreAttributes) {
  */
 function publishPartialSample(sampleInst, event) {
   const eventType = event || getSampleEventType(sampleInst);
+
   // will be over written when unwrapping json.stringified fields
   const sample = sampleInst.get ? sampleInst.get() : sampleInst;
   publishObject(sample, eventType);

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -101,6 +101,10 @@ function publishPartialSample(sampleInst, event) {
 
   // will be over written when unwrapping json.stringified fields
   const sample = sampleInst.get ? sampleInst.get() : sampleInst;
+
+  delete sample.aspect;
+  delete sample.subject;
+
   publishObject(sample, eventType);
   return sample;
 } // publishPartialSample

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -92,7 +92,7 @@ function publishObject(inst, event, changedKeys, ignoreAttributes) {
 /**
  * Publishes the sample without attaching the related subject and the aspect to
  * the redis channel
- * @param  {Object} sampleInst - The sampel instance to be published
+ * @param  {Object} sampleInst - The sample instance to be published
  * @param  {String} event - The event type that is being published.
  * @returns {Object} - the sample object
  */

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -30,14 +30,16 @@ module.exports = (io) => {
     const parsedObj = rtUtils.parseObject(mssgObj[key], key);
     if (featureToggles.isFeatureEnabled('publishPartialSample') &&
     rtUtils.isThisSample(parsedObj)) {
+      const useSampleStore =
+        featureToggles.isFeatureEnabled('enableRedisSampleStore');
       /*
        * assign the subjectModel to the database model if sampleStore is
        * not enabled
        */
       const subjectModel =
-        featureToggles.isFeatureEnabled('enableRedisSampleStore') ? undefined :
+        useSampleStore ? undefined :
           require('../db/index').Subject; // eslint-disable-line global-require
-      rtUtils.attachAspectSubject(parsedObj, subjectModel)
+      rtUtils.attachAspectSubject(parsedObj, useSampleStore, subjectModel)
       .then((obj) => {
         console.log('object to be emitted this is a complete sample', obj);
        /*

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -30,7 +30,14 @@ module.exports = (io) => {
     const parsedObj = rtUtils.parseObject(mssgObj[key], key);
     if (featureToggles.isFeatureEnabled('publishPartialSample') &&
     rtUtils.isThisSample(parsedObj)) {
-      rtUtils.attachAspectSubject(parsedObj)
+      /*
+       * assign the subjectModel to the database model if sampleStore is
+       * not enabled
+       */
+      const subjectModel =
+        featureToggles.isFeatureEnabled('enableRedisSampleStore') ? undefined :
+          require('../db/index').Subject; // eslint-disable-line global-require
+      rtUtils.attachAspectSubject(parsedObj, subjectModel)
       .then((obj) => {
         console.log('object to be emitted this is a complete sample', obj);
        /*

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -26,26 +26,22 @@ module.exports = (io) => {
     // message object to be sent to the clients
     const mssgObj = JSON.parse(mssgStr);
     const key = Object.keys(mssgObj)[0];
-    console.log('-----key---', key);
     const parsedObj = rtUtils.parseObject(mssgObj[key], key);
     if (featureToggles.isFeatureEnabled('publishPartialSample') &&
     rtUtils.isThisSample(parsedObj)) {
       const useSampleStore =
         featureToggles.isFeatureEnabled('enableRedisSampleStore');
-      /*
-       * assign the subjectModel to the database model if sampleStore is
-       * not enabled
-       */
+
+      // assign the subject db model if sampleStore is not enabled
       const subjectModel =
         useSampleStore ? undefined :
           require('../db/index').Subject; // eslint-disable-line global-require
       rtUtils.attachAspectSubject(parsedObj, useSampleStore, subjectModel)
       .then((obj) => {
-        console.log('object to be emitted this is a complete sample', obj);
-       /*
-        * pass on the message received through the redis subscriber to the
-        * socket io emitter to send data to the browser clients.
-        */
+        /*
+         * pass on the message received through the redis subscriber to the
+         * socket io emitter to send data to the browser clients.
+         */
         emitter(io, key, obj);
       });
     } else {

--- a/realtime/socketIOEmitter.js
+++ b/realtime/socketIOEmitter.js
@@ -15,8 +15,8 @@
 const rtUtils = require('./utils');
 const initEvent = 'refocus.internal.realtime.perspective.namespace.initialize';
 
-module.exports = (io, key, mssgObj) => {
-  const obj = rtUtils.parseObject(mssgObj[key], key);
+module.exports = (io, key, obj) => {
+  // newObjectAsString contains { key: {new: obj }}
   const newObjectAsString = rtUtils.getNewObjAsString(key, obj);
 
   // Initialize namespace when perspective initialize namespace event is sent
@@ -26,9 +26,8 @@ module.exports = (io, key, mssgObj) => {
 
   for (const nsp in io.nsps) {
     // Send events only if namespace connections > 0
-    if (nsp && (Object.keys(nsp).length > 0) &&
-     rtUtils.shouldIEmitThisObj(nsp, obj)) {
-      // newObjectAsString contains { key: {new: obj }}
+    if (nsp && Object.keys(nsp).length &&
+         rtUtils.shouldIEmitThisObj(nsp, obj)) {
       io.of(nsp).emit(key, newObjectAsString);
     }
   }

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -14,7 +14,6 @@ const ip = require('ip');
 const constants = require('./constants');
 const redisClient = require('../cache/redisCache').client.sampleStore;
 const redisStore = require('../cache/sampleStore');
-const featureToggles = require('feature-toggles');
 
 const eventName = {
   add: 'refocus.internal.realtime.subject.add',
@@ -315,16 +314,24 @@ function isIpWhitelisted(addr, whitelist) {
 } // isIpWhitelisted
 
 /**
- * [attachAspectSubject description]
- * @param  {[type]} sampInst [description]
- * @return {[type]}          [description]
+ * When passed in a sample, its related subject and aspect is attached to the
+ * sample. If useSampleStore is set to true, the subject ans aspect is fetched
+ * for the cache instead of the database.
+ * @param {Object} sample - The sample instance.
+ * @param {Boolen} useSampleStore - The sample store flag, the subject and the
+ *   aspect is fetched from the cache if this is set.
+ * @param {Model} subjectModel - The database subject model.
+ * @param {Model} aspectModel - The database aspect model.
+ * @returns {Promise} - which resolves to a complete sample with its subject and
+ *   aspect.
  */
-function attachAspectSubject(sample, subjectModel, aspectModel) {
+function attachAspectSubject(sample, useSampleStore, subjectModel,
+  aspectModel) {
   const nameParts = sample.name.split('|');
   const subName = nameParts[0];
   const aspName = nameParts[1];
   let promiseArr = [];
-  if (featureToggles.isFeatureEnabled('enableRedisSampleStore')) {
+  if (useSampleStore) {
     const subKey = redisStore.toKey('subject', subName);
     const aspKey = redisStore.toKey('aspect', aspName);
     const getAspectPromise = sample.aspect ? Promise.resolve(sample.aspect) :

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -37,7 +37,6 @@ describe('tests/cache/models/samples/get.js, ' +
 
   before(rtu.populateRedis);
   after(rtu.forceDelete);
-  after(rtu.flushRedis);
   after(() => tu.toggleOverride('enableRedisSampleStore', false));
 
   it('updatedAt and createdAt fields have the expected format', (done) => {

--- a/tests/realtime/realtimeUtils.js
+++ b/tests/realtime/realtimeUtils.js
@@ -216,5 +216,21 @@ describe('tests/realtime/realtimeUtils.js, realtime utils Tests >', () => {
         }
       });
     });
+
+    describe('attachAspectSubject tests', () => {
+      it('useSampleStore = true', () => {
+        realtimeUtils.attachAspectSubject(looksLikeSampleObjNA, true)
+        .then((sample) => {
+          expect(sample).deep.equal(looksLikeSampleObjNA);
+        });
+      });
+
+      it('useSampleStore = false', () => {
+        realtimeUtils.attachAspectSubject(looksLikeSampleObjNA, false)
+        .then((sample) => {
+          expect(sample).deep.equal(looksLikeSampleObjNA);
+        });
+      });
+    });
   });
 });

--- a/tests/realtime/redisPublisher.js
+++ b/tests/realtime/redisPublisher.js
@@ -27,8 +27,8 @@ describe('tests/realtime/redisPublisher.js >', () => {
     const aspectName = `${tu.namePrefix}Aspect`;
     const sampleName = `${subjectName}|${aspectName}`;
 
-    before(() => tu.toggleOverride('enableRedisSampleStore', true));
-    beforeEach((done) => {
+    before((done) => {
+      tu.toggleOverride('enableRedisSampleStore', true);
       let a1;
       let s1;
       Aspect.create({
@@ -62,9 +62,10 @@ describe('tests/realtime/redisPublisher.js >', () => {
       .catch(done);
     });
 
-    afterEach(rtu.forceDelete);
-    afterEach(rtu.flushRedis);
-    after(() => tu.toggleOverride('enableRedisSampleStore', false));
+    after((done) => {
+      tu.toggleOverride('enableRedisSampleStore', false);
+      rtu.forceDelete(done);
+    });
 
     it('certain fields in aspect should be array, and others ' +
     'should be undefined', (done) => {
@@ -118,6 +119,39 @@ describe('tests/realtime/redisPublisher.js >', () => {
         done();
       })
       .catch(done);
+    });
+    describe('publishPartialSample tests', () => {
+      it('sample passed in without subject and aspect should be published ' +
+        ' without that', (done) => {
+        Sample.findOne({ where: { name: sampleName } })
+        .then((sam) => {
+          const sampInst = sam.get();
+          delete sampInst.aspect;
+          delete sampInst.subject;
+          return publisher.publishPartialSample(sampInst);
+        })
+        .then((pubObj) => {
+          expect(pubObj.subject).to.equal(undefined);
+          expect(pubObj.aspect).to.equal(undefined);
+          done();
+        })
+        .catch(done);
+      });
+
+      it('sample passed in with subject and aspect should be published ' +
+        ' without that', (done) => {
+        Sample.findOne({ where: { name: sampleName } })
+        .then((sam) => {
+          const sampInst = sam.get();
+          return publisher.publishPartialSample(sampInst);
+        })
+        .then((pubObj) => {
+          expect(pubObj.subject).to.equal(undefined);
+          expect(pubObj.aspect).to.equal(undefined);
+          done();
+        })
+        .catch(done);
+      });
     });
   });
 
@@ -244,6 +278,40 @@ describe('tests/realtime/redisPublisher.js >', () => {
           // pass plain object
           eventType = publisher.getSampleEventType(sam.get());
           expect(eventType).to.equal(sampleEvent.add);
+          done();
+        })
+        .catch(done);
+      });
+    });
+
+    describe('publishPartialSample tests', () => {
+      it('sample passed in without subject and aspect should be published ' +
+        ' without that', (done) => {
+        Sample.findById(sampId)
+        .then((sam) => {
+          const sampInst = sam.get();
+          delete sampInst.aspect;
+          delete sampInst.subject;
+          return publisher.publishPartialSample(sampInst);
+        })
+        .then((pubObj) => {
+          expect(pubObj.subject).to.equal(undefined);
+          expect(pubObj.aspect).to.equal(undefined);
+          done();
+        })
+        .catch(done);
+      });
+
+      it('sample passed in with subject and aspect should be published ' +
+        ' without that', (done) => {
+        Sample.findById(sampId)
+        .then((sam) => {
+          const sampInst = sam.get();
+          return publisher.publishPartialSample(sampInst);
+        })
+        .then((pubObj) => {
+          expect(pubObj.subject).to.equal(undefined);
+          expect(pubObj.aspect).to.equal(undefined);
           done();
         })
         .catch(done);


### PR DESCRIPTION
This PR has the following changes
- Refactored the "publishSample" method in "redisPublisher.js" by moving the attach subject and aspect to utils.
- Refactored redisSubscriber.js to parse and extract the objects before calling the emitter(). 
-  Added a feature to publish the samples without attaching the subject/aspect and letting the subscriber attach them. 
- Unit tests to prove these changes work.
- Some minor changes to fix flappers not related to the above changes.