### PR TITLE
Minor collectors tweaks

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -2292,7 +2292,7 @@ paths:
             enum:
               - name
               - status
-              - isRegistered
+              - registered
               - lastHeartbeat
               - lastModifiedAt
               - createdBy
@@ -2304,7 +2304,7 @@ paths:
               - version
               - -name
               - -status
-              - -isRegistered
+              - -registered
               - -lastHeartbeat
               - -lastModifiedAt
               - -createdBy
@@ -2333,10 +2333,10 @@ paths:
           required: false
           type: string
         -
-          name: isRegistered
+          name: registered
           in: query
           description: >-
-            Filter by isRegistered (true|false).
+            Filter by registered (true|false).
           required: false
           type: boolean
         -
@@ -11132,8 +11132,8 @@ definitions:
         items:
           type: "object"
         description: "Generators assigned to this collector."
-      isRegistered:
-        type: "string"
+      registered:
+        type: boolean
         description: "Boolean. If false, means deregistered. Changed by the DEREGISTER command"
         enum:
         - true
@@ -11531,7 +11531,7 @@ parameters:
         - name
         - id
         - status
-        - isRegistered
+        - registered
         - currentGenerators
         - lastHeartbeat
         - lastModifiedAt

--- a/migrations/20180122232810-collector-add-host-ipaddress.js
+++ b/migrations/20180122232810-collector-add-host-ipaddress.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * migrations/20180122232810-collector-add-host-ipaddress.js
+ */
+'use strict'; // eslint-disable-line strict
+const TBL = 'Collectors';
+
+module.exports = {
+  up(qi, Sequelize) {
+    let attr;
+    return qi.sequelize.transaction(
+      () => qi.describeTable(TBL)
+      .then((attributes) => attr = attributes)
+      .then(() => {
+        if (attr.hasOwnProperty('host')) {
+          return qi.addColumn(TBL, 'host', {
+            type: Sequelize.STRING(4096),
+            allowNull: true,
+          });
+        }
+
+        return true;
+      })
+      .then(() => {
+        if (attr.hasOwnProperty('ipAddress')) {
+          return qi.addColumn(TBL, 'ipAddress', {
+            type: Sequelize.STRING(60),
+            allowNull: true,
+          });
+        }
+
+        return true;
+      })
+    );
+  },
+
+  down(qi) {
+    return qi.sequelize.transaction(() => qi.removeColumn(TBL, 'host')
+    .then(() => qi.removeColumn(TBL, 'ipAddress')));
+  },
+};

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -159,8 +159,8 @@ describe('tests/api/v1/collectors/start.js >', () => {
     const _collector = JSON.parse(JSON.stringify(u.toCreate));
     _collector.name = 'newCollector';
 
-    it('create a new collector record with isRegistered=true ' +
-      ' and status=RUNNING, and return with a collector token', (done) => {
+    it('create a new collector record with registered=true ' +
+      'and status=RUNNING, and return with a collector token', (done) => {
       api.post(path)
       .set('Authorization', token)
       .send(_collector)


### PR DESCRIPTION
In db, add a migration to add host and ipAddress to collectors table if not already there.
In api, rename collector "isRegistered" to match "registered" (in db) and set type to boolean for registered attribute in collector response.