### PR TITLE
Encode additional information for user tracking in token payload

### DIFF
--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -117,7 +117,7 @@ function postCollector(req, res, next) {
      * special token for that collector to use for all further communication
      */
     o.dataValues.token = jwtUtil
-      .createToken(toPost.name, toPost.name);
+      .createToken(toPost.name, toPost.name, { IsCollector: true });
     return res.status(httpStatus.CREATED)
       .json(u.responsify(o, helper, req.method));
   })

--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -349,8 +349,9 @@ function startCollector(req, res, next) {
          * When a collector registers itself with Refocus, Refocus sends back a
          * special token for that collector to use for all subsequent heartbeats.
          */
-        collector.dataValues.token = jwtUtil
-          .createToken(requestBody.name, requestBody.name);
+        collector.dataValues.token = jwtUtil.createToken(
+          requestBody.name, requestBody.name, { IsCollector: true }
+        );
         return res.status(httpStatus.OK)
           .json(u.responsify(collector, helper, req.method));
       });
@@ -376,7 +377,9 @@ function startCollector(req, res, next) {
   })
   .then(() => returnedCollector.update(requestBody))
   .then((retVal) => {
-    retVal.dataValues.token = jwtUtil.createToken(retVal.name, retVal.name);
+    retVal.dataValues.token = jwtUtil.createToken(
+      retVal.name, retVal.name, { IsCollector: true }
+    );
     return res.status(httpStatus.OK)
       .json(u.responsify(retVal, helper, req.method));
   })

--- a/api/v1/controllers/tokens.js
+++ b/api/v1/controllers/tokens.js
@@ -18,6 +18,7 @@ const doGet = require('../helpers/verbs/doGet');
 const jwtUtil = require('../../../utils/jwtUtil');
 const u = require('../helpers/verbs/utils');
 const httpStatus = require('../constants').httpStatus;
+const Profile = require('../helpers/nouns/profiles').model;
 
 module.exports = {
 
@@ -80,14 +81,23 @@ module.exports = {
 
     // create token to be returned in response.
     const tokenName = req.swagger.params.queryBody.value.name;
-    const token = jwtUtil.createToken(
-      tokenName, user.name
-    );
+    let token;
+    Profile.isAdmin(user.profileId)
+    .then((isAdmin) => {
+      const payloadObj = {
+        ProfileName: user.profile.name,
+        IsAdmin: isAdmin,
+      };
 
-    // create token object in db
-    return helper.model.create({
-      name: tokenName,
-      createdBy: user.id,
+      token = jwtUtil.createToken(
+        tokenName, user.name, payloadObj
+      );
+
+      // create token object in db
+      return helper.model.create({
+        name: tokenName,
+        createdBy: user.id,
+      });
     })
     .then((createdToken) => {
       resultObj.dbTime = new Date() - resultObj.reqStartTime;

--- a/config/passportconfig.js
+++ b/config/passportconfig.js
@@ -71,9 +71,11 @@ module.exports = (passportModule) => {
     })
     .then((profile) =>
 
-      // if non-sso register, create new user and token object.
-      // Note: Used User.findById after creation so that we can get profile
-      // attached to user object.
+    /**
+     * if non-sso register, create new user and token object.
+     * Note: Used User.findById after creation so that we can get profile
+     * attached to user object.
+     */
       User.create({
         profileId: profile.id,
         name: userName,

--- a/jobQueue/jobWrapper.js
+++ b/jobQueue/jobWrapper.js
@@ -126,10 +126,13 @@ function logJobOnComplete(req, job) {
       }
 
       logObject.ipAddress = activityLogUtil.getIPAddrFromReq(req);
-      const tokenDetails = jwtUtil.getTokenDetailsFromRequest(req);
-      logObject.user = tokenDetails.username;
-      logObject.token = tokenDetails.tokenname;
 
+      /**
+       * we already set UserName and TokenName in req headers when verifying
+       * token
+       */
+      logObject.user = req.headers.UserName;
+      logObject.token = req.headers.TokenName;
     }
 
     // continue to update and print logObject on job completion.

--- a/tests/api/v1/admin/rebuildSampleStore.js
+++ b/tests/api/v1/admin/rebuildSampleStore.js
@@ -23,7 +23,6 @@ const Subject = tu.db.Subject;
 const Sample = tu.db.Sample;
 const jwtUtil = require('../../../../utils/jwtUtil');
 const path = '/v1/admin/sampleStore/rebuild';
-const adminUser = require('../../../../config').db.adminUser;
 const expect = require('chai').expect;
 const initialFeatureState = featureToggles
   .isFeatureEnabled(sampleStore.constants.featureName);
@@ -31,9 +30,7 @@ const initialFeatureState = featureToggles
 describe('tests/api/v1/admin/rebuildSampleStore.js >', () => {
   describe(`POST ${path} (feature is off) >`, () => {
     let token;
-    const predefinedAdminUserToken = jwtUtil.createToken(
-      adminUser.name, adminUser.name
-    );
+    const predefinedAdminUserToken = tu.createAdminToken();
     const uname = `${tu.namePrefix}test@test.com`;
     let testUserToken = '';
 
@@ -89,9 +86,7 @@ describe('tests/api/v1/admin/rebuildSampleStore.js >', () => {
 
   describe(`POST ${path} (feature is on) >`, () => {
     let token;
-    const predefinedAdminUserToken = jwtUtil.createToken(
-      adminUser.name, adminUser.name
-    );
+    const predefinedAdminUserToken = tu.createAdminToken();
     const uname = `${tu.namePrefix}test@test.com`;
     let testUserToken = '';
     let a1;

--- a/tests/api/v1/aspects/postWithCreatedBy.js
+++ b/tests/api/v1/aspects/postWithCreatedBy.js
@@ -11,25 +11,16 @@
  */
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
-const adminUser = require('../../../../config').db.adminUser;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/aspects';
-const Aspect = tu.db.Aspect;
 const expect = require('chai').expect;
-const ZERO = 0;
-const ONE = 1;
-const tokenPath = '/v1/tokens';
 
 describe('tests/api/v1/aspects/postWithCreatedBy.js, ' + path + ' >', () => {
   let token;
   let user;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
   before((done) => {
     tu.toggleOverride('returnUser', true);
     tu.createUserAndToken()

--- a/tests/api/v1/bots/post.js
+++ b/tests/api/v1/bots/post.js
@@ -47,11 +47,11 @@ describe('tests/api/v1/bots/post.js >', () => {
         return done(err);
       }
 
-      const botToken = jwtUtil
-        .createToken(u.name, u.name);
       const fakeToken = jwtUtil
         .createToken(u.name + 'Fail', u.name + 'Fail');
-      expect(res.body.token).to.equal(botToken);
+
+      // since createToken uses current timestamp, the token value is not fixed.
+      expect(res.body.token).to.not.equal(undefined);
       expect(res.body.token).to.not.equal(fakeToken);
       expect(res.body.name).to.equal(u.name);
       expect(res.body.ui.name).to.equal('uiBlob');

--- a/tests/api/v1/generatorTemplates/postWithCreatedBy.js
+++ b/tests/api/v1/generatorTemplates/postWithCreatedBy.js
@@ -11,8 +11,6 @@
  */
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
-const adminUser = require('../../../../config').db.adminUser;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
@@ -23,9 +21,6 @@ const expect = require('chai').expect;
 describe('tests/api/v1/generatorTemplates/postWithCreatedBy.js > ', () => {
   let token;
   let user;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
   const generatorTemplateToCreate = u.getGeneratorTemplate();
   before((done) => {
     tu.toggleOverride('returnUser', true);

--- a/tests/api/v1/generators/postWithCreatedBy.js
+++ b/tests/api/v1/generators/postWithCreatedBy.js
@@ -11,8 +11,6 @@
  */
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
-const adminUser = require('../../../../config').db.adminUser;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
@@ -25,9 +23,6 @@ const expect = require('chai').expect;
 describe('tests/api/v1/generators/postWithCreatedBy.js >', () => {
   let token;
   let user;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
 
   const generatorToCreate = u.getGenerator();
   const generatorTemplate = gtUtil.getGeneratorTemplate();

--- a/tests/api/v1/globalconfig/delete.js
+++ b/tests/api/v1/globalconfig/delete.js
@@ -13,21 +13,17 @@
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/globalconfig';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const ZERO = 0;
 const ONE = 1;
 
 describe('tests/api/v1/globalconfig/delete.js >', () => {
   let token;
   const uname = `${tu.namePrefix}test@test.com`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
   const config = tu.namePrefix + '_GLOBAL_CONFIG_ABC';
 

--- a/tests/api/v1/globalconfig/get.js
+++ b/tests/api/v1/globalconfig/get.js
@@ -13,19 +13,15 @@
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/globalconfig';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
 
 describe('tests/api/v1/globalconfig/get.js >', () => {
   let token;
   const uname = `${tu.namePrefix}test@test.com`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
 
   before((done) => {

--- a/tests/api/v1/globalconfig/patch.js
+++ b/tests/api/v1/globalconfig/patch.js
@@ -13,20 +13,16 @@
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/globalconfig';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
 
 describe('tests/api/v1/globalconfig/patch.js >', () => {
   let token;
   const uname = `${tu.namePrefix}test@test.com`;
   let testUserToken = '';
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   const GLOBAL_CONFIG = tu.namePrefix + '_GLOBAL_CONFIG_ABC';
 
   before((done) => {

--- a/tests/api/v1/globalconfig/post.js
+++ b/tests/api/v1/globalconfig/post.js
@@ -13,20 +13,16 @@
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/globalconfig';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const ZERO = 0;
 
 describe('tests/api/v1/globalconfig/post.js >', () => {
   let token;
   const key = `${tu.namePrefix}_GLOBAL_CONFIG_ABC`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   const uname = `${tu.namePrefix}test@test.com`;
   let testUserToken = '';
 

--- a/tests/api/v1/lenses/postWithinstalledBy.js
+++ b/tests/api/v1/lenses/postWithinstalledBy.js
@@ -11,8 +11,6 @@
  */
 'use strict'; // eslint-disable-line strict
 const featureToggles = require('feature-toggles');
-const adminUser = require('../../../../config').db.adminUser;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
@@ -25,9 +23,7 @@ const ZERO = 0;
 describe('tests/api/v1/lenses/postWithInstalledBy.js >', () => {
   let token;
   let user;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
 
   before((done) => {
     tu.toggleOverride('returnUser', true);

--- a/tests/api/v1/profiles/delete.js
+++ b/tests/api/v1/profiles/delete.js
@@ -19,13 +19,9 @@ const u = require('./utils');
 const path = '/v1/profiles';
 const Profile = tu.db.Profile;
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 
 describe('tests/api/v1/profiles/delete.js >', () => {
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let token;
   const p0 = { name: `${tu.namePrefix}1` };
 

--- a/tests/api/v1/profiles/post.js
+++ b/tests/api/v1/profiles/post.js
@@ -18,13 +18,9 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/profiles';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 
 describe('tests/api/v1/profiles/post.js >', () => {
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let token;
   const p0 = { name: `${tu.namePrefix}1` };
 

--- a/tests/api/v1/profiles/put.js
+++ b/tests/api/v1/profiles/put.js
@@ -17,9 +17,7 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/profiles';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const adminProfile = require('../../../../config').db.adminProfile;
-const adminUser = require('../../../../config').db.adminUser;
 const Profile = tu.db.Profile;
 
 describe('tests/api/v1/profiles/put.js >', () => {
@@ -27,9 +25,7 @@ describe('tests/api/v1/profiles/put.js >', () => {
   const pname = `${tu.namePrefix}testProfile`;
   const newName = pname + '2';
   /* out of the box admin user token */
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
 
   beforeEach((done) => {
     // Create profile __testProfile

--- a/tests/api/v1/samples/upsertWithProvider.js
+++ b/tests/api/v1/samples/upsertWithProvider.js
@@ -16,13 +16,10 @@ const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const expect = require('chai').expect;
-const ZERO = 0;
 const Sample = tu.db.Sample;
 const Aspect = tu.db.Aspect;
 const Subject = tu.db.Subject;
-const adminUser = require('../../../../config').db.adminUser;
-const predefinedAdminUserToken =
-  tu.createTokenFromUserName(adminUser.name, adminUser.name);
+const predefinedAdminUserToken = tu.createAdminToken();
 
 describe(`tests/api/v1/samples/upsertWithProvider.js, upsert without cache >`,
 () => {

--- a/tests/api/v1/ssoconfig/delete.js
+++ b/tests/api/v1/ssoconfig/delete.js
@@ -14,20 +14,14 @@ const expect = require('chai').expect;
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/ssoconfig';
-const jwtUtil = require('../../../../utils/jwtUtil');
-const ZERO = 0;
 const ONE = 1;
 
 describe(`tests/api/v1/ssoconfig/delete.js, DELETE ${path} >`, () => {
   let token;
-  const uname = `${tu.namePrefix}test@test.com`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
 
   before((done) => {

--- a/tests/api/v1/ssoconfig/patch.js
+++ b/tests/api/v1/ssoconfig/patch.js
@@ -14,20 +14,14 @@ const expect = require('chai').expect;
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/ssoconfig';
-const jwtUtil = require('../../../../utils/jwtUtil');
-const ZERO = 0;
 const ONE = 1;
 
 describe(`tests/api/v1/ssoconfig/patch.js, PATCH ${path} >`, () => {
   let token;
-  const uname = `${tu.namePrefix}test@test.com`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
 
   before((done) => {

--- a/tests/api/v1/ssoconfig/post.js
+++ b/tests/api/v1/ssoconfig/post.js
@@ -14,20 +14,14 @@ const expect = require('chai').expect;
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/ssoconfig';
-const jwtUtil = require('../../../../utils/jwtUtil');
-const ZERO = 0;
 const ONE = 1;
 
 describe(`tests/api/v1/ssoconfig/post.js, POST ${path} >`, () => {
   let token;
-  const uname = `${tu.namePrefix}test@test.com`;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
 
   before((done) => {

--- a/tests/api/v1/ssoconfig/put.js
+++ b/tests/api/v1/ssoconfig/put.js
@@ -14,19 +14,14 @@ const expect = require('chai').expect;
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
-const adminUser = require('../../../../config').db.adminUser;
 const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/ssoconfig';
-const jwtUtil = require('../../../../utils/jwtUtil');
-const ZERO = 0;
 const ONE = 1;
 
 describe(`tests/api/v1/ssoconfig/put.js, PUT ${path} >`, () => {
   let token;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   let testUserToken = '';
 
   before((done) => {

--- a/tests/api/v1/subjects/postWithCreatedBy.js
+++ b/tests/api/v1/subjects/postWithCreatedBy.js
@@ -12,24 +12,17 @@
 'use strict';
 const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
-const adminUser = require('../../../../config').db.adminUser;
-const jwtUtil = require('../../../../utils/jwtUtil');
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const Subject = tu.db.Subject;
 const path = '/v1/subjects';
 const expect = require('chai').expect;
-const ZERO = 0;
 
 describe('tests/api/v1/subjects/postWithCreatedBy.js, returnUser toggle on >',
 () => {
   let token;
   let user;
   const n2b = { name: `${tu.namePrefix}Quebec` };
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
 
   before((done) => {
     tu.toggleOverride('returnUser', true);

--- a/tests/api/v1/tokens/delete.js
+++ b/tests/api/v1/tokens/delete.js
@@ -17,11 +17,8 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/tokens';
 const expect = require('chai').expect;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 const regPath = '/v1/register';
 const tokenPath = '/v1/tokens';
-const Token = tu.db.Token;
 
 describe(`tests/api/v1/tokens/delete.js, DELETE ${path} >`, () => {
   /* user uname has 2 tokens: Voldemort and Tom
@@ -29,8 +26,7 @@ describe(`tests/api/v1/tokens/delete.js, DELETE ${path} >`, () => {
   const uname = `${tu.namePrefix}test@refocus.com`;
   const tname1 = `${tu.namePrefix}Voldemort`;
   const tname2 = `${tu.namePrefix}Tom`;
-  const predefinedAdminUserToken =
-    jwtUtil.createToken(adminUser.name, adminUser.name);
+  const predefinedAdminUserToken = tu.createAdminToken();
   let userToken = '';
   let tid1;
   let tid2;

--- a/tests/api/v1/tokens/revokeRestore.js
+++ b/tests/api/v1/tokens/revokeRestore.js
@@ -20,13 +20,10 @@ const expect = require('chai').expect;
 const Profile = tu.db.Profile;
 const User = tu.db.User;
 const Token = tu.db.Token;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 
 describe('tests/api/v1/tokens/revokeRestore.js, ' +
 `api: POST ${path}/:id/revoke and POST ${path}/:id/restore >`, () => {
-  const predefinedAdminUserToken =
-    jwtUtil.createToken(adminUser.name, adminUser.name);
+  const predefinedAdminUserToken = tu.createAdminToken();
   let usr;
   let tid;
 

--- a/tests/api/v1/userTokens/delete.js
+++ b/tests/api/v1/userTokens/delete.js
@@ -18,16 +18,12 @@ const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
 
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 const regPath = '/v1/register';
 const tokenPath = '/v1/tokens';
 
 describe('tests/api/v1/userTokens/delete.js, ' +
 `DELETE ${path}/U/tokens/T >`, () => {
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
 
   /* user uname has 2 tokens: Voldemort and Tom
    user with unameOther has 1 token: Dumbledore */

--- a/tests/api/v1/userTokens/revokeRestore.js
+++ b/tests/api/v1/userTokens/revokeRestore.js
@@ -17,19 +17,12 @@ const tu = require('../../../testUtils');
 const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
-const Profile = tu.db.Profile;
-const User = tu.db.User;
-const Token = tu.db.Token;
-const jwtUtil = require('../../../../utils/jwtUtil');
-const adminUser = require('../../../../config').db.adminUser;
 const registerPath = '/v1/register';
 const tokenPath = '/v1/tokens';
 
 describe('tests/api/v1/userTokens/revokeRestore.js, ' +
 `POST ${path}/U/tokens/T/[revoke|restore] >`, () => {
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
   const uname = `${tu.namePrefix}test@refocus.com`;
   const tname = `${tu.namePrefix}Voldemort`;
   let userId;

--- a/tests/api/v1/users/patch.js
+++ b/tests/api/v1/users/patch.js
@@ -20,6 +20,7 @@ const expect = require('chai').expect;
 const jwtUtil = require('../../../../utils/jwtUtil');
 const Profile = tu.db.Profile;
 const User = tu.db.User;
+const OBAdminProfile = require('../../../../config').db.adminProfile;
 const OBAdminUser = require('../../../../config').db.adminUser;
 
 describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
@@ -35,9 +36,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
   const normalUserToken = jwtUtil.createToken(userOne, userOne);
 
   // out of the box admin user token
-  const OBAdminUserToken = jwtUtil.createToken(
-    OBAdminUser.name, OBAdminUser.name
-  );
+  const OBAdminUserToken = tu.createAdminToken();
 
   before((done) => {
     Profile.create({ name: pname + ONE })
@@ -82,7 +81,7 @@ describe(`tests/api/v1/users/patch.js, PATCH ${path} >`, () => {
     const userFour = `${tu.namePrefix}wwwwww@refocus.com`;
     const userZero = `${tu.namePrefix}fffffff@refocus.com`;
     const adminUserToken = jwtUtil.createToken(
-      userFour, userFour
+      userFour, userFour, { IsAdmin: true, ProfileName: OBAdminProfile.name }
     );
 
     before((done) => {

--- a/tests/api/v1/users/put.js
+++ b/tests/api/v1/users/put.js
@@ -18,9 +18,9 @@ const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
 const jwtUtil = require('../../../../utils/jwtUtil');
+const OBAdminProfile = require('../../../../config').db.adminProfile;
 const Profile = tu.db.Profile;
 const User = tu.db.User;
-const Token = tu.db.Token;
 
 describe(`tests/api/v1/users/put.js, PUT ${path} >`, () => {
   const ZERO = 0;
@@ -36,9 +36,7 @@ describe(`tests/api/v1/users/put.js, PUT ${path} >`, () => {
   const tname = `${tu.namePrefix}Voldemort`;
   const pname = `${tu.namePrefix}testProfile`;
   /* out of the box admin user token */
-  const OBAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const OBAdminUserToken = tu.createAdminToken();
 
   before((done) => {
     Profile.create({ name: pname + ONE })
@@ -84,7 +82,7 @@ describe(`tests/api/v1/users/put.js, PUT ${path} >`, () => {
     const userFour = `${tu.namePrefix}wwwwww@refocus.com`;
     const userZero = `${tu.namePrefix}fffffff@refocus.com`;
     const adminUserToken = jwtUtil.createToken(
-      userFour, userFour
+      userFour, userFour, { IsAdmin: true, ProfileName: OBAdminProfile.name }
     );
 
     before((done) => {

--- a/tests/enforceToken/revoke.js
+++ b/tests/enforceToken/revoke.js
@@ -7,23 +7,19 @@
  */
 
 /**
- * tests/tokenReq/api/token/revoke.js
+ * tests/enforceToken/revoke.js
  */
 const expect = require('chai').expect;
 const supertest = require('supertest');
 const api = supertest(require('../../index').app);
-const adminUser = require('../../config').db.adminUser;
 const constants = require('../../api/v1/constants');
-const jwtUtil = require('../../utils/jwtUtil');
 const u = require('../testUtils');
 const registerPath = '/v1/register';
 const tokenPath = '/v1/tokens';
 
 describe('tests/enforceToken/revoke.js, enforceToken: revoke >', () => {
   let defaultToken;
-  const predefinedAdminUserToken = jwtUtil.createToken(
-    adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = u.createAdminToken();
 
   beforeEach((done) => {
     api.post(registerPath)

--- a/tests/limiter/limiter.js
+++ b/tests/limiter/limiter.js
@@ -16,10 +16,7 @@ const constants = require('../../api/v1/constants');
 const tu = require('../testUtils');
 const u = require('./utils');
 const path = '/v1/aspects';
-const Aspect = tu.db.Aspect;
 const expect = require('chai').expect;
-const jwtUtil = require('../../utils/jwtUtil');
-const adminUser = require('../../config').db.adminUser;
 
 describe('tests/limiter/limiter.js >', () => {
   let token;
@@ -36,8 +33,7 @@ describe('tests/limiter/limiter.js >', () => {
     .then((tok2) => {
       token2 = tok2;
     })
-    .then(() => predefinedAdminUserToken = jwtUtil
-      .createToken(adminUser.name, adminUser.name))
+    .then(() => predefinedAdminUserToken = tu.createAdminToken())
     .then(() => done())
     .catch(done);
   });

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -19,6 +19,8 @@ const db = require('../db');
 const testStartTime = new Date();
 const userName = `${pfx}testUser@refocus.com`;
 const featureToggles = require('feature-toggles');
+const adminUser = require('../config').db.adminUser;
+const adminProfile = require('../config').db.adminProfile;
 
 /**
  * Performs a regex test on the key to determine whether it looks like a
@@ -167,6 +169,15 @@ module.exports = {
     }))
     .then(() => jwtUtil.createToken(userName, userName));
   }, // createToken
+
+  // create admin token
+  createAdminToken() {
+    return jwtUtil.createToken(
+      adminUser.name,
+      adminUser.name,
+      { IsAdmin: true, ProfileName: adminProfile.name }
+    );
+  }, // createAdminToken
 
   // delete user
   forceDeleteUser(done) {

--- a/tests/utils/jwtUtil.js
+++ b/tests/utils/jwtUtil.js
@@ -13,12 +13,18 @@
 const expect = require('chai').expect;
 const jwtUtil = require('../../utils/jwtUtil');
 const tu = require('../testUtils');
+const jwt = require('jsonwebtoken');
+const Promise = require('bluebird');
+const jwtVerifyAsync = Promise.promisify(jwt.verify);
+const conf = require('../../config');
+const adminUser = require('../../config').db.adminUser;
+const secret = conf.environment[conf.nodeEnv].tokenSecret;
 const Bot = tu.db.Bot;
 const n = `${tu.namePrefix}Testing`;
 const User = tu.db.User;
 const Profile = tu.db.Profile;
 const Collector = tu.db.Collector;
-const adminUser = require('../../config').db.adminUser;
+
 
 describe('tests/utils/jwtUtil.js >', () => {
   const newBot = {
@@ -31,11 +37,10 @@ describe('tests/utils/jwtUtil.js >', () => {
   let collectorInst;
   let userToken;
   let collectorToken;
+  let profile;
   const testStartTime = new Date();
 
-  const predefinedAdminUserToken = jwtUtil.createToken(
-      adminUser.name, adminUser.name
-  );
+  const predefinedAdminUserToken = tu.createAdminToken();
 
   // dummy callback that returns a promise.
   const dummyCallback = function dummy () {
@@ -46,12 +51,15 @@ describe('tests/utils/jwtUtil.js >', () => {
 
   before((done) => {
     Profile.create({ name: tu.namePrefix + 'myProfile' })
-    .then((createdProfile) => User.create({
-      email: 'testToken@refocus.com',
-      profileId: createdProfile.id,
-      name: `${tu.namePrefix}myRefocusUser`,
-      password: 'abcd',
-    }))
+    .then((createdProfile) => {
+      profile = createdProfile;
+      return User.create({
+        email: 'testToken@refocus.com',
+        profileId: createdProfile.id,
+        name: `${tu.namePrefix}myRefocusUser`,
+        password: 'abcd',
+      });
+    })
     .then((user) => {
       userInst = user;
       return Collector.create({
@@ -62,11 +70,17 @@ describe('tests/utils/jwtUtil.js >', () => {
     })
     .then((collector) => {
       collectorInst = collector;
-      return tu.createTokenFromUserName(userInst.name);
+      return jwtUtil.createToken(
+        userInst.name,
+        userInst.name,
+        { IsAdmin: false, ProfileName: profile.name }
+      );
     })
     .then((token) => {
       userToken = token;
-      return tu.createTokenFromUserName(collectorInst.name);
+      return jwtUtil.createToken(
+        collectorInst.name, collectorInst.name, { IsCollector: true }
+      );
     })
     .then((token) => {
       collectorToken = token;
@@ -175,6 +189,137 @@ describe('tests/utils/jwtUtil.js >', () => {
         expect(request.headers.TokenName).to.equal(undefined);
         return done();
       }).catch(done);
+    });
+  });
+
+  describe('createToken tests', () => {
+    it('No additional payload - no extra headers set',
+    (done) => {
+      const token = jwtUtil.createToken('myTokenName', 'myUserName');
+      jwtVerifyAsync(token, secret, {})
+      .then((decodedData) => {
+        expect(decodedData.username).to.be.equal('myUserName');
+        expect(decodedData.tokenname).to.be.equal('myTokenName');
+        expect(decodedData.timestamp).to.be.an('number');
+        expect(decodedData.ProfileName).to.be.equal(undefined);
+        expect(decodedData.IsAdmin).to.be.equal(undefined);
+        expect(decodedData.isBot).to.be.equal(undefined);
+        expect(decodedData.IsCollector).to.be.equal(undefined);
+        return done();
+      }).catch(done);
+    });
+
+    it('With payload - all headers in payload present in default headers',
+    (done) => {
+      const token = jwtUtil.createToken(
+        'myTokenName',
+        'myUserName',
+        { ProfileName: 'myProfile', IsAdmin: false }
+      );
+      jwtVerifyAsync(token, secret, {})
+      .then((decodedData) => {
+        expect(decodedData.username).to.be.equal('myUserName');
+        expect(decodedData.tokenname).to.be.equal('myTokenName');
+        expect(decodedData.timestamp).to.be.an('number');
+        expect(decodedData.ProfileName).to.be.equal('myProfile');
+        expect(decodedData.IsAdmin).to.be.equal(false);
+        expect(decodedData.isBot).to.be.equal(undefined);
+        expect(decodedData.IsCollector).to.be.equal(undefined);
+        return done();
+      }).catch(done);
+    });
+
+    it('With payload - some headers in payload present in default headers',
+    (done) => {
+      const token = jwtUtil.createToken(
+        'myTokenName',
+        'myUserName',
+        { IsCollector: true, RandomHeader: 'randomStr' }
+      );
+      jwtVerifyAsync(token, secret, {})
+      .then((decodedData) => {
+        expect(decodedData.username).to.be.equal('myUserName');
+        expect(decodedData.tokenname).to.be.equal('myTokenName');
+        expect(decodedData.timestamp).to.be.an('number');
+        expect(decodedData.IsCollector).to.be.equal(true);
+        expect(decodedData.ProfileName).to.be.equal(undefined);
+        expect(decodedData.IsAdmin).to.be.equal(undefined);
+        expect(decodedData.isBot).to.be.equal(undefined);
+        expect(decodedData.RandomHeader).to.be.equal(undefined);
+        return done();
+      }).catch(done);
+    });
+
+    it('Create token with empty payload', (done) => {
+      const token = jwtUtil.createToken('myTokenName', 'myUserName', {});
+      jwtVerifyAsync(token, secret, {})
+      .then((decodedData) => {
+        expect(decodedData.username).to.be.equal('myUserName');
+        expect(decodedData.tokenname).to.be.equal('myTokenName');
+        expect(decodedData.timestamp).to.be.an('number');
+        expect(decodedData.ProfileName).to.be.equal(undefined);
+        expect(decodedData.IsAdmin).to.be.equal(undefined);
+        expect(decodedData.isBot).to.be.equal(undefined);
+        expect(decodedData.IsCollector).to.be.equal(undefined);
+        return done();
+      }).catch(done);
+    });
+  });
+
+  describe('assignHeaderValues tests', () => {
+    it('decodedTokenData empty', (done) => {
+      const req = { headers: {} };
+      jwtUtil.assignHeaderValues(req, {});
+      expect(req.headers.UserName).to.be.equal(undefined);
+      expect(req.headers.TokenName).to.be.equal(undefined);
+      expect(req.headers.ProfileName).to.be.equal('');
+      expect(req.headers.IsAdmin).to.be.equal(false);
+      expect(req.headers.IsCollector).to.be.equal(false);
+      expect(req.headers.IsBot).to.be.equal(false);
+      return done();
+    });
+
+    it('decodedTokenData with all valid headers', (done) => {
+      const req = { headers: {} };
+      jwtUtil.assignHeaderValues(
+        req,
+        {
+          username: 'myUserName',
+          tokenname: 'myTokenName',
+          IsAdmin: true,
+          ProfileName: 'Admin',
+        }
+      );
+      expect(req.headers.UserName).to.be.equal('myUserName');
+      expect(req.headers.TokenName).to.be.equal('myTokenName');
+      expect(req.headers.ProfileName).to.be.equal('Admin');
+      expect(req.headers.IsAdmin).to.be.equal(true);
+      expect(req.headers.IsCollector).to.be.equal(false);
+      expect(req.headers.IsBot).to.be.equal(false);
+      return done();
+    });
+
+    it('decodedTokenData with some invalid headers - invalid headers ignored',
+    (done) => {
+      const req = { headers: {} };
+      jwtUtil.assignHeaderValues(
+        req,
+        {
+          username: 'myUserName',
+          tokenname: 'myTokenName',
+          IsAdmin: true,
+          ProfileName: 'Admin',
+          Random: 'randomVal', //ignored
+        }
+      );
+      expect(req.headers.UserName).to.be.equal('myUserName');
+      expect(req.headers.TokenName).to.be.equal('myTokenName');
+      expect(req.headers.ProfileName).to.be.equal('Admin');
+      expect(req.headers.IsAdmin).to.be.equal(true);
+      expect(req.headers.IsCollector).to.be.equal(false);
+      expect(req.headers.IsBot).to.be.equal(false);
+      expect(req.headers.Random).to.be.equal(undefined);
+      return done();
     });
   });
 });

--- a/utils/apiLog.js
+++ b/utils/apiLog.js
@@ -110,9 +110,12 @@ function logAPI(req, resultObj, retval, recordCountOverride) {
       logObject.request_id = req.headers['x-request-id'];
     }
 
-    const tokenDetails = jwtUtil.getTokenDetailsFromRequest(req);
-    logObject.user = tokenDetails.username;
-    logObject.token = tokenDetails.tokenname;
+    /**
+     * we already set UserName and TokenName in req headers when verifying
+     * token
+     */
+    logObject.user = req.headers.UserName;
+    logObject.token = req.headers.TokenName;
 
     combineAndLog(resultObj, logObject, obj, recordCountOverride);
   }

--- a/utils/jwtUtil.js
+++ b/utils/jwtUtil.js
@@ -19,9 +19,16 @@ const User = require('../db/index').User;
 const Token = require('../db/index').Token;
 const Collector = require('../db/index').Collector;
 const Bot = require('../db/index').Bot;
-const Profile = require('../db/index').Profile;
 const Promise = require('bluebird');
 const jwtVerifyAsync = Promise.promisify(jwt.verify);
+
+// these headers will be assigned default values if not present in token.
+const headersWithDefaults = {
+  ProfileName: '',
+  IsAdmin: false,
+  IsCollector: false,
+  IsBot: false,
+};
 
 /**
  * Adds a key and its value to the passed in object.
@@ -35,35 +42,32 @@ function assignKeyValue(object, key, value) {
 } // assignKeyValue
 
 /**
- * Assigns user related information to the request header.
- * @param  {Object}  req  - The request object
- * @param  {String}  tokenName - Token name parsed from the token
- * @param  {Boolean} isAdmin  - Flag to indicate if the request was made by an
- * Admin user
+ * Assign request headers using token info
+ * @param  {Object} req - Request object
+ * @param  {Object} decodedTokenData - decoded data from token
  */
-function assignUserHeaders(req, tokenName, isAdmin) {
-  assignKeyValue(req.headers, 'UserName', req.user.name);
-  assignKeyValue(req.headers, 'TokenName', tokenName);
-  assignKeyValue(req.headers, 'ProfileName', req.user.profile.name);
-  assignKeyValue(req.headers, 'IsAdmin', isAdmin);
-  assignKeyValue(req.headers, 'IsCollector', false);
-  assignKeyValue(req.headers, 'IsBot', false);
-} // assignUserHeaders
+function assignHeaderValues(req, decodedTokenData) {
+  // username and tokenname should always be there if createToken function is
+  // used for creating token
+  if (decodedTokenData.username) {
+    assignKeyValue(req.headers, 'UserName', decodedTokenData.username);
+  }
 
-/**
- * Assigns collector related information to the request header
- * @param  {Object} req - The request object
- * @param  {String} userName  - The username parsed from the token
- * @param  {String} tokenName - The tokenname parsed from the token
- */
-function assignCollectorHeaders(req, userName, tokenName) {
-  assignKeyValue(req.headers, 'UserName', userName);
-  assignKeyValue(req.headers, 'TokenName', tokenName);
-  assignKeyValue(req.headers, 'ProfileName', '');
-  assignKeyValue(req.headers, 'IsCollector', true);
-  assignKeyValue(req.headers, 'IsAdmin', false);
-  assignKeyValue(req.headers, 'IsBot', false);
-} // assignCollectorHeaders
+  if (decodedTokenData.tokenname) {
+    assignKeyValue(req.headers, 'TokenName', decodedTokenData.tokenname);
+  }
+
+  Object.keys(headersWithDefaults).forEach((headerName) => {
+    let headerValue;
+    if (decodedTokenData.hasOwnProperty(headerName)) {
+      headerValue = decodedTokenData[headerName];
+    } else {
+      headerValue = headersWithDefaults[headerName];
+    }
+
+    assignKeyValue(req.headers, headerName, headerValue);
+  });
+}
 
 /**
  * Attaches the resource type to the error and passes it on to the next
@@ -149,7 +153,8 @@ function verifyCollectorToken(req, cb) {
       });
     }
 
-    assignCollectorHeaders(req, decodedData.username, decodedData.tokenname);
+    assignHeaderValues(req, decodedData);
+
     if (cb) {
       return cb();
     }
@@ -203,10 +208,8 @@ function verifyUserToken(req, cb) {
     }
 
     req.user = user.get();
-    return Profile.isAdmin(req.user.profileId);
-  })
-  .then((isAdmin) => {
-    assignUserHeaders(req, decodedData.tokenname, isAdmin);
+    assignHeaderValues(req, decodedData);
+
     /*
      * No need to check the token record if this is the default UI
      * token.
@@ -260,39 +263,34 @@ function verifyToken(req, cb) {
 } // verifyToken
 
 /**
- * Get token details (user name and token name) from the request.
- *
- * @param {Object} req - The request object.
- * @returns {Promise} - Resolves to an object containing "username" and
- *  "tokenname" attributes.
- */
-function getTokenDetailsFromRequest(req) {
-  let username;
-  let tokenname;
-  if (req && req.headers) {
-    username = req.headers.UserName;
-    tokenname = req.headers.TokenName;
-    return { username, tokenname };
-  }
-
-  username = req.session.passport.user.name;
-  tokenname = '__UI';
-  return { username, tokenname };
-} // getTokenDetailsFromRequest
-
-/**
  * Create jwt token.
  *
  * @param {string} tokenName - the name of the token
  * @param {string} userName - the name of the user
+ * @param {Object} payloadObj - optional additional info to be included in
+ * jwt claim
  * @returns {string} created token
  */
-function createToken(tokenName, userName) {
+function createToken(tokenName, userName, payloadObj) {
   const jwtClaim = {
     tokenname: tokenName,
     username: userName,
-    timestamp: Date.now,
+    timestamp: Date.now(),
   };
+
+  /*
+    If payload not given, no additional headers are set.
+    If payload is given, set only the headers which matches the headers in
+    headersWithDefaults.
+   */
+  if (payloadObj) {
+    Object.keys(payloadObj).forEach((key) => {
+      if (headersWithDefaults.hasOwnProperty(key)) {
+        jwtClaim[key] = payloadObj[key];
+      }
+    });
+  }
+
   const createdToken = jwt.sign(jwtClaim, secret);
   return createdToken;
 }
@@ -300,7 +298,7 @@ function createToken(tokenName, userName) {
 module.exports = {
   verifyToken,
   createToken,
-  getTokenDetailsFromRequest,
   verifyCollectorToken,
   verifyBotToken,
+  assignHeaderValues, // for testing purposes only
 };

--- a/view/loadView.js
+++ b/view/loadView.js
@@ -76,16 +76,20 @@ function samlAuthentication(userProfile, done) {
       return Profile.findOrCreate({ where: { name: 'RefocusSSOUser' } });
     }
 
+    // profile already attached - default scope applied on find
     return done(null, user);
   })
   .spread((profile) =>
-    User.create({
+    User.create({ // default scope not applied on create, hence no profile
       email: userProfile.email,
       profileId: profile.id,
       name: userProfile.email,
       password: viewConfig.dummySsoPassword,
       sso: true,
     })
+  )
+  .then((createdUser) =>
+    User.findById(createdUser.id) // to get profile name with user object
   )
   .then((user) => {
     done(null, user);
@@ -217,18 +221,30 @@ module.exports = function loadView(app, passport) {
         failureRedirect: '/login',
       }),
     (_req, _res) => {
-      if (_req.user && _req.user.name) {
-        const token = jwtUtil.createToken(_req.user.name, _req.user.name);
-        _req.session.token = token;
-      }
+      // We make sure we have _req.user.profile.name in user returned from
+      // samlAuthentication
+      const user = _req.user;
 
-      if (_req.body.RelayState) {
-        // get the redirect url from relay state if present
-        _res.redirect(_req.body.RelayState);
-      } else {
-        // redirect to home page
-        _res.redirect('/');
-      }
+      return Profile.isAdmin(user.profileId)
+      .then((isAdmin) => {
+        const payloadObj = {
+          ProfileName: user.profile.name,
+          IsAdmin: isAdmin,
+        };
+
+        if (user && user.name && user.profile && user.profile.name) {
+          const token = jwtUtil.createToken(user.name, user.name, payloadObj);
+          _req.session.token = token;
+        }
+
+        if (_req.body.RelayState) {
+          // get the redirect url from relay state if present
+          _res.redirect(_req.body.RelayState);
+        } else {
+          // redirect to home page
+          _res.redirect('/');
+        }
+      });
     }
   );
 

--- a/view/loadView.js
+++ b/view/loadView.js
@@ -79,15 +79,20 @@ function samlAuthentication(userProfile, done) {
     // profile already attached - default scope applied on find
     return done(null, user);
   })
-  .spread((profile) =>
-    User.create({ // default scope not applied on create, hence no profile
+  .spread((profile) => {
+
+    /**
+     * default scope not applied on create, so we use User.find after this to
+     * get profile attached to user.
+     */
+    return User.create({
       email: userProfile.email,
       profileId: profile.id,
       name: userProfile.email,
       password: viewConfig.dummySsoPassword,
       sso: true,
-    })
-  )
+    });
+  })
   .then((createdUser) =>
     User.findById(createdUser.id) // to get profile name with user object
   )


### PR DESCRIPTION
Large number of updates in test files: most of them are updating the admin token with { isAdmin:true, ProfileName: 'Admin'}.
Plus some added/updated tests in tests/utils/jwtUtil.js
Rest of the changes are related to the code which calls createToken - touches a lot of token code. So, once this is merged,  I will also test all the use cases in staging (esp SSO use case for which we do not have integration tests).

@shriramshankar @iamigo : It would be great if you can test this manually as well, in case I missed some use case. 

Some use cases:
User registers first time.
User authenticates.
An SSO user signs in.
An existing SSO user registers.
A token is created using Refocus UI.
Anything else?

Extra change: Corrected Date.now -> Date.now() in createToken.
Note: This PR does not make any change for createToken corresponding to Bots. I am assuming that will be handled by IMC team. fyi @kamilsmuga 

