### PR TITLE
Remove the requirement that a SGT provide connection.method.

### DIFF
--- a/db/model/generatortemplate.js
+++ b/db/model/generatortemplate.js
@@ -57,7 +57,6 @@ const connectionSchema = {
     method: {
       description: 'The http method',
       enum: ['DELETE', 'GET', 'PATCH', 'POST', 'PUT'],
-      required: true,
     },
     url: {
       description: 'The url to connect to. Specify variables for variable ' +
@@ -65,7 +64,6 @@ const connectionSchema = {
       '["url", "toUrl"] is required.',
       type: 'string',
     },
-
     toUrl: {
       description: 'The string body of a function which returns the url ' +
       'to connect to. One of ["url", "toUrl"] is required.',


### PR DESCRIPTION
Our collector code should treat a connection.method as "GET".