### PR TITLE
Keep trying to reconnect even when getting ECONNREFUSED

### DIFF
--- a/cache/redisCache.js
+++ b/cache/redisCache.js
@@ -29,14 +29,6 @@ const opts = {
   /* Redis Client Retry Strategy */
   retry_strategy: (options) => {
     /*
-     * Stop retrying if we're getting an ECONNREFUSED error. Flush all commands
-     * with a custom error message.
-     */
-    if (options.error && options.error.code === 'ECONNREFUSED') {
-      return new Error('The server refused the connection');
-    }
-
-    /*
      * Stop retrying if we've exceeded the configured threshold since the last
      * successful connection. Flush all commands with a custom error message.
      */

--- a/config/redisConfig.js
+++ b/config/redisConfig.js
@@ -67,8 +67,8 @@ module.exports = {
       pe[pe.REDIS_SESSION] : PRIMARY_REDIS,
   },
   retryStrategy: {
-    /* Number of times to attempt to reconnect. Default 10. */
-    attempt: +pe.REDIS_RETRY_ATTEMPT || 10,
+    /* Number of times to attempt to reconnect. Default 100. */
+    attempt: +pe.REDIS_RETRY_ATTEMPT || 100,
 
     backoffFactor: +pe.REDIS_RETRY_BACKOFF_FACTOR || 100,
 


### PR DESCRIPTION
because the redis instance can still be brought back up and we should keep trying as it is being brought back up.
Also increase the number of attempts.