### PR TITLE
remove req.query from loadView

### DIFF
--- a/view/loadView.js
+++ b/view/loadView.js
@@ -146,20 +146,7 @@ module.exports = function loadView(app, passport) {
           transportProtocol: viewConfig.socketIOtransportProtocol,
         };
 
-        const templateVars = Object.assign(
-          {},
-          { queryParams: JSON.stringify(req.query) },
-          trackObj
-        );
-
-        // if url contains a query, render perspective detail page with realtime
-        // updates
-        if ((key === '/perspectives' && Object.keys(req.query).length) ||
-        key === '/perspectives/:key') {
-          res.render(viewmap[key], templateVars);
-        } else {
-          res.render(viewmap[key], trackObj);
-        }
+        res.render(viewmap[key], trackObj);
       }
     )
   );

--- a/view/perspective/perspective.pug
+++ b/view/perspective/perspective.pug
@@ -31,9 +31,6 @@ html(lang = 'en')
     var realtimeEventThrottleMilliseconds = #{eventThrottle};
   script.
     var transProtocol = '#{transportProtocol}';
-  script
-    if queryParams
-      | var queryParams = !{queryParams}
   script(src='/static/perspective/app.js')
   script.
     var trackingId = '#{trackingId}';


### PR DESCRIPTION
The original intention of having req.query in loadView.js was to load an unnamed perspective using the req.query. 
Currently any GET unnamed perspective will redirect to the default perspective. The loading unnamed perspective no longer functions.
Hence we can take out all references to req.query.