### PR TITLE
minor fix in doPost so on non-auth error, do not proceed to postPromise.then

### DIFF
--- a/api/v1/helpers/verbs/doPost.js
+++ b/api/v1/helpers/verbs/doPost.js
@@ -80,7 +80,9 @@ function doPost(req, res, next, props) {
           props.model.create(toPost);
       }
 
-      return u.handleError(next, err, props.modelName);
+      // non FORBIDDEN error. Throw it to be caught by the latter .catch.
+      // this bypasses the postPromise.then function
+      throw err;
     });
   } else if (props.modelName === 'Sample') {
 
@@ -96,10 +98,6 @@ function doPost(req, res, next, props) {
   }
 
   return postPromise.then((o) => {
-    if (!o) { // could be here from u.handleError
-      return;
-    }
-
     resultObj.dbTime = new Date() - resultObj.reqStartTime;
     u.logAPI(req, resultObj, o);
 

--- a/api/v1/helpers/verbs/doPost.js
+++ b/api/v1/helpers/verbs/doPost.js
@@ -73,7 +73,6 @@ function doPost(req, res, next, props) {
       return props.model.create(toPost);
     })
     .catch((err) => {
-
       // if no user found, proceed with post sample
       if (err.status === httpStatus.FORBIDDEN) {
         return isCacheOn ?
@@ -97,6 +96,10 @@ function doPost(req, res, next, props) {
   }
 
   return postPromise.then((o) => {
+    if (!o) { // could be here from u.handleError
+      return;
+    }
+
     resultObj.dbTime = new Date() - resultObj.reqStartTime;
     u.logAPI(req, resultObj, o);
 

--- a/api/v1/helpers/verbs/doPost.js
+++ b/api/v1/helpers/verbs/doPost.js
@@ -73,6 +73,7 @@ function doPost(req, res, next, props) {
       return props.model.create(toPost);
     })
     .catch((err) => {
+
       // if no user found, proceed with post sample
       if (err.status === httpStatus.FORBIDDEN) {
         return isCacheOn ?
@@ -80,8 +81,10 @@ function doPost(req, res, next, props) {
           props.model.create(toPost);
       }
 
-      // non FORBIDDEN error. Throw it to be caught by the latter .catch.
-      // this bypasses the postPromise.then function
+      /*
+       * non FORBIDDEN error. Throw it to be caught by the latter .catch.
+       * This bypasses the postPromise.then function
+       */
       throw err;
     });
   } else if (props.modelName === 'Sample') {


### PR DESCRIPTION
Problem:
when POST sample with non-auth error, 
u.handleError returns nothing, so postPromise.then((o) => ... runs with 
undefined o. This throws an unintentional TypeError:
`TypeError: Cannot read property 'name' of undefined
    at Object.attachAspectSubject (/Users/anny.he/workspace/refocus/realtime/utils.js:330:27)
    at Object.publishSample (/Users/anny.he/workspace/refocus/realtime/redisPublisher.js:128:18)
    at postPromise.then (/Users/anny.he/workspace/refocus/api/v1/helpers/verbs/doPost.js:114:17)`
as the code tries to attach subjects and aspects to an undefined sample.
The fix is simple: throw err instead of handleError, to bypass the postPromise.then block