### PR TITLE
fix the samples surviving subject delete issue

### DIFF
--- a/db/helpers/subjectUtils.js
+++ b/db/helpers/subjectUtils.js
@@ -110,11 +110,14 @@ function throwNotMatchError(parentId, parentAbsolutePath) {
  * redis sample store.
  *
  * @param {String} absolutePath - The absolutePath of the subject
+ * @returns {Promise}
  */
 function removeFromRedis(absolutePath) {
-  redisOps.deleteKey(subjectType, absolutePath);
-  redisOps.deleteKeys(sampleType, subjectType, absolutePath);
-  redisOps.deleteKey(subAspMapType, absolutePath);
+  return Promise.all([
+    redisOps.deleteKey(subjectType, absolutePath),
+    redisOps.deleteKeys(sampleType, subjectType, absolutePath),
+    redisOps.deleteKey(subAspMapType, absolutePath),
+  ]);
 } // removeFromRedis
 
 module.exports = {

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -463,10 +463,6 @@ module.exports = function subject(seq, dataTypes) {
       afterDelete(inst /* , opts */) {
         if (inst.getDataValue('isPublished')) {
           common.publishChange(inst, eventName.del);
-
-          if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
-            subjectUtils.removeFromRedis(inst.absolutePath);
-          }
         }
 
         return new seq.Promise((resolve, reject) =>
@@ -474,6 +470,11 @@ module.exports = function subject(seq, dataTypes) {
           .then((par) => {
             if (par) {
               par.decrement('childCount');
+            }
+
+            // if cache is on, remove reference to subjects in the cache
+            if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
+              return subjectUtils.removeFromRedis(inst.absolutePath);
             }
           })
           .then(() => resolve(inst))

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -461,10 +461,6 @@ module.exports = function subject(seq, dataTypes) {
        *  if an error was encountered
        */
       afterDelete(inst /* , opts */) {
-        if (inst.getDataValue('isPublished')) {
-          common.publishChange(inst, eventName.del);
-        }
-
         return new seq.Promise((resolve, reject) =>
           inst.getParent()
           .then((par) => {
@@ -472,9 +468,13 @@ module.exports = function subject(seq, dataTypes) {
               par.decrement('childCount');
             }
 
-            // if cache is on, remove reference to subjects in the cache
-            if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
-              return subjectUtils.removeFromRedis(inst.absolutePath);
+            if (inst.getDataValue('isPublished')) {
+              common.publishChange(inst, eventName.del);
+
+              // if cache is on, remove reference to subjects in the cache
+              if (featureToggles.isFeatureEnabled(sampleStoreFeature)) {
+                return subjectUtils.removeFromRedis(inst.absolutePath);
+              }
             }
           })
           .then(() => resolve(inst))


### PR DESCRIPTION
- tested locally. Resolves the issue.
testing methodology:
- run server with cache turned on: `REDIS_SAMPLE_STORE=true node .`
- create published subject root and root.child, 1 published aspect
- create samples out of the subjects and aspects
- GET /v1/samples to make sure the samples are there
- DELETE child subject
- GET /v1/samples should show only one sample, the sample that is attached to root
- DELETE root subject
- GET /v1/samples should show []