### PR TITLE
add toggle to throw error on hmset with undefined key

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -254,6 +254,12 @@ function upsertOneSample(sampleQueryBodyObj, isBulk, user) {
     // sampleQueryBodyObj updated with fields
     createSampHsetCommand(sampleQueryBodyObj, sample, aspectObj);
 
+    if (featureToggles.isFeatureEnabled('hmsetWithoutKeyError') &&
+      !sampleKey) {
+      throw new Error('Found hmset object without key. Object is' +
+        JSON.stringify(sampleQueryBodyObj));
+    }
+
     // if sample exists, just update sample.
     if (sample) {
       // to avoid updating sample name

--- a/cache/redisOps.js
+++ b/cache/redisOps.js
@@ -11,6 +11,7 @@
  */
 'use strict'; // eslint-disable-line strict
 
+const featureToggles = require('feature-toggles');
 const redisStore = require('./sampleStore');
 const redisClient = require('./redisCache').client.sampleStore;
 const rsConstant = redisStore.constants;
@@ -39,6 +40,12 @@ function capitalizeFirstLetter(str) {
  * @returns {Promise} - which resolves to true
  */
 function hmSet(objectName, name, value) {
+  if (featureToggles.isFeatureEnabled('hmsetWithoutKeyError') &&
+    (!objectName || !name)) {
+    throw new Error('Found hmset object without key. Object is' +
+      JSON.stringify(value));
+  }
+
   const cleanobj =
           redisStore['clean' + capitalizeFirstLetter(objectName)](value);
   const nameKey = redisStore.toKey(objectName, name);
@@ -399,6 +406,12 @@ module.exports = {
    * @returns {array} - Command array
    */
   setHashMultiCmd(type, name, kvObj) {
+    if (featureToggles.isFeatureEnabled('hmsetWithoutKeyError') &&
+      (!type || !name)) {
+      throw new Error('Found hmset object without key. Object is' +
+        JSON.stringify(kvObj));
+    }
+
     if (!Object.keys(kvObj).length) {
       return [];
     }

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -113,6 +113,9 @@ const longTermToggles = {
  * things from getting out of hand and keeping tons of dead unused code around.
  */
 const shortTermToggles = {
+  // Enable api activity logging
+  hmsetWithoutKeyError:
+    environmentVariableTrue(pe, 'HMSET_WITHOUT_KEY_ERROR'),
 
   // Cache the GET request for samples with wildcard by name
   cacheGetSamplesByNameWildcard: environmentVariableTrue(pe,


### PR DESCRIPTION
- throws error whenever hmset with undefined key
- excluding the hmset in clock and db folder, as those are the least likely to hmset with undefined key