### PR TITLE
flapper fix for bulkUpsert worker logging tests

### DIFF
--- a/tests/cache/jobQueue/bulkUpsert.js
+++ b/tests/cache/jobQueue/bulkUpsert.js
@@ -32,6 +32,8 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
 
   before((done) => {
     tu.toggleOverride('enableWorkerProcess', true);
+    tu.toggleOverride('enableApiActivityLogs', false);
+    tu.toggleOverride('enableWorkerActivityLogs', false);
     jobQueue.process(jobType.BULKUPSERTSAMPLES, bulkUpsertSamplesJob);
     tu.toggleOverride('enableRedisSampleStore', true);
     tu.createToken()
@@ -83,6 +85,9 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
         name: `${tu.namePrefix}NOT_EXIST|${tu.namePrefix}Aspect1`,
         value: '2',
       }, {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`,
+        value: '4',
+      }, {
         name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect2`,
         value: '4',
       },
@@ -105,6 +110,7 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
   it('test logging', (done) => {
     tu.toggleOverride('enableApiActivityLogs', true);
     tu.toggleOverride('enableWorkerActivityLogs', true);
+    logger.on('logging', testLogMessage);
     let workerLogged = false;
     let apiLogged = false;
 
@@ -131,7 +137,6 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
       //don't call done() yet, need to wait for data to be logged
     });
 
-    logger.on('logging', testLogMessage);
     function testLogMessage(transport, level, msg, meta) {
       const logObj = {};
       msg.split(' ').forEach((entry) => {

--- a/tests/jobQueue/v1/bulkUpsert.js
+++ b/tests/jobQueue/v1/bulkUpsert.js
@@ -30,6 +30,8 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
 
   before((done) => {
     tu.toggleOverride('enableWorkerProcess', true);
+    tu.toggleOverride('enableApiActivityLogs', false);
+    tu.toggleOverride('enableWorkerActivityLogs', false);
     jobQueue.process(jobType.BULKUPSERTSAMPLES, bulkUpsertSamplesJob);
     tu.createToken()
     .then((returnedToken) => {
@@ -77,6 +79,9 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
         name: `${tu.namePrefix}NOT_EXIST|${tu.namePrefix}Aspect1`,
         value: '2',
       }, {
+        name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`,
+        value: '4',
+      }, {
         name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect2`,
         value: '4',
       },
@@ -93,6 +98,7 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
   it('test logging', (done) => {
     tu.toggleOverride('enableApiActivityLogs', true);
     tu.toggleOverride('enableWorkerActivityLogs', true);
+    logger.on('logging', testLogMessage);
     let workerLogged = false;
     let apiLogged = false;
 
@@ -119,7 +125,6 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
       //don't call done() yet, need to wait for data to be logged
     });
 
-    logger.on('logging', testLogMessage);
     function testLogMessage(transport, level, msg, meta) {
       const logObj = {};
       msg.split(' ').forEach((entry) => {
@@ -202,6 +207,9 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
         {
           name: `${tu.namePrefix}NOT_EXIST|${tu.namePrefix}Aspect1`,
           value: '2',
+        }, {
+          name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect1`,
+          value: '4',
         }, {
           name: `${tu.namePrefix}Subject|${tu.namePrefix}Aspect2`,
           value: '4',


### PR DESCRIPTION
The problem was an event was getting captured out of order from one of the other tests that had different data, which was causing an expect error.
I moved the event attachment and explicitly set the toggles to prevent this from happening, and made the data the same for all tests so if it does happen it should still pass.