### PR TITLE
initial commit for removing the statusChangedAt field from aspect

### DIFF
--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -19,7 +19,10 @@ const PFX = 'samsto';
 const SEP = ':';
 const ONE = 1;
 const constants = {
-  ISOfields: ['updatedAt', 'createdAt', 'statusChangedAt'],
+  ISOfields: {
+    sample: ['updatedAt', 'createdAt', 'statusChangedAt'],
+    aspect: ['updatedAt', 'createdAt'],
+  },
   featureName: 'enableRedisSampleStore',
   fieldsToStringify: {
     aspect: [
@@ -115,13 +118,13 @@ function removeNullsAndStringifyArrays(obj, arrayFields) {
  * output value: 2017-03-14T02:22:42.255Z
  *
  * @param {Object} obj - Contains keys whose values need be converted
+ * @param {String} resourceType - Ie. sample, aspect.
  * If value is provided, return the ISO formatted date.
  * If no value, return the ISO formatted date with now time.
  * @returns {String} The date string in ISO format.
-
  */
-function convertToISO(obj) {
-  constants.ISOfields.forEach((field) => {
+function convertToISO(obj, resourceType) {
+  constants.ISOfields[resourceType].forEach((field) => {
     if (!obj[field]) {
       obj[field] = new Date().toISOString();
     } else if (obj[field] && obj[field].toISOString) {
@@ -158,7 +161,7 @@ function cleanAspect(a) {
     constants.fieldsToStringify.aspect);
 
   // convert date time fields to proper format
-  convertToISO(retval);
+  convertToISO(retval, 'aspect');
 
   return retval;
 } // cleanAspect
@@ -177,7 +180,7 @@ function cleanSample(s) {
     constants.fieldsToStringify.sample);
 
   // convert date time fields to proper format
-  convertToISO(retval);
+  convertToISO(retval, 'sample');
 
   return retval;
 } // cleanSample

--- a/tests/api/v1/samples/get.js
+++ b/tests/api/v1/samples/get.js
@@ -113,7 +113,7 @@ describe(`tests/api/v1/samples/get.js, GET ${path} >`, () => {
 
       res.body.forEach((sample) => {
         expect(sample.statusChangedAt).to.be.an('string');
-      })
+      });
       done();
     });
   });
@@ -129,7 +129,7 @@ describe(`tests/api/v1/samples/get.js, GET ${path} >`, () => {
 
       res.body.forEach((sample) => {
         expect(sample.aspect.statusChangedAt).to.be.undefined;
-      })
+      });
       done();
     });
   });

--- a/tests/api/v1/samples/get.js
+++ b/tests/api/v1/samples/get.js
@@ -102,6 +102,38 @@ describe(`tests/api/v1/samples/get.js, GET ${path} >`, () => {
     });
   });
 
+  it('basic get: samples have statusChangedAt field', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      res.body.forEach((sample) => {
+        expect(sample.statusChangedAt).to.be.an('string');
+      })
+      done();
+    });
+  });
+
+  it('basic get: aspect does not have statusChangedAt', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      res.body.forEach((sample) => {
+        expect(sample.aspect.statusChangedAt).to.be.undefined;
+      })
+      done();
+    });
+  });
+
   it('basic get by id', (done) => {
     api.get(`${path}/${sampleName}`)
     .set('Authorization', token)

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -76,7 +76,7 @@ describe('tests/cache/models/samples/get.js, ' +
 
       res.body.forEach((sample) => {
         expect(sample.statusChangedAt).to.be.an('string');
-      })
+      });
       done();
     });
   });
@@ -92,7 +92,7 @@ describe('tests/cache/models/samples/get.js, ' +
 
       res.body.forEach((sample) => {
         expect(sample.aspect.statusChangedAt).to.be.undefined;
-      })
+      });
       done();
     });
   });

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -65,6 +65,38 @@ describe('tests/cache/models/samples/get.js, ' +
     });
   });
 
+  it('basic get: samples have statusChangedAt field', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      res.body.forEach((sample) => {
+        expect(sample.statusChangedAt).to.be.an('string');
+      })
+      done();
+    });
+  });
+
+  it('basic get: aspect does not have statusChangedAt', (done) => {
+    api.get(path)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      res.body.forEach((sample) => {
+        expect(sample.aspect.statusChangedAt).to.be.undefined;
+      })
+      done();
+    });
+  });
+
   it('returns aspectId, subjectId, and NO aspect object', (done) => {
     api.get(path)
     .set('Authorization', token)


### PR DESCRIPTION
on  GET /v1/samples with redis sample cache on
- the sample itself should have a "statusChangedAt" attribute
- sample.aspect should NOT have  "statusChangedAt" attribute

add tests 
- GET samples with cache on: show the fix works: aspect should NOT have  "statusChangedAt" attribute
- GET samples with cache off: no fix needed. Add tests to check that aspect should NOT have  "statusChangedAt" attribute