### PR TITLE
Enforce Profile Access For Write Protected Resources

### DIFF
--- a/api/v1/controllers/roomTypes.js
+++ b/api/v1/controllers/roomTypes.js
@@ -18,6 +18,8 @@ const doGet = require('../helpers/verbs/doGet');
 const doPatch = require('../helpers/verbs/doPatch');
 const doPost = require('../helpers/verbs/doPost');
 const doPut = require('../helpers/verbs/doPut');
+const u = require('../helpers/verbs/utils');
+const authUtils = require('../helpers/authUtils');
 
 module.exports = {
 
@@ -31,7 +33,17 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   deleteRoomTypes(req, res, next) {
-    doDelete(req, res, next, helper);
+    authUtils.profileHasWriteAccess(req, helper.model)
+    .then((ok) => {
+      if(ok) {
+        doDelete(req, res, next, helper);
+      } else {
+        u.forbidden(next);
+      }
+    })
+    .catch((err) => {
+      u.forbidden(next);
+    });
   },
 
   /**
@@ -70,7 +82,17 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchRoomType(req, res, next) {
-    doPatch(req, res, next, helper);
+    authUtils.profileHasWriteAccess(req, helper.model)
+    .then((ok) => {
+      if(ok) {
+        doPatch(req, res, next, helper);
+      } else {
+        u.forbidden(next);
+      }
+    })
+    .catch((err) => {
+      u.forbidden(next);
+    });
   },
 
   /**
@@ -83,7 +105,17 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   postRoomTypes(req, res, next) {
-    doPost(req, res, next, helper);
+    authUtils.profileHasWriteAccess(req, helper.model)
+    .then((ok) => {
+      if(ok) {
+        doPost(req, res, next, helper);
+      } else {
+        u.forbidden(next);
+      }
+    })
+    .catch((err) => {
+      u.forbidden(next);
+    });
   },
 
 }; // exports

--- a/db/model/profile.js
+++ b/db/model/profile.js
@@ -146,7 +146,7 @@ module.exports = function profile(seq, dataTypes) {
         return new Promise((resolve, reject) => {
           Profile.findById(profileId)
           .then((p) => resolve(p &&
-            p[accessModel] === 'rw'.toLowerCase()))
+            p[accessModel] === 'rw'))
           .catch(reject);
         });
       }, // hasWriteAccess

--- a/db/model/profile.js
+++ b/db/model/profile.js
@@ -146,7 +146,7 @@ module.exports = function profile(seq, dataTypes) {
         return new Promise((resolve, reject) => {
           Profile.findById(profileId)
           .then((p) => resolve(p &&
-            p[accessModel] === 'rw'))
+            p[accessModel].toLowerCase() === 'rw'))
           .catch(reject);
         });
       }, // hasWriteAccess

--- a/db/model/profile.js
+++ b/db/model/profile.js
@@ -145,8 +145,7 @@ module.exports = function profile(seq, dataTypes) {
         const accessModel = model.getProfileAccessField();
         return new Promise((resolve, reject) => {
           Profile.findById(profileId)
-          .then((p) => resolve(p &&
-            p[accessModel].toLowerCase() === 'rw'))
+          .then((p) => resolve(p && p[accessModel] === 'rw'))
           .catch(reject);
         });
       }, // hasWriteAccess

--- a/db/model/profile.js
+++ b/db/model/profile.js
@@ -142,7 +142,7 @@ module.exports = function profile(seq, dataTypes) {
       }, // isAdmin
 
       hasWriteAccess(profileId, model) {
-        const accessModel = model.getAccessField();
+        const accessModel = model.getProfileAccessField();
         return new Promise((resolve, reject) => {
           Profile.findById(profileId)
           .then((p) => resolve(p &&


### PR DESCRIPTION
@iamigo Wanted to check that you're okay with the way I'm doing this for RoomTypes before I enforce it in other controllers. This will mean that if someone is making a write request, it will only be allowed if that users profile has 'rw' access to that resource. (Means that an access token will always be required for write operations (incl POST, PATCH, PUT, DELETE) to that resource)