### PR TITLE
Reencrypt sgcontext

### DIFF
--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -29,7 +29,7 @@ const httpStatus = require('../constants').httpStatus;
 const decryptSGContextValues = require('../../../utils/cryptUtils')
                                 .decryptSGContextValues;
 const encrypt = require('../../../utils/cryptUtils').encrypt;
-const GlobalConfig = require('../../../db/index').GlobalConfig;
+const GlobalConfig = require('../helpers/nouns/globalconfig').model;
 const encryptionAlgoForCollector = require('../../../config')
                                     .encryptionAlgoForCollector;
 const ZERO = 0;

--- a/config.js
+++ b/config.js
@@ -113,6 +113,10 @@ const queueStatsActivityLogsInterval = 60000;
 
 const GET_REQUEST_DEFAULT_LIMIT = +pe.GET_REQUEST_DEFAULT_LIMIT || 10000;
 
+// encryption/decryption algorithm used for securing the context variables when
+// sent to collector.
+const encryptionAlgoForCollector = 'aes-256-cbc';
+
 module.exports = {
   api: {
     defaults: {
@@ -252,4 +256,5 @@ module.exports = {
   hiddenRoutes,
   corsRoutes,
   GET_REQUEST_DEFAULT_LIMIT,
+  encryptionAlgoForCollector,
 };

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -69,7 +69,6 @@ describe('tests/api/v1/collectors/heartbeat.js > ' +
     .then(() => cryptUtils.encryptSGContextValues(GlobalConfig,
         looksLikeSG, looksLikeSGT))
     .then((sg) => {
-      // console.log(sg);
       encryptedSG = sg;
       encryptedSG.generatorTemplate = looksLikeSGT;
 

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2017, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/collectors/heartbeat.js
+ */
+'use strict'; // eslint-disable-line strict
+const reEncryptSGContextValues = require(
+  '../../../../api/v1/controllers/collectors'
+).reEncryptSGContextValues;
+const tu = require('../../../testUtils');
+const expect = require('chai').expect;
+const cryptUtils = require('../../../../utils/cryptUtils');
+const GlobalConfig = tu.db.GlobalConfig;
+const dbConstants = require('../../../../db/constants');
+const config = require('../../../../config');
+
+describe('tests/api/v1/collectors/heartbeat.js > ' +
+  'reEncryptSGContextValues', () => {
+  const secretKey = 'mySecretKey';
+  const algorithm = 'aes-256-cbc';
+  const password = 'superlongandsupersecretpassword';
+  const secretInformation = 'asecretthatyoushouldnotknow';
+  const otherNonSecretInformation = 'nonsecreInformation';
+  const authToken = 'collectorAuthToken';
+  const timestamp = Date.now().toString();
+
+  let encryptedSG;
+  beforeEach((done) => {
+    const looksLikeSGT = {
+      name: 'My_TEST_SGT',
+      version: '1.0.0',
+      contextDefinition: {
+        password: {
+          encrypted: true,
+        },
+        secretInformation: {
+          encrypted: true,
+        },
+        otherNonSecretInformation: {
+          encrypted: false,
+        },
+      },
+    };
+
+    const looksLikeSG = {
+      name: 'MY_TEST_SG',
+      version: '1.0.0',
+      context: {
+        password,
+        secretInformation,
+        otherNonSecretInformation,
+      },
+    };
+
+    GlobalConfig.create({
+      key: dbConstants.SGEncryptionKey,
+      value: secretKey,
+    })
+    .then(() => GlobalConfig.create({
+      key: dbConstants.SGEncryptionAlgorithm,
+      value: algorithm,
+    }))
+    .then(() => cryptUtils.encryptSGContextValues(GlobalConfig,
+        looksLikeSG, looksLikeSGT))
+    .then((sg) => {
+      // console.log(sg);
+      encryptedSG = sg;
+      encryptedSG.generatorTemplate = looksLikeSGT;
+
+      done();
+    }).catch(done);
+  });
+
+  afterEach((done) => {
+    GlobalConfig.destroy({ truncate: true, force: true })
+    .then(() => done())
+    .catch(done);
+  });
+
+  it('when encrypted is set to true in SGT, the related encrypted SG values ' +
+    'should be decrypted and encrypted again with given auth token and ' +
+    'timestamp.', (done) => {
+    let reencryptedSampleGen;
+    const secretKeyColl = authToken + timestamp;
+
+    // reencrypt context values
+    reEncryptSGContextValues(encryptedSG, authToken, timestamp)
+    .then((reencryptedSG) => {
+      // verify the reencryptedSG context values
+      reencryptedSampleGen = reencryptedSG;
+      expect(reencryptedSG).to.not.equal(undefined);
+      expect(reencryptedSG.context.secretInformation)
+        .to.not.equal(encryptedSG.secretInformation);
+      expect(reencryptedSG.context.otherNonSecretInformation)
+        .equal(otherNonSecretInformation);
+      expect(Object.keys(reencryptedSG)).to.deep
+        .equal(Object.keys(encryptedSG));
+
+      // decrypt the reencryptedSG, this would basically happen on collector
+      const sg = reencryptedSG;
+      const sgt = reencryptedSG.generatorTemplate;
+      Object.keys(sgt.contextDefinition).forEach((key) => {
+        if (sgt.contextDefinition[key].encrypted && sg.context[key]) {
+          sg.context[key] = cryptUtils.decrypt(sg.context[key],
+            secretKeyColl, config.encryptionAlgoForCollector);
+        }
+      });
+
+      return sg;
+    })
+    .then((decryptedSG) => {
+      // verify the decrypted context values
+      expect(decryptedSG).to.not.equal(undefined);
+      expect(decryptedSG.context.secretInformation)
+        .equal(secretInformation);
+      expect(decryptedSG.context.otherNonSecretInformation)
+        .equal(otherNonSecretInformation);
+      expect(Object.keys(decryptedSG)).to.deep
+        .equal(Object.keys(reencryptedSampleGen));
+      done();
+    });
+  });
+
+  it('error when authToken null', (done) => {
+    reEncryptSGContextValues(encryptedSG, null, timestamp)
+    .then(() => done(new Error('Validation error should be thrown!')))
+    .catch((err) => {
+      expect(err.name).to.equal('ValidationError');
+      expect(err.explanation).to.equal('Collector authentication token or ' +
+        'timestamp not available to encrypt the context values');
+      done();
+    })
+    .catch(done);
+  });
+
+  it('error when timestamp null/undefined', (done) => {
+    reEncryptSGContextValues(encryptedSG, authToken)
+    .then(() => done(new Error('Validation error should be thrown!')))
+    .catch((err) => {
+      expect(err.name).to.equal('ValidationError');
+      expect(err.explanation).to.equal('Collector authentication token or ' +
+        'timestamp not available to encrypt the context values');
+      done();
+    })
+    .catch(done);
+  });
+
+  it('error when SGT not defined as an attribute of SG', (done) => {
+    delete encryptedSG.generatorTemplate;
+    reEncryptSGContextValues(encryptedSG, authToken, timestamp)
+    .then(() => done(new Error('Validation error should be thrown!')))
+    .catch((err) => {
+      expect(err.name).to.equal('ValidationError');
+      expect(err.explanation).to.equal('Sample generator template not found ' +
+        'in sample generator.');
+      done();
+    })
+    .catch(done);
+  });
+});

--- a/tests/utils/crypt.js
+++ b/tests/utils/crypt.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * tests/utils/cryptUtils.js
+ * tests/utils/crypt.js
  */
 'use strict'; // eslint-disable-line strict
 const expect = require('chai').expect;

--- a/utils/cryptUtils.js
+++ b/utils/cryptUtils.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * utils/cryptUtils
+ * utils/cryptUtils.js
  *
  * Utils for encryption and decryption needs in refocus
  */


### PR DESCRIPTION
These changes does not include the behaviour of decryptSGContextValues in case an error is thrown when key/algo is not present in globalConfig. I can create new PR, when those changes go in.

This PR is based on #560 and should be merged after that