### PR TITLE
Remove the "cacheGetSamplesByNameWildcard" short-term toggle.

### DIFF
--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -23,7 +23,6 @@ const ZERO = 0;
  * @param  {Array} attributes - Resource fields array
  */
 function applyFieldListFilter(resource, attributes) {
-  // apply field list filter
   Object.keys(resource).forEach((field) => {
     if (!attributes.includes(field)) {
       delete resource[field];

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -114,10 +114,6 @@ const shortTermToggles = {
   logInvalidHmsetValues: environmentVariableTrue(pe,
     'LOG_INVALID_HMSET_VALUES'),
 
-  // Cache the GET request for samples with wildcard by name
-  cacheGetSamplesByNameWildcard: environmentVariableTrue(pe,
-    'CACHE_GET_SAMPLES_BY_NAME_WILDCARD'),
-
   // Enable GET from cache for /v1/subjects, /v1/subjects/{key}
   getSubjectFromCache: environmentVariableTrue(pe,
     'GET_SUBJECT_FROM_CACHE'),

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -20,13 +20,11 @@ const samstoinit = require('../../../../cache/sampleStoreInit');
 const expect = require('chai').expect;
 const redisCache = require('../../../../cache/redisCache').client.cache;
 const featureToggles = require('feature-toggles');
-const cacheGetSamplesByNameWildcard =
-  featureToggles.isFeatureEnabled('cacheGetSamplesByNameWildcard');
 const enableRedisSampleStore =
   featureToggles.isFeatureEnabled('enableRedisSampleStore');
 
 describe('tests/cache/models/samples/get.js, ' +
-`api::redisEnabled::GET ${path}`, () => {
+`api::redisEnabled::GET ${path} >`, () => {
   let userId;
   let token;
   const s1s2a1 = '___Subject1.___Subject2|___Aspect1';
@@ -49,7 +47,7 @@ describe('tests/cache/models/samples/get.js, ' +
     enableRedisSampleStore));
 
   describe('with returnUser toggle on, should return user object with ' +
-    'profile field: ', () => {
+    'profile field >', () => {
     const Aspect = tu.db.Aspect;
     const Subject = tu.db.Subject;
     const Sample = tu.db.Sample;
@@ -178,7 +176,7 @@ describe('tests/cache/models/samples/get.js, ' +
     });
   });
 
-  describe('with returnUser toggle OFF', () => {
+  describe('with returnUser toggle OFF >', () => {
     before(rtu.populateRedis);
     after(rtu.forceDelete);
 
@@ -681,15 +679,13 @@ describe('tests/cache/models/samples/get.js, ' +
   });
 });
 
-describe('tests/cache/models/samples/get.js, Basic Get with ' +
-  'cacheGetSamplesWildcard flag on', () => {
+describe('tests/cache/models/samples/get.js > cache the response >', () => {
   let token;
   const s1s2a1 = '___Subject1.___Subject2|___Aspect1';
   const s1s2a2 = '___Subject1.___Subject2|___Aspect2';
   const s1s3a1 = '___Subject1.___Subject3|___Aspect1';
 
   before((done) => {
-    tu.toggleOverride('cacheGetSamplesByNameWildcard', true);
     tu.toggleOverride('enableRedisSampleStore', true);
     tu.createToken()
     .then((returnedToken) => {
@@ -704,8 +700,6 @@ describe('tests/cache/models/samples/get.js, Basic Get with ' +
   after(tu.forceDeleteUser);
 
   after(() => {
-    tu.toggleOverride('cacheGetSamplesByNameWildcard',
-      cacheGetSamplesByNameWildcard);
     tu.toggleOverride('enableRedisSampleStore',
       enableRedisSampleStore);
   });
@@ -745,55 +739,6 @@ describe('tests/cache/models/samples/get.js, Basic Get with ' +
         (cacheErr, reply) => {
         if (cacheErr || !reply) {
           expect(res.body.length).to.be.equal(1);
-          expect(res.body[0].name).to.equal(s1s2a1);
-          return done();
-        }
-      });
-    });
-  });
-});
-
-describe('tests/cache/models/samples/get.js, Basic Get with ' +
-  'cacheGetSamplesWildcard flag off', () => {
-  let token;
-  const s1s2a1 = '___Subject1.___Subject2|___Aspect1';
-  const s1s2a2 = '___Subject1.___Subject2|___Aspect2';
-  const s1s3a1 = '___Subject1.___Subject3|___Aspect1';
-
-  before((done) => {
-    tu.toggleOverride('cacheGetSamplesByNameWildcard', false);
-    tu.toggleOverride('enableRedisSampleStore', true);
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
-      done();
-    })
-    .catch(done);
-  });
-
-  before(rtu.populateRedis);
-  after(rtu.forceDelete);
-  after(tu.forceDeleteUser);
-
-  after(() => {
-    tu.toggleOverride('cacheGetSamplesByNameWildcard',
-      cacheGetSamplesByNameWildcard);
-    tu.toggleOverride('enableRedisSampleStore',
-      enableRedisSampleStore);
-  });
-
-  it('get with wildcard should not cache response', (done) => {
-    api.get(`${path}?name=___Subj*`)
-    .set('Authorization', token)
-    .expect(constants.httpStatus.OK)
-    .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
-
-      redisCache.get('___Subj*', (cacheErr, reply) => {
-        if (cacheErr || !reply) {
-          expect(res.body.length).to.be.equal(3);
           expect(res.body[0].name).to.equal(s1s2a1);
           return done();
         }

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -679,7 +679,7 @@ describe('tests/cache/models/samples/get.js, ' +
   });
 });
 
-describe.only('tests/cache/models/samples/get.js > cache the response >', () => {
+describe('tests/cache/models/samples/get.js > cache the response >', () => {
   let token;
   const s1s2a1 = '___Subject1.___Subject2|___Aspect1';
   const s1s2a2 = '___Subject1.___Subject2|___Aspect2';


### PR DESCRIPTION
Standard behavior now is to cache the response from a samples query if using wildcard search by name. The field list must also match to return a cached response.