### PR TITLE
fix heartbeat response

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -11340,7 +11340,7 @@ definitions:
       List of generators assigned to this agent since last heartbeat.
       New generator templates are included as well.
     items:
-      $ref: "#/definitions/GeneratorTemplateResponse"
+      $ref: "#/definitions/HeartbeatGeneratorResponse"
 
   GeneratorsUpdatedResponse:
     type: array
@@ -11348,7 +11348,7 @@ definitions:
       List of generators assigned to this agent, but were modified
       since last heartbeat.
     items:
-      $ref: "#/definitions/GeneratorTemplateResponse"
+      $ref: "#/definitions/HeartbeatGeneratorResponse"
 
   GeneratorsRemovedResponse:
     readOnly: true
@@ -11415,6 +11415,82 @@ definitions:
         type: array
         items:
           type: string
+      tags:
+        type: array
+        items:
+          type: string
+          maxLength: 60
+          pattern: ^[0-9A-Za-z_][0-9A-Za-z_\\-]{1,59}$
+        description: >
+          Array of tag names. Tag name: Max 60 characters; case insensitive;
+          allows alpha-numeric characters, underscore (_) and dash (-). Tag
+          names cannot start with a dash (-).
+      connection:
+        type: object
+        description: Information about the connection.
+      context:
+        type: object
+        description: >
+          Variables accessible inside the transform function.
+      generatorTemplate:
+        $ref: "#/definitions/GeneratorTemplateResponse"
+
+  HeartbeatGeneratorResponse:
+    type: object
+    description: >-
+      The designation of which subjects and aspects to collect, plus any additional context data
+    properties:
+      description:
+        type: string
+        maxLength: 4096
+        description: >
+          A description of the generator.
+      helpEmail:
+        type: string
+        description: >
+          The email address where a user can go to get more help about the generator.
+        maxLength: 254
+      helpUrl:
+        type: string
+        maxLength: 2082
+        description: >
+          The url where a user can go to get more help about the generator.
+      createdBy:
+        readOnly: true
+        type: string
+        description: >
+          Id of the User who created this Generator.
+      id:
+        type: string
+        readOnly: true
+        description: >
+          The collector id.
+      isActive:
+        type: boolean
+        description: Whether or not the generator is running on a collector.
+      name:
+        type: string
+        readOnly: true
+        description: The generator's name.
+      subjectQuery:
+        type: string
+        readOnly: true
+        description: The query to append to GET subjects.
+      collectors:
+        description: List of collectors this Sample Generator should try to use.
+        type: array
+        items:
+          type: object
+      subjects:
+        description: Array of subjects.
+        type: array
+        items:
+          type: object
+      aspects:
+        description: Array of aspects.
+        type: array
+        items:
+          type: object
       tags:
         type: array
         items:

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -211,6 +211,12 @@ module.exports = function generator(seq, dataTypes) {
           .catch(reject)
         );
       },
+
+      findForHeartbeat(findOpts) {
+        return Generator.findAll(findOpts)
+        .then((gens) => gens.map((g) => g.updateForHeartbeat()))
+        .then((genpromises) => Promise.all(genpromises));
+      }, // findForHeartbeat
     },
 
     hooks: {
@@ -369,10 +375,10 @@ module.exports = function generator(seq, dataTypes) {
           seq.Promise.all(aspectPromises),
           seq.Promise.all(subjectPromises),
           (aspectRecords, subjectRecords) => {
-            this.aspects = aspectRecords.filter((found) => found)
+            g.aspects = aspectRecords.filter((found) => found)
               .map((rec) => rec.get());
-            this.subjects = subjectRecords.map((rec) => rec.get());
-            return this;
+            g.subjects = subjectRecords.map((rec) => rec.get());
+            return g;
           }
         );
       }, // updateForHeartbeat

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -340,8 +340,11 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 },
-            res))
+          .then((res) => {
+            u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res);
+            expect(res.body.generatorsAdded[0].aspects[0])
+              .to.contain.property('name', 'Temperature');
+          })
           .then(done).catch(done);
         });
 

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -271,7 +271,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
       });
     });
 
-    describe('generator changes', () => {
+    describe('generator changes >', () => {
       // reset the tracked changes
       beforeEach((done) => {
         Promise.resolve()
@@ -335,7 +335,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('basic updates', () => {
+      describe('basic updates >', () => {
         it('post', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
@@ -429,7 +429,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('basic updates to multiple generators', () => {
+      describe('basic updates to multiple generators >', () => {
         it('post', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
@@ -495,7 +495,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('basic updates with multiple collectors', () => {
+      describe('basic updates with multiple collectors >', () => {
         it('post', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))
@@ -533,7 +533,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('multiple updates to the same generator', () => {
+      describe('multiple updates to the same generator >', () => {
         it('post + patch', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
@@ -687,7 +687,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('updates to multiple generators', () => {
+      describe('updates to multiple generators >', () => {
         it('update', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
@@ -729,7 +729,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('multiple updates to multiple generators', () => {
+      describe('multiple updates to multiple generators >', () => {
         it('post then move all twice', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1]))
@@ -800,7 +800,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('multiple generators multiple collectors', () => {
+      describe('multiple generators multiple collectors >', () => {
         it('update', (done) => {
           Promise.resolve()
           .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -75,7 +75,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  describe('if the collector is registered and status is STOPPED:', () => {
+  describe('if the collector is registered and status is STOPPED >', () => {
     it('if the user is among the writers, start the collector ' +
       'and return the expected response', (done) => {
       api.post(path)
@@ -145,7 +145,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
     });
   });
 
-  describe('if the collector is registered:', () => {
+  describe('if the collector is registered >', () => {
     it('reject if the status is PAUSED', (done) => {
       const _collector = u.getCollectorToCreate();
       _collector.name = 'PausedCollector';
@@ -180,7 +180,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
     });
   });
 
-  describe('if collector not found', () => {
+  describe('if collector not found >', () => {
     before(() => tu.toggleOverride('returnUser', true));
     after(() => tu.toggleOverride('returnUser', false));
 

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -53,7 +53,8 @@ describe('tests/api/v1/collectors/start.js >', () => {
   });
 
   beforeEach((done) => {
-    GeneratorTemplate.create(generatorTemplate)
+    sgUtils.createGeneratorAspects()
+    .then(() => GeneratorTemplate.create(generatorTemplate))
     .then(() => {
       const gen1 = sgUtils.getGenerator();
       gen1.name += 'generator-1';
@@ -101,6 +102,8 @@ describe('tests/api/v1/collectors/start.js >', () => {
         expect(sg1.collectors).to.equal(undefined);
         expect(sg2.GeneratorCollectors).to.equal(undefined);
         expect(sg2.collectors).to.equal(undefined);
+        expect(res.body.generatorsAdded[0].aspects[0])
+          .to.contain.property('name', 'Temperature');
         return done();
       });
     });

--- a/tests/db/model/generator/find.js
+++ b/tests/db/model/generator/find.js
@@ -141,10 +141,9 @@ describe('tests/db/model/generator/find.js >', () => {
     .then((res) => {
       expect(res).to.be.an('array').to.have.lengthOf(2);
       expect(res[0].aspects[0]).to.contain.property('name', 'Temperature');
-      console.log('findForHeartbeat', res);
-      expect(res[1].subjects[0]).to.contain.property('absolutePath', 'foo.bar');
+      expect(res[0].subjects[0]).to.contain.property('absolutePath', 'foo.bar');
       done();
-    })      
+    })
     .catch(done);
   });
 });

--- a/tests/db/model/generator/find.js
+++ b/tests/db/model/generator/find.js
@@ -110,27 +110,40 @@ describe('tests/db/model/generator/find.js >', () => {
   it('updateForHeartbeat - array of subjects', (done) => {
     Generator.findById(g2DBInstance.id)
     .then((g) => {
-      expect(g.get().aspects).to.be.an('array').to.have.lengthOf(3)
+      expect(g.aspects).to.be.an('array').to.have.lengthOf(3)
       .that.includes('Temperature')
       .that.includes('Weather')
       .that.includes('Humidity');
-      expect(g.get().subjects).to.be.an('array')
+      expect(g.subjects).to.be.an('array')
       .that.includes('foo.bar')
       .that.includes('foo.baz');
       return g;
     })
     .then((g) => g.updateForHeartbeat())
     .then((g) => {
-      const asp = g.get().aspects;
+      const asp = g.aspects;
       expect(asp).to.be.an('array').to.have.lengthOf(2);
       expect(asp[0]).to.contain.property('name', 'Temperature');
       expect(asp[1]).to.contain.property('name', 'Weather');
-      const sub = g.get().subjects;
+      const sub = g.subjects;
       expect(sub).to.be.an('array');
       expect(sub[0]).to.contain.property('absolutePath', 'foo.bar');
       expect(sub[1]).to.contain.property('absolutePath', 'foo.baz');
       done();
     })
+    .catch(done);
+  });
+
+  it('findForHeartbeat', (done) => {
+    Generator.findForHeartbeat({
+      where: { id: [generatorDBInstance.id, g2DBInstance.id] },
+    })
+    .then((res) => {
+      expect(res).to.be.an('array').to.have.lengthOf(2);
+      expect(res[0].aspects[0]).to.contain.property('name', 'Temperature');
+      expect(res[1].subjects[1]).to.contain.property('absolutePath', 'foo.baz');
+      done();
+    })      
     .catch(done);
   });
 });

--- a/tests/db/model/generator/find.js
+++ b/tests/db/model/generator/find.js
@@ -141,7 +141,8 @@ describe('tests/db/model/generator/find.js >', () => {
     .then((res) => {
       expect(res).to.be.an('array').to.have.lengthOf(2);
       expect(res[0].aspects[0]).to.contain.property('name', 'Temperature');
-      expect(res[1].subjects[1]).to.contain.property('absolutePath', 'foo.baz');
+      console.log('findForHeartbeat', res);
+      expect(res[1].subjects[0]).to.contain.property('absolutePath', 'foo.bar');
       done();
     })      
     .catch(done);


### PR DESCRIPTION
- update the generator db model to add a class fn called "findForHeartbeat" (which calls the recently-added "updateForHeartbeat")
- update the heartbeat response model definition in swagger: generatorsAdded/Updated have arrays of subject records and aspect records
- update the collector api to use the new "updateForHeartbeat" and "findForHeartbeat" functions when preparing the generatorsAdded/Updated to return