### PR TITLE
removed references to authUtils from the controllers

### DIFF
--- a/api/v1/controllers/globalconfig.js
+++ b/api/v1/controllers/globalconfig.js
@@ -18,7 +18,6 @@ const doPost = require('../helpers/verbs/doPost');
 const doGet = require('../helpers/verbs/doGet');
 const doFind = require('../helpers/verbs/doFind');
 const u = require('../helpers/verbs/utils');
-const authUtils = require('../helpers/authUtils');
 
 module.exports = {
 
@@ -33,17 +32,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   deleteGlobalConfig(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doDelete(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doDelete(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -85,17 +78,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchGlobalConfig(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPatch(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doPatch(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -109,17 +96,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   postGlobalConfig(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPost(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doPost(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
 }; // exports

--- a/api/v1/controllers/profiles.js
+++ b/api/v1/controllers/profiles.js
@@ -9,7 +9,7 @@
 /**
  * api/v1/controllers/profiles.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const helper = require('../helpers/nouns/profiles');
 const doDelete = require('../helpers/verbs/doDelete');
@@ -19,7 +19,6 @@ const doPatch = require('../helpers/verbs/doPatch');
 const doPost = require('../helpers/verbs/doPost');
 const doPut = require('../helpers/verbs/doPut');
 const u = require('../helpers/verbs/utils');
-const authUtils = require('../helpers/authUtils');
 
 module.exports = {
 
@@ -34,17 +33,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   deleteProfile(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doDelete(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doDelete(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -86,17 +79,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchProfile(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPatch(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doPatch(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -110,17 +97,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   postProfile(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPost(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doPost(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -135,16 +116,10 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   putProfile(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPut(req, res, next, helper);
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+    if (req.headers.IsAdmin) {
+      doPut(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 }; // exports

--- a/api/v1/controllers/tokens.js
+++ b/api/v1/controllers/tokens.js
@@ -9,7 +9,7 @@
 /**
  * api/v1/controllers/tokens.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const helper = require('../helpers/nouns/tokens');
 const apiErrors = require('../apiErrors');
@@ -18,7 +18,6 @@ const doGet = require('../helpers/verbs/doGet');
 const jwtUtil = require('../../../utils/jwtUtil');
 const u = require('../helpers/verbs/utils');
 const httpStatus = require('../constants').httpStatus;
-const authUtils = require('../helpers/authUtils');
 
 module.exports = {
 
@@ -33,31 +32,22 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   deleteTokenById(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doDelete(req, res, next, helper);
-      } else {
-        // also OK if user is NOT admin but is deleting own token
-        let userId;
-        authUtils.getUser(req)
-        .then((user) => {
-          userId = user.id;
-          const id = req.swagger.params.key.value;
-          return helper.model.findById(id);
-        })
-        .then((o) => {
-          if (o && o.createdBy === userId) {
-            doDelete(req, res, next, helper);
-          } else {
-            u.forbidden(next);
-          }
-        });
-      }
-    })
-    .catch((err) => {
-      u.forbidden(next);
-    });
+    if (req.headers.IsAdmin) {
+      doDelete(req, res, next, helper);
+    } else {
+      // also OK if user is NOT admin but is deleting own token
+      const id = req.swagger.params.key.value;
+      helper.model.findById(id)
+      .then((token) => {
+        if (token && token.createdBy === req.user.id) {
+          doDelete(req, res, next, helper);
+        } else {
+          u.forbidden(next);
+        }
+      }).catch((err) => {
+        u.forbidden(next);
+      });
+    }
   },
 
   /**
@@ -86,27 +76,23 @@ module.exports = {
    */
   postToken(req, res, next) {
     const resultObj = { reqStartTime: req.timestamp };
-    let tokenValue;
+    const user = req.user;
 
-    // get user details from req
-    authUtils.getUser(req)
-    .then((user) => {
-      // create token to be returned in response.
-      const tokenName = req.swagger.params.queryBody.value.name;
-      tokenValue = jwtUtil.createToken(
-        tokenName, user.name
-      );
+    // create token to be returned in response.
+    const tokenName = req.swagger.params.queryBody.value.name;
+    const token = jwtUtil.createToken(
+      tokenName, user.name
+    );
 
-      // create token object in db
-      return helper.model.create({
-        name: tokenName,
-        createdBy: user.id,
-      });
+    // create token object in db
+    return helper.model.create({
+      name: tokenName,
+      createdBy: user.id,
     })
     .then((createdToken) => {
       resultObj.dbTime = new Date() - resultObj.reqStartTime;
       const tokenObj = u.responsify(createdToken, helper, req.method);
-      tokenObj.token = tokenValue;
+      tokenObj.token = token;
       u.logAPI(req, resultObj, tokenObj);
       return res.status(httpStatus.CREATED).json(tokenObj);
     })
@@ -125,32 +111,26 @@ module.exports = {
    */
   restoreTokenById(req, res, next) {
     const resultObj = { reqStartTime: req.timestamp };
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        const id = req.swagger.params.key.value;
-        helper.model.findById(id)
-        .then((o) => {
-          if (o.isRevoked === '0') {
-            throw new apiErrors.InvalidTokenActionError();
-          }
+    if (req.headers.IsAdmin) {
+      const id = req.swagger.params.key.value;
+      helper.model.findById(id)
+      .then((o) => {
+        if (o.isRevoked === '0') {
+          throw new apiErrors.InvalidTokenActionError();
+        }
 
-          return o.restore();
-        })
-        .then((o) => {
-          resultObj.dbTime = new Date() - resultObj.reqStartTime;
-          const retval = u.responsify(o, helper, req.method);
-          u.logAPI(req, resultObj, retval);
-          res.status(httpStatus.OK).json(retval);
-        })
-        .catch((err) => u.handleError(next, err, helper.modelName));
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+        return o.restore();
+      })
+      .then((o) => {
+        resultObj.dbTime = new Date() - resultObj.reqStartTime;
+        const retval = u.responsify(o, helper, req.method);
+        u.logAPI(req, resultObj, retval);
+        res.status(httpStatus.OK).json(retval);
+      })
+      .catch((err) => u.handleError(next, err, helper.modelName));
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -164,31 +144,25 @@ module.exports = {
    */
   revokeTokenById(req, res, next) {
     const resultObj = { reqStartTime: req.timestamp };
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        const id = req.swagger.params.key.value;
-        helper.model.findById(id)
-        .then((o) => {
-          if (o.isRevoked > '0') {
-            throw new apiErrors.InvalidTokenActionError();
-          }
+    if (req.headers.IsAdmin) {
+      const id = req.swagger.params.key.value;
+      helper.model.findById(id)
+      .then((o) => {
+        if (o.isRevoked > '0') {
+          throw new apiErrors.InvalidTokenActionError();
+        }
 
-          return o.revoke();
-        })
-        .then((o) => {
-          resultObj.dbTime = new Date() - resultObj.reqStartTime;
-          const retval = u.responsify(o, helper, req.method);
-          u.logAPI(req, resultObj, retval);
-          res.status(httpStatus.OK).json(retval);
-        })
-        .catch((err) => u.handleError(next, err, helper.modelName));
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+        return o.revoke();
+      })
+      .then((o) => {
+        resultObj.dbTime = new Date() - resultObj.reqStartTime;
+        const retval = u.responsify(o, helper, req.method);
+        u.logAPI(req, resultObj, retval);
+        res.status(httpStatus.OK).json(retval);
+      })
+      .catch((err) => u.handleError(next, err, helper.modelName));
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 }; // exports

--- a/api/v1/controllers/userTokens.js
+++ b/api/v1/controllers/userTokens.js
@@ -16,7 +16,6 @@ const apiErrors = require('../apiErrors');
 const cnstnts = require('../constants');
 const u = require('../helpers/verbs/utils');
 const httpStatus = cnstnts.httpStatus;
-const authUtils = require('../helpers/authUtils');
 
 /**
  * where clause to get user tokens
@@ -26,8 +25,10 @@ const authUtils = require('../helpers/authUtils');
 function whereClauseForUser(userNameOrId) {
   const whr = {};
   if (u.looksLikeId(userNameOrId)) {
-    /* need to use '$table.field$' for association fields. User IDs in the url
-    are case-sensitve. */
+    /*
+     * need to use '$table.field$' for association fields. User IDs in the url
+     * are case-sensitve.
+     */
     whr.where = { '$User.id$': {} };
     whr.where['$User.id$'] = userNameOrId;
   } else {
@@ -68,7 +69,6 @@ module.exports = {
     const user = req.swagger.params.key.value;
     const tokenName = req.swagger.params.tokenName.value;
     const whr = whereClauseForUserAndTokenName(user, tokenName);
-    let tokenToDel;
 
     // get user token
     helper.model.findOne(whr)
@@ -88,32 +88,17 @@ module.exports = {
         });
       }
 
-      tokenToDel = token;
-
-      // Check if requesting user is Admin
-      return authUtils.isAdmin(req);
-    })
-    .then((isAdmin) => {
-      // if admin, delete the token
-      if (isAdmin) {
-        return tokenToDel.destroy();
+      /*
+       * Ok to destory the token if the request is made by an admin user or
+       * if an non admin user wants to revoke their own token
+       */
+      if (req.headers.IsAdmin || token.createdBy === req.user.id) {
+        return token.destroy();
       }
 
-      // Get user details from req
-      return authUtils.getUser(req)
-      .then((currentUser) => {
-        // OK to delete if user is NOT admin but is deleting own token
-        if (tokenToDel && tokenToDel.createdBy === currentUser.id) {
-          return tokenToDel.destroy();
-        }
-
-        // else forbidden
-        throw new apiErrors.ForbiddenError({
-          explanation: 'Forbidden.',
-        });
-      })
-      .catch((err) => {
-        throw err;
+      // else forbidden
+      throw new apiErrors.ForbiddenError({
+        explanation: 'Forbidden.',
       });
     })
     .then((o) => {
@@ -198,41 +183,35 @@ module.exports = {
    */
   restoreTokenByName(req, res, next) {
     const resultObj = { reqStartTime: req.timestamp };
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        const user = req.swagger.params.key.value;
-        const tokenName = req.swagger.params.tokenName.value;
-        const whr = whereClauseForUserAndTokenName(user, tokenName);
-        helper.model.findOne(whr)
-        .then((o) => {
-          if (!o) {
-            const err = new apiErrors.ResourceNotFoundError();
-            err.resource = helper.model.name;
-            err.key = user + ', ' + tokenName;
-            throw err;
-          }
+    if (req.headers.IsAdmin) {
+      const user = req.swagger.params.key.value;
+      const tokenName = req.swagger.params.tokenName.value;
+      const whr = whereClauseForUserAndTokenName(user, tokenName);
+      helper.model.findOne(whr)
+      .then((o) => {
+        if (!o) {
+          const err = new apiErrors.ResourceNotFoundError();
+          err.resource = helper.model.name;
+          err.key = user + ', ' + tokenName;
+          throw err;
+        }
 
-          if (o.isRevoked === '0') {
-            throw new apiErrors.InvalidTokenActionError();
-          }
+        if (o.isRevoked === '0') {
+          throw new apiErrors.InvalidTokenActionError();
+        }
 
-          return o.restore();
-        })
-        .then((o) => {
-          resultObj.dbTime = new Date() - resultObj.reqStartTime;
-          const retval = u.responsify(o, helper, req.method);
-          res.status(httpStatus.OK).json(retval);
-          u.logAPI(req, resultObj, retval);
-        })
-        .catch((err) => u.handleError(next, err, helper.modelName));
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+        return o.restore();
+      })
+      .then((o) => {
+        resultObj.dbTime = new Date() - resultObj.reqStartTime;
+        const retval = u.responsify(o, helper, req.method);
+        res.status(httpStatus.OK).json(retval);
+        u.logAPI(req, resultObj, retval);
+      })
+      .catch((err) => u.handleError(next, err, helper.modelName));
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 
   /**
@@ -246,40 +225,34 @@ module.exports = {
    */
   revokeTokenByName(req, res, next) {
     const resultObj = { reqStartTime: req.timestamp };
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        const user = req.swagger.params.key.value;
-        const tokenName = req.swagger.params.tokenName.value;
-        const whr = whereClauseForUserAndTokenName(user, tokenName);
-        helper.model.findOne(whr)
-        .then((o) => {
-          if (!o) {
-            const err = new apiErrors.ResourceNotFoundError();
-            err.resource = helper.model.name;
-            err.key = user + ', ' + tokenName;
-            throw err;
-          }
+    if (req.headers.IsAdmin) {
+      const user = req.swagger.params.key.value;
+      const tokenName = req.swagger.params.tokenName.value;
+      const whr = whereClauseForUserAndTokenName(user, tokenName);
+      helper.model.findOne(whr)
+      .then((o) => {
+        if (!o) {
+          const err = new apiErrors.ResourceNotFoundError();
+          err.resource = helper.model.name;
+          err.key = user + ', ' + tokenName;
+          throw err;
+        }
 
-          if (o.isRevoked > '0') {
-            throw new apiErrors.InvalidTokenActionError();
-          }
+        if (o.isRevoked > '0') {
+          throw new apiErrors.InvalidTokenActionError();
+        }
 
-          return o.revoke();
-        })
-        .then((o) => {
-          resultObj.dbTime = new Date() - resultObj.reqStartTime;
-          const retval = u.responsify(o, helper, req.method);
-          u.logAPI(req, resultObj, retval);
-          res.status(httpStatus.OK).json(retval);
-        })
-        .catch((err) => u.handleError(next, err, helper.modelName));
-      } else {
-        u.forbidden(next);
-      }
-    })
-    .catch((err) => {
+        return o.revoke();
+      })
+      .then((o) => {
+        resultObj.dbTime = new Date() - resultObj.reqStartTime;
+        const retval = u.responsify(o, helper, req.method);
+        u.logAPI(req, resultObj, retval);
+        res.status(httpStatus.OK).json(retval);
+      })
+      .catch((err) => u.handleError(next, err, helper.modelName));
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 }; // exports

--- a/api/v1/controllers/userTokens.js
+++ b/api/v1/controllers/userTokens.js
@@ -89,7 +89,7 @@ module.exports = {
       }
 
       /*
-       * Ok to destory the token if the request is made by an admin user or
+       * Ok to destroy the token if the request is made by an admin user or
        * if an non admin user wants to revoke their own token
        */
       if (req.headers.IsAdmin || token.createdBy === req.user.id) {

--- a/api/v1/controllers/users.js
+++ b/api/v1/controllers/users.js
@@ -18,7 +18,6 @@ const doGet = require('../helpers/verbs/doGet');
 const doPatch = require('../helpers/verbs/doPatch');
 const doPost = require('../helpers/verbs/doPost');
 const doPut = require('../helpers/verbs/doPut');
-const authUtils = require('../helpers/authUtils');
 const u = require('../helpers/verbs/utils');
 
 module.exports = {
@@ -74,20 +73,11 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchUser(req, res, next) {
-
-    // Only an admin may modify a user's profile
-    if (req.body.profileId) {
-      authUtils.isAdmin(req)
-      .then((ok) => {
-        if (ok) {
-          doPatch(req, res, next, helper);
-        } else {
-          u.forbidden(next);
-        }
-      })
-      .catch((err) => {
-        u.forbidden(next);
-      });
+    if (req.headers.IsAdmin) {
+      doPatch(req, res, next, helper);
+    } else if (req.body.profileId && !req.headers.IsAdmin) {
+      // Only an admin may modify a user's profile
+      u.forbidden(next);
     } else {
       doPatch(req, res, next, helper);
     }
@@ -121,28 +111,18 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   putUser(req, res, next) {
-    authUtils.isAdmin(req)
-    .then((ok) => {
-      if (ok) {
-        doPut(req, res, next, helper);
-      } else {
-        /*
-         * normal user allow iff user PUTTing themself AND profileId does
-         * not change
-         */
-        authUtils.getUser(req)
-        .then((user) => {
-          if (req.swagger.params.key.value === user.name &&
-            user.profileId === req.body.profileId) {
-            doPut(req, res, next, helper);
-          } else {
-            u.forbidden(next);
-          }
-        });
-      }
-    })
-    .catch((err) => {
+    const user = req.user;
+    if (req.headers.IsAdmin) {
+      doPut(req, res, next, helper);
+    } else if (req.swagger.params.key.value === user.name &&
+      user.profileId === req.body.profileId) {
+      /*
+       * Allow normal user iff user PUTTing themself AND profileId does
+       * not change
+       */
+      doPut(req, res, next, helper);
+    } else {
       u.forbidden(next);
-    });
+    }
   },
 }; // exports

--- a/api/v1/helpers/verbs/postUtils.js
+++ b/api/v1/helpers/verbs/postUtils.js
@@ -12,7 +12,6 @@
 'use strict'; // eslint-disable-line strict
 const constants = require('../../constants');
 const logAPI = require('../../../../utils/apiLog').logAPI;
-const authUtils = require('../authUtils');
 const u = require('./utils');
 const featureToggles = require('feature-toggles');
 
@@ -24,16 +23,10 @@ const featureToggles = require('feature-toggles');
  */
 function makePostPromise(params, props, req) {
   const toPost = params.queryBody.value;
-  if (featureToggles.isFeatureEnabled('returnUser')) {
-    return authUtils.getUser(req)
-    .then((user) => {
-      if (user) {
-        toPost.createdBy = user.id;
-      }
 
-      return props.model.create(toPost, user);
-    }) // if no user found, create the model with the user
-    .catch(() => props.model.create(toPost));
+  if (featureToggles.isFeatureEnabled('returnUser')) {
+    toPost.createdBy = req.user.id;
+    return props.model.create(toPost, req.user);
   }
 
   return props.model.create(toPost);

--- a/tests/api/v1/users/patch.js
+++ b/tests/api/v1/users/patch.js
@@ -20,22 +20,21 @@ const expect = require('chai').expect;
 const jwtUtil = require('../../../../utils/jwtUtil');
 const Profile = tu.db.Profile;
 const User = tu.db.User;
-const Token = tu.db.Token;
+const OBAdminUser = require('../../../../config').db.adminUser;
 
 describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
-  const ZERO = 0;
   const ONE = 1;
   const TWO = 2;
   let profileOneId = '';
   let profileTwoId = '';
-  const OBAdminUser = require('../../../../config').db.adminUser;
   const userOne = `${tu.namePrefix}test@refocus.com`;
   const userTwo = `${tu.namePrefix}poop@refocus.com`;
   const userThree = `${tu.namePrefix}quote@refocus.com`;
   const tname = `${tu.namePrefix}Voldemort`;
   const pname = `${tu.namePrefix}testProfile`;
   const normalUserToken = jwtUtil.createToken(userOne, userOne);
-  /* out of the box admin user token */
+
+  // out of the box admin user token
   const OBAdminUserToken = jwtUtil.createToken(
     OBAdminUser.name, OBAdminUser.name
   );
@@ -57,14 +56,16 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         password: userOne,
       });
     })
-    /* another normal user */
+
+    // another normal user
     .then(() => User.create({
       profileId: profileTwoId,
       name: userTwo,
       email: userTwo,
       password: userTwo,
     }))
-    /* another normal user */
+
+    // another normal user
     .then(() => User.create({
       profileId: profileTwoId,
       name: userThree,
@@ -94,14 +95,16 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         },
       })
       .then((OBAdminUser) => adminProfileId = OBAdminUser.profileId)
-      /* create a normal user */
+
+      // create a normal user
       .then(() => User.create({
         profileId: profileOneId,
         name: userZero,
         email: userZero,
         password: userZero,
       }))
-      /* create a normal user */
+
+      // create a normal user
       .then(() => User.create({
         profileId: profileOneId,
         name: userFour,
@@ -128,7 +131,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         expect(res.body.errors).to.have.length(1);
         expect(res.body.errors)
         .to.have.deep.property('[0].type', 'AdminUpdateDeleteForbidden');
-        done();
+        return done();
       });
     });
 
@@ -143,7 +146,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         }
 
         expect(res.body.profileId).to.equal(profileTwoId);
-        done();
+        return done();
       });
     });
 
@@ -158,7 +161,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         }
 
         expect(res.body.profileId).to.equal(profileTwoId);
-        done();
+        return done();
       });
     });
   });
@@ -177,7 +180,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         expect(res.body.errors).to.have.length(1);
         expect(res.body.errors)
         .to.have.deep.property('[0].type', 'AdminUpdateDeleteForbidden');
-        done();
+        return done();
       });
     });
 
@@ -192,7 +195,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         }
 
         expect(res.body.profileId).to.equal(profileTwoId);
-        done();
+        return done();
       });
     });
   });
@@ -210,7 +213,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         }
 
         expect(res.body.name).to.equal(newName);
-        done();
+        return done();
       });
     });
 
@@ -227,7 +230,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
         expect(res.body.errors).to.have.length(1);
         expect(res.body.errors)
         .to.have.deep.property('[0].type', 'ForbiddenError');
-        done();
+        return done();
       });
     });
   });

--- a/tests/api/v1/verbs/doPost.js
+++ b/tests/api/v1/verbs/doPost.js
@@ -13,7 +13,6 @@
 const expect = require('chai').expect;
 const pu = require('../../../../api/v1/helpers/verbs/postUtils');
 
-
 describe('api/v1/helpers/verbs/postUtils.js, Tests >', () => {
   const ASPECT = {
     name: 'hello',

--- a/tests/api/v1/verbs/doPost.js
+++ b/tests/api/v1/verbs/doPost.js
@@ -11,11 +11,8 @@
  */
 'use strict';
 const expect = require('chai').expect;
-const sinon = require('sinon');
-const featureToggles = require('feature-toggles');
 const pu = require('../../../../api/v1/helpers/verbs/postUtils');
-const authUtils = require('../../../../api/v1/helpers/authUtils');
-const apiErrors = require('../../../../api/v1/apiErrors');
+
 
 describe('api/v1/helpers/verbs/postUtils.js, Tests >', () => {
   const ASPECT = {
@@ -46,43 +43,5 @@ describe('api/v1/helpers/verbs/postUtils.js, Tests >', () => {
       done();
     })
     .catch(done);
-  });
-
-  describe('stubbing authUtils: throw ForbiddenError', () => {
-    let authUtilsStub;
-    let featureToggleStub;
-    beforeEach(() => {
-      featureToggleStub = sinon.stub(featureToggles,
-        'isFeatureEnabled').returns(true);
-      authUtilsStub = sinon.stub(authUtils, 'getUser')
-        .returns(Promise.reject(new apiErrors.ForbiddenError()));
-    });
-    afterEach(() => {
-      featureToggleStub.restore();
-      authUtilsStub.restore();
-    });
-
-    it('makePostPromise: when POSTing a non-sample,' +
-      ' on forbidden error, return the expected promise', (done) => {
-      const expectedStr = 'made it to props.model.create';
-      const props = {
-        modelName: 'Aspect',
-        model: {
-          create: () => Promise.resolve(expectedStr),
-        },
-      };
-      const params = {
-        queryBody: {
-          value: ASPECT,
-        },
-      };
-
-      pu.makePostPromise(params, props, req)
-      .then((str) => {
-        expect(str).to.equal(expectedStr);
-        done();
-      })
-      .catch(done);
-    });
   });
 });


### PR DESCRIPTION
This is first of the many PRs to use the user information added to the request body and request headers instead of decoding the token everytime the user information is needed.