### PR TITLE
Check for sample missing name

### DIFF
--- a/api/v1/controllers/samples.js
+++ b/api/v1/controllers/samples.js
@@ -245,6 +245,7 @@ module.exports = {
     createSample
     .then((sample) => {
       createdSample = sample;
+      /* reload now if the sample came from the db */
       return isReturnUserEnabled && sample.get ? sample.reload() : sample;
     })
     .then(() => {

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -59,6 +59,7 @@ function updateInstance(o, puttableFields, toPut) {
 
 /**
  * Sorts the array field of an object or an array of objects alphabetically.
+ *
  * @param {Object} props - The helpers/nouns module for the given DB model
  * @param  {Object|Array} instArrayOrObject  - The instance object or an array
  *   of instance object with fields containing an array of objects that needs
@@ -80,8 +81,7 @@ function sortArrayObjectsByField(props, instArrayOrObject) {
 } // sortArrayObjectsByField
 
 /**
- * Sends the udpated record back in the json response
- * with status code 200.
+ * Sends the udpated record back in the json response with status code 200.
  *
  * @param {Object} resultObj - For logging
  * @param {Object} req - The request object
@@ -92,13 +92,12 @@ function sortArrayObjectsByField(props, instArrayOrObject) {
  */
 function handleUpdatePromise(resultObj, req, retVal, props, res) {
   const returnObj = retVal.get ? retVal.get() : retVal;
-
   sortArrayObjectsByField(props, returnObj);
 
   // publish the update event to the redis channel
   if (props.publishEvents) {
-    publisher.publishSample(
-      returnObj, props.associatedModels.subject, realtimeEvents.sample.upd);
+    publisher.publishSample(returnObj, props.associatedModels.subject,
+      realtimeEvents.sample.upd);
   }
 
   // update the cache
@@ -111,10 +110,9 @@ function handleUpdatePromise(resultObj, req, retVal, props, res) {
 
   resultObj.dbTime = new Date() - resultObj.reqStartTime;
   logAPI(req, resultObj, returnObj);
-
   return res.status(constants.httpStatus.OK)
     .json(responsify(returnObj, props, req.method));
-}
+} // handleUpdatePromise
 
 /**
  * In-place removal of certain keys from the input object

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -31,6 +31,7 @@ const sampleType = redisOps.sampleType;
 const featureToggles = require('feature-toggles');
 const commonUtils = require('../../utils/common');
 const sampleNameSeparator = '|';
+const logger = require('winston');
 
 const sampFields = {
   PROVIDER: 'provider',
@@ -78,6 +79,8 @@ function parseName(name) {
     return retval;
   }
 
+  logger.error(`cache/models/samples.parseName|Invalid sample name "${name}"`);
+  console.trace(); // eslint-disable-line no-console
   throw new redisErrors.ResourceNotFoundError({
     explanation: `Invalid sample name "${name}"`,
   });

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -79,7 +79,7 @@ function parseName(name) {
   }
 
   throw new redisErrors.ResourceNotFoundError({
-    explanation: `Invalid sample name "${sampleName}"`,
+    explanation: `Invalid sample name "${name}"`,
   });
 } // parseName
 
@@ -776,7 +776,10 @@ module.exports = {
       return redisOps.executeBatchCmds(cmds);
     })
     .then(() => redisOps.getHashPromise(sampleType, sampleName))
-    .then((updatedSamp) => cleanAddAspectToSample(updatedSamp, aspectObj));
+    .then((updatedSamp) => {
+      parseName(updatedSamp.name); // throw if invalid name
+      return cleanAddAspectToSample(updatedSamp, aspectObj);
+    });
   }, // putSample
 
   /**
@@ -828,9 +831,8 @@ module.exports = {
         modelUtils.applyFieldListFilter(sample, opts.attributes);
       }
 
-      // clean and attach aspect to sample, add api links as well
-      const sampleRes = cleanAddAspectToSample(sample, aspect);
       parseName(sampleName); // throw if invalid name
+      const sampleRes = cleanAddAspectToSample(sample, aspect);
       return sampleRes;
     });
   }, // getSample

--- a/tests/cache/jobQueue/bulkUpsert.js
+++ b/tests/cache/jobQueue/bulkUpsert.js
@@ -28,7 +28,7 @@ const logger = require('../../../utils/activityLog').logger;
 const RADIX = 10;
 
 describe('tests/cache/jobQueue/bulkUpsert.js, ' +
-'redisStore: POST using worker process' + path, () => {
+'redisStore: POST using worker process, ' + path + ' >', () => {
   let token;
 
   before((done) => {
@@ -77,8 +77,7 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
     tu.toggleOverride('enableRedisSampleStore', false);
   });
 
-  it('should return ok status with the job id for good ' +
-      'or bad samples', (done) => {
+  it('return ok status with job id for good or bad samples', (done) => {
     api.post(path)
     .set('Authorization', token)
     .send([
@@ -108,7 +107,7 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
     });
   });
 
-  it('test logging', (done) => {
+  it('logging', (done) => {
     tu.toggleOverride('enableApiActivityLogs', true);
     tu.toggleOverride('enableWorkerActivityLogs', true);
     logger.on('logging', testLogMessage);

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -624,7 +624,7 @@ describe('tests/cache/models/samples/get.js, ' +
         }
 
         expect(res.body.errors[0].description)
-        .to.be.equal('Incorrect sample name.');
+        .to.be.equal('Invalid sample name "abc"');
         return done();
       });
     });

--- a/tests/cache/models/samples/post.js
+++ b/tests/cache/models/samples/post.js
@@ -99,8 +99,9 @@ describe('tests/cache/models/samples/post.js >', () => {
             }
 
             const _err = res.body.errors[ZERO];
-            expect(_err.type).to.equal('ResourceNotFoundError');
-            expect(_err.description).to.equal('Aspect not found.');
+            expect(_err).to.have.property('type', 'ResourceNotFoundError');
+            expect(_err.description)
+            .to.match(/Aspect \"[a-f0-9-]*\" not found./);
             return done();
           });
         });
@@ -128,8 +129,9 @@ describe('tests/cache/models/samples/post.js >', () => {
             }
 
             const _err = res.body.errors[ZERO];
-            expect(_err.type).to.equal('ResourceNotFoundError');
-            expect(_err.description).to.equal('Subject not found.');
+            expect(_err).to.have.property('type', 'ResourceNotFoundError');
+            expect(_err.description)
+            .to.match(/Subject \"[a-z0-9-]*\" not found./);
             return done();
           });
         });
@@ -155,10 +157,10 @@ describe('tests/cache/models/samples/post.js >', () => {
             return done(err);
           }
 
-          expect(res.body.errors[ZERO].type)
-          .to.equal('DuplicateResourceError');
+          expect(res.body.errors[ZERO])
+          .to.have.property('type', 'DuplicateResourceError');
           expect(res.body.errors[ZERO].description)
-          .to.equal('Sample already exists.');
+          .to.match(/Sample \".*\" already exists./);
           return done();
         });
       });
@@ -173,10 +175,10 @@ describe('tests/cache/models/samples/post.js >', () => {
             return done(err);
           }
 
-          expect(res.body.errors[ZERO].type)
-          .to.equal('DuplicateResourceError');
+          expect(res.body.errors[ZERO])
+          .to.have.property('type', 'DuplicateResourceError');
           expect(res.body.errors[ZERO].description)
-          .to.equal('Sample already exists.');
+          .to.match(/Sample \".*\" already exists./);
           return done();
         });
       });

--- a/tests/cache/models/samples/upsert.js
+++ b/tests/cache/models/samples/upsert.js
@@ -411,14 +411,14 @@ describe('tests/cache/models/samples/upsert.js, ' +
         name: `${subject.name}xxxxx`,
         value: '2',
       })
-      .expect(constants.httpStatus.BAD_REQUEST)
+      .expect(constants.httpStatus.NOT_FOUND)
       .end((err, res) => {
         if (err) {
           return done(err);
         }
 
         expect(res.body.errors[0].description)
-        .to.be.equal('Incorrect sample name.');
+        .to.be.equal('Invalid sample name "___test_subjectxxxxx"');
         done();
       });
     });

--- a/utils/common.js
+++ b/utils/common.js
@@ -14,9 +14,8 @@ const constants = require('../api/v1/constants');
 const featureToggles = require('feature-toggles');
 
 /**
- * Logs with stack trace if toggle is on and
- *  there are invalid values in hmset object.
- * Otherwise has no effect.
+ * Logs with stack trace if toggle is on and there are invalid values in hmset
+ * object, otherwise has no effect.
  *
  * @param {String} key The redis key to hmset the object
  * @param {Object} obj The object from hmset
@@ -25,7 +24,7 @@ function logInvalidHmsetValues(key, obj) {
   if (featureToggles.isFeatureEnabled('logInvalidHmsetValues')) {
     for (let _key in obj) {
       if ((obj[_key] === undefined) || Array.isArray(obj[_key])) {
-        console.trace('Invalid hmset params found when setting: key ' + key +
+        console.trace('Invalid hmset params: key ' + key +
           ' with undefined field: ' + _key + ', received: ' +
           JSON.stringify(obj));
         break;


### PR DESCRIPTION
- api/v1/controllers/samples.js
  - add logging to sample find/post/patch/put/upsert to track invalid sample name problems, e.g. missing name
- api/v1/helpers/verbs/utils.js
  - noop (comments and formatting changes only)
- cache/models/samples.js
  - consolidate all the sample name splitting and validation into helper fn "parseName"
  - call parseName where we used to split and validate the sample name, and call it again on the sample we're returning *after* performing the operation (upsertOneSample/patchSample/putSample/getSample/findSamples)
  - checkWritePermission does not need sample arg so simplified the fn signature and its callers
  - add more details to error explanations, e.g. the subject/aspect/sample name or id
- tests/cache/jobQueue/bulkUpsert.js
  - comments and formatting changes only
- tests/cache/models/samples/get.js
  - updated to match more detailed error message
- tests/cache/models/samples/post.js
  - updated to match more detailed error message
- tests/cache/models/samples/upsert.js
  - updated to match more detailed error message
- utils/common.js
  - comments and logging changes only