### PR TITLE
set sudo: false for faster travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
 language: node_js
 node_js:
   - "6"
+
+# Set sudo to false for "container-based" environment, a fast boot time
+# environment in which sudo commands are not available.
 sudo: false
+
+# By default, travis clones repositories to a depth of 50 commits, which is
+# only really useful if you are performing git operations. Please note that if
+# you use a depth of 1 and have a queue of jobs, Travis CI won’t build commits
+# that are in the queue when you push a new commit.
+git:
+  depth: 2
+
 env:
   global:
     - NODE_ENV=build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "6"
-
+sudo: false
 env:
   global:
     - NODE_ENV=build


### PR DESCRIPTION
Shaves 5s off the git.checkout time. (We've got a long way to go, but it's a tiny start.)