### PR TITLE
Remove ssflag real time logging

### DIFF
--- a/api/v1/helpers/nouns/aspects.js
+++ b/api/v1/helpers/nouns/aspects.js
@@ -9,12 +9,10 @@
 /**
  * api/v1/helpers/nouns/aspects.js
  */
-'use strict';
+'use strict'; // eslint-disable-line strict
 
 const Aspect = require('../../../../db/index').Aspect;
-
 const m = 'aspect';
-
 const fieldsWithJsonArrayType = ['relatedLinks'];
 const fieldsWithArrayType = ['tags'];
 const fieldsWithEnum = ['valueType'];
@@ -28,9 +26,6 @@ module.exports = {
     PUT: `Overwrite all attributes of this ${m}`,
   },
   baseUrl: '/v1/aspects',
-  fieldScopeMap: {
-    samples: 'withSamples',
-  },
   model: Aspect,
   modelName: 'Aspect',
 

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -139,9 +139,9 @@ function cleanAddAspectToSample(sampleObj, aspectObj) {
   if (aspect) {
     modelUtils.cleanQueryBodyObj(aspect, embeddedAspectFields);
     sampleStore.convertAspectStrings(aspect);
+    sampleRes.aspect = aspect;
   }
 
-  sampleRes.aspect = aspect;
   return sampleRes;
 } // cleanAddAspectToSample
 

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -9,6 +9,8 @@
 /**
  * cache/models/utils.js
  */
+'use strict'; // eslint-disable-line strict
+
 const apiConstants = require('../../api/v1/constants');
 const defaults = require('../../config').api.defaults;
 const sampleStore = require('../sampleStore');

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -13,7 +13,6 @@
 const common = require('../helpers/common');
 const u = require('../helpers/aspectUtils');
 const constants = require('../constants');
-const featureToggles = require('feature-toggles');
 const assoc = {};
 const timeoutLength = 10;
 const timeoutRegex = /^[0-9]{1,9}[SMHDsmhd]$/;
@@ -164,15 +163,6 @@ module.exports = function aspect(seq, dataTypes) {
         }, {
           override: true,
         });
-
-        Aspect.addScope('withSamples', {
-          include: [
-            {
-              association: assoc.samples,
-              attributes: { exclude: ['aspectId'] },
-            },
-          ],
-        });
       },
     },
     hooks: {
@@ -181,8 +171,7 @@ module.exports = function aspect(seq, dataTypes) {
        * TODO:
        * 1. Have a look at the sampleStore logic and confirm that it is
        * doing what it is supposed to do.
-       * 2. Wrap all the calls to redis in a promise and resolve it at the end
-       * like it has been done in the afterUpdate hook.
+       *
        */
 
       /**
@@ -190,14 +179,19 @@ module.exports = function aspect(seq, dataTypes) {
        * and the sampleStore if any.
        *
        * @param {Aspect} inst - The deleted instance
+       * @returns {Promise}
        */
       afterCreate(inst /* , opts */) {
+        const promiseArr = [];
+
         // Prevent any changes to original inst dataValues object
         const instDataObj = JSON.parse(JSON.stringify(inst.get()));
 
         // create an entry in aspectStore
-        redisOps.addKey(aspectType, inst.getDataValue('name'));
-        redisOps.hmSet(aspectType, inst.name, instDataObj);
+        promiseArr.push(redisOps.addKey(aspectType, inst.getDataValue('name')));
+        promiseArr.push(redisOps.hmSet(aspectType, inst.name, instDataObj));
+
+        return Promise.all(promiseArr);
       }, // hooks.afterCreate
 
       /**
@@ -213,58 +207,6 @@ module.exports = function aspect(seq, dataTypes) {
           .catch((err) => reject(err))
         );
       }, // hooks.beforeDestroy
-
-      /**
-       * Recalculate sample status if any of the status ranges changed.
-       * If aspect tags changed, send a "delete" realtime event for all the
-       * samples for this aspect. (The afterUpdate hook will subsequently send
-       * an "add" event.) This way, perspectives which filter by aspect tags
-       * will get the right samples.
-       *
-       * @param {Aspect} inst - The instance being updated
-       * @returns {Promise}
-       */
-      beforeUpdate(inst /* , opts */) {
-        const statusRangeWasUpdated = inst.changed('criticalRange') ||
-          inst.changed('warningRange') ||
-          inst.changed('infoRange') ||
-          inst.changed('okRange');
-        if (statusRangeWasUpdated) {
-          return new seq.Promise((resolve, reject) =>
-            inst.getSamples()
-            .each((samp) => {
-              samp.aspect = inst;
-              samp.calculateStatus();
-              samp.setStatusChangedAt();
-              samp.save();
-            })
-            .then(() => resolve(inst))
-            .catch((err) => reject(err))
-          );
-        }
-
-        if (inst.changed('tags')) {
-          return new seq.Promise((resolve, reject) => {
-            inst.getSamples()
-            .each((samp) =>
-              common.sampleAspectAndSubjectArePublished(seq, samp)
-              .then((published) => {
-                if (published) {
-                  return common.augmentSampleWithSubjectAspectInfo(seq, samp)
-                  .then((s) => {
-                    common.publishChange(s, sampleEventNames.del);
-                  });
-                }
-
-                return seq.Promise.resolve(true);
-              }))
-            .then(() => resolve(inst))
-            .catch(reject);
-          });
-        } // tags changed
-
-        return seq.Promise.resolve(true);
-      }, // hooks.beforeUpdate
 
       /**
        * If isPublished is being updated from true to false or the name of the
@@ -294,66 +236,42 @@ module.exports = function aspect(seq, dataTypes) {
          * 4. if the aspect that is updated is already published, update the
          * the aspect with the new values.
         */
-        {
-          if (nameChanged && inst.isPublished) {
-            const newAspName = inst.name;
-            const oldAspectName = inst._previousDataValues.name;
+        if (nameChanged && inst.isPublished) {
+          const newAspName = inst.name;
+          const oldAspectName = inst._previousDataValues.name;
 
-            // rename entry in aspectStore
-            promiseArr.push(redisOps.renameKey(aspectType,
-              oldAspectName, newAspName));
+          // rename entry in aspectStore
+          promiseArr.push(redisOps.renameKey(aspectType,
+            oldAspectName, newAspName));
 
+          /*
+           * delete multiple possible sample entries in the sample master
+           * list of index and the related sample hashes
+           */
+          promiseArr.push(redisOps.deleteKeys(sampleType, aspectType,
+            oldAspectName));
+        } else if (isPublishedChanged) {
+          // Prevent any changes to original inst dataValues object
+          const instDataObj = JSON.parse(JSON.stringify(inst.get()));
+          promiseArr.push(redisOps.hmSet(aspectType, inst.name, instDataObj));
+
+          // add the aspect to the aspect master list regardless of isPublished
+          promiseArr.push(redisOps.addKey(aspectType, inst.name));
+          if (!inst.isPublished) {
             /*
-             * delete multiple possible sample entries in the sample master
-             * list of index and the related sample hashes
+             * Delete multiple possible entries in the sample master list of
+             * index
              */
-            promiseArr.push(redisOps.deleteKeys(sampleType, aspectType,
-              oldAspectName));
-          } else if (isPublishedChanged) {
-
-            // Prevent any changes to original inst dataValues object
-            const instDataObj = JSON.parse(JSON.stringify(inst.get()));
-            promiseArr.push(redisOps.hmSet(aspectType, inst.name, instDataObj));
-
-            // add the aspect to the aspect master list regardless of isPublished
-            promiseArr.push(redisOps.addKey(aspectType, inst.name));
-            if (!inst.isPublished) {
-
-              /*
-               * Delete multiple possible entries in the sample master list of
-               * index
-               */
-              promiseArr.push(redisOps.deleteKeys(sampleType,
-                aspectType, inst.name));
-            }
-          } else if (inst.isPublished) {
-            const instChanged = {};
-            Object.keys(inst._changed)
-            .filter(key => inst._changed[key])
-            .forEach(key => instChanged[key] = inst[key]);
-            promiseArr.push(redisOps.hmSet(aspectType, inst.name, instChanged));
+            promiseArr.push(redisOps.deleteKeys(sampleType,
+              aspectType, inst.name));
           }
+        } else if (inst.isPublished) {
+          const instChanged = {};
+          Object.keys(inst._changed)
+          .filter((key) => inst._changed[key])
+          .forEach((key) => instChanged[key] = inst[key]);
+          promiseArr.push(redisOps.hmSet(aspectType, inst.name, instChanged));
         }
-
-        if (inst.changed('tags')) {
-          return new seq.Promise((resolve, reject) => {
-            inst.getSamples()
-            .each((samp) =>
-              common.sampleAspectAndSubjectArePublished(seq, samp)
-              .then((published) => {
-                if (published) {
-                  return common.augmentSampleWithSubjectAspectInfo(seq, samp)
-                  .then((s) => {
-                    common.publishChange(s, sampleEventNames.add);
-                  });
-                }
-
-                return seq.Promise.resolve(true);
-              }))
-            .then(() => resolve(inst))
-            .catch(reject);
-          });
-        } // tags changed
 
         return seq.Promise.all(promiseArr);
       }, // hooks.afterUpdate
@@ -363,15 +281,20 @@ module.exports = function aspect(seq, dataTypes) {
        * and the sampleStore if any.
        *
        * @param {Aspect} inst - The deleted instance
+       * @returns {Promise}
        */
       afterDelete(inst /* , opts */) {
+        const promiseArr = [];
         if (inst.getDataValue('isPublished')) {
           // delete the entry in the aspectStore
-          redisOps.deleteKey(aspectType, inst.name);
+          promiseArr.push(redisOps.deleteKey(aspectType, inst.name));
 
           // delete multiple possible entries in sampleStore
-          redisOps.deleteKeys(sampleType, aspectType, inst.name);
+          promiseArr.push(redisOps.deleteKeys(sampleType,
+            aspectType, inst.name));
         }
+
+        return Promise.all(promiseArr);
       }, // hooks.afterDelete
 
       /**

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -191,8 +191,7 @@ module.exports = function subject(seq, dataTypes) {
        * TODO:
        * 1. Have a look at the sampleStore logic and confirm that it is
        * doing what it is supposed to do.
-       * 2. Wrap all the calls to redis in a promise and resolve it at the end
-       * like it has been done in the afterUpdate hook of the aspect model.
+       *
        */
 
       /**
@@ -222,6 +221,8 @@ module.exports = function subject(seq, dataTypes) {
        *  record
        */
       afterCreate(inst /* , opts */) {
+        const promiseArr = [];
+
         /*
          * add entry to the subjectStore in redis only if the subject
          * is published and the sampleStoreFeature is enabled
@@ -231,12 +232,13 @@ module.exports = function subject(seq, dataTypes) {
 
           // Prevent any changes to original inst dataValues object
           const instDataObj = JSON.parse(JSON.stringify(inst.get()));
-          redisOps.addKey(subjectType, inst.getDataValue('absolutePath'));
-          redisOps.hmSet(
+          promiseArr.push(redisOps.addKey(subjectType,
+            inst.getDataValue('absolutePath')));
+          promiseArr.push(redisOps.hmSet(
             subjectType,
             inst.getDataValue('absolutePath'),
             instDataObj
-          );
+          ));
         }
 
         // no change here
@@ -246,6 +248,8 @@ module.exports = function subject(seq, dataTypes) {
             if (par) {
               par.increment('childCount');
             }
+
+            return Promise.all(promiseArr);
           })
           .then(() => resolve(inst))
           .catch((err) => reject(err))
@@ -258,6 +262,7 @@ module.exports = function subject(seq, dataTypes) {
        * publish the updated and former subject to redis channel.
        *
        * @param {Subject} inst - The updated instance
+       * @returns {Promise}
        */
       afterUpdate(inst /* , opts */) {
         const promiseArr = [];
@@ -270,35 +275,33 @@ module.exports = function subject(seq, dataTypes) {
          * 3. if the asbsolutepath of the subject changes: rename the subject key,
          *   update subject, delete subject aspect map, and remove its samples
          */
-        {
-          if (inst.changed('absolutePath') ||
-            (inst.changed('isPublished') && !inst.isPublished)) {
-            const newAbsPath = inst.absolutePath;
-            const oldAbsPath = inst._previousDataValues.absolutePath;
+        if (inst.changed('absolutePath') ||
+          (inst.changed('isPublished') && !inst.isPublished)) {
+          const newAbsPath = inst.absolutePath;
+          const oldAbsPath = inst._previousDataValues.absolutePath;
 
-            if (inst.changed('absolutePath')) {
-              // rename entry in subject store
-              promiseArr.push(redisOps.renameKey(subjectType, oldAbsPath,
-               newAbsPath));
-            }
-
-            /*
-             * Delete multiple possible
-             * entries in sample master list of index.
-             * Delete the subject to aspect mapping
-             */
-            promiseArr.push(redisOps.deleteKeys(sampleType, subjectType,
-              oldAbsPath));
-            promiseArr.push(redisOps.deleteKey(subAspMapType, oldAbsPath));
+          if (inst.changed('absolutePath')) {
+            // rename entry in subject store
+            promiseArr.push(redisOps.renameKey(subjectType, oldAbsPath,
+             newAbsPath));
           }
 
-          // Prevent any changes to original inst dataValues object
-          const instDataObj = JSON.parse(JSON.stringify(inst.get()));
-
-          //  update subject
-          promiseArr.push(redisOps.hmSet(subjectType, inst.absolutePath,
-            instDataObj));
+          /*
+           * Delete multiple possible
+           * entries in sample master list of index.
+           * Delete the subject to aspect mapping
+           */
+          promiseArr.push(redisOps.deleteKeys(sampleType, subjectType,
+            oldAbsPath));
+          promiseArr.push(redisOps.deleteKey(subAspMapType, oldAbsPath));
         }
+
+        // Prevent any changes to original inst dataValues object
+        const instDataObj = JSON.parse(JSON.stringify(inst.get()));
+
+        //  update subject
+        promiseArr.push(redisOps.hmSet(subjectType, inst.absolutePath,
+          instDataObj));
 
         if (inst.changed('parentAbsolutePath') ||
           inst.changed('absolutePath')) {
@@ -361,7 +364,7 @@ module.exports = function subject(seq, dataTypes) {
         }
 
         return Promise.all(promiseArr);
-      }, // hooks.afterupdate
+      }, // hooks.afterUpdate
 
       /**
        * Decrements childCount in parent.
@@ -480,13 +483,11 @@ module.exports = function subject(seq, dataTypes) {
 
           // If either is empty, decrement the parent's childCount
           if ((papChanged && papEmpty) || (pidChanged && pidEmpty)) {
-
             // set parentAbsolutePath, parentId to null
             return updateParentFields(Subject, null, null, inst);
           }
 
           if ((papChanged && pidChanged) && (!papEmpty && !pidEmpty)) {
-
             // do parentAbsolutePath and parentId point to the same subject?
             return validateParentField(Subject,
               inst.parentAbsolutePath, inst.absolutePath, 'absolutePath')

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -114,10 +114,7 @@ function publishObject(inst, event, changedKeys, ignoreAttributes, opts) {
  */
 function publishSample(sampleInst, subjectModel, event, aspectModel) {
   const eventType = event || getSampleEventType(sampleInst);
-  const useSampleStore =
-    featureToggles.isFeatureEnabled('enableRedisSampleStore');
-  return rtUtils.attachAspectSubject(sampleInst, useSampleStore, subjectModel,
-    aspectModel)
+  return rtUtils.attachAspectSubject(sampleInst, subjectModel, aspectModel)
   .then((sample) => {
     if (sample) {
       publishObject(sample, eventType);

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -370,7 +370,7 @@ function isIpWhitelisted(addr, whitelist) {
  * When passed in a sample, its related subject and aspect is attached to the
  * sample. If useSampleStore is set to true, the subject ans aspect is fetched
  * for the cache instead of the database.
- * @param {Object} sample - The sample instance. Could be from db directly
+ * @param {Object} sample - The sample instance.
  * @param {Model} subjectModel - The database subject model.
  * @param {Model} aspectModel - The database aspect model.
  * @returns {Promise} - which resolves to a complete sample with its subject and

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -396,8 +396,7 @@ describe('tests/api/v1/samples/patch.js >', () => {
     before(u.populateRedis);
     after(u.forceDelete);
 
-    // TODO: unskip this when sampleStore flag is removed from aspects
-    it.skip('cannot patch sample if aspect not published', (done) => {
+    it('cannot patch sample if aspect not published', (done) => {
       api.patch(`${path}/${sampleName}`)
       .set('Authorization', token3)
       .send({ value: '3' })

--- a/tests/api/v1/samples/put.js
+++ b/tests/api/v1/samples/put.js
@@ -180,8 +180,7 @@ describe(`tests/api/v1/samples/put.js, PUT ${path} >`, () => {
     });
   });
 
-  // TODO: unskip this once sampleStore flag is removed from the subject model
-  describe.skip('subject isPublished false >', () => {
+  describe('subject isPublished false >', () => {
     beforeEach((done) => {
       tu.db.Subject.findById(subjectId1)
       .then((sub) => {
@@ -190,8 +189,6 @@ describe(`tests/api/v1/samples/put.js, PUT ${path} >`, () => {
       })
       .catch(done);
     });
-
-    beforeEach(u.populateRedisIfEnabled);
 
     it('cannot create sample if subject not published', (done) => {
       api.put(`${path}/${sampleName1}`)
@@ -202,8 +199,7 @@ describe(`tests/api/v1/samples/put.js, PUT ${path} >`, () => {
     });
   });
 
-  // TODO: unskip this once sampleStore flag is removed from the aspect model
-  describe.skip('aspect isPublished false >', () => {
+  describe('aspect isPublished false >', () => {
     beforeEach((done) => {
       tu.db.Aspect.findById(aspectId1)
       .then((asp) => {

--- a/tests/api/v1/samples/upsert.js
+++ b/tests/api/v1/samples/upsert.js
@@ -163,8 +163,7 @@ describe(`tests/api/v1/samples/upsert.js, POST ${path} >`, () => {
       .catch(done);
     });
 
-    // TODO: unskip this when sampleStore flag is removed from aspects
-    it.skip('name refers to unpublished aspect', (done) => {
+    it('name refers to unpublished aspect', (done) => {
       api.post(path)
       .set('Authorization', token)
       .send({

--- a/tests/api/v1/samples/upsertBulk.js
+++ b/tests/api/v1/samples/upsertBulk.js
@@ -314,8 +314,7 @@ describe(`tests/api/v1/samples/upsertBulk.js, POST ${path} >`, () => {
       .catch(done);
     });
 
-    // TODO: unskip this when sampleStore flag is removed from the aspect model
-    it.skip('no samples created if aspect isPublished is false', (done) => {
+    it('no samples created if aspect isPublished is false', (done) => {
       api.post(path)
       .set('Authorization', token)
       .send([

--- a/tests/db/helpers/common.js
+++ b/tests/db/helpers/common.js
@@ -15,7 +15,7 @@ const tu = require('../../testUtils');
 const u = require('../model/subject/utils');
 const Subject = tu.db.Subject;
 const Aspect = tu.db.Aspect;
-const Sample = tu.db.Sample;
+const Sample = tu.Sample;
 const common = require('../../../db/helpers/common');
 
 describe('tests/db/helpers/common.js >', () => {
@@ -120,7 +120,9 @@ describe('tests/db/helpers/common.js >', () => {
       .catch(done);
     });
   });
-  describe('test sampleAspectAndSubjectArePublished and ' +
+
+  // TODO: delete these tests when deleting the sample model
+  describe.skip('test sampleAspectAndSubjectArePublished and ' +
   'augmentSampleWithSubjectAspectInfo function >', () => {
     let sub;
     before((done) => {

--- a/tests/db/model/aspect/utils.js
+++ b/tests/db/model/aspect/utils.js
@@ -54,10 +54,10 @@ module.exports = {
 
   forceDelete(done) {
     Promise.join(rcli.flushallAsync(),
-    tu.forceDelete(tu.db.Aspect, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+      tu.forceDelete(tu.db.Aspect, testStartTime)
+      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+      .then(() => tu.forceDelete(tu.db.User, testStartTime))
+      .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
     )
     .then(() => done())
     .catch(done);

--- a/tests/db/model/sample/statusCalculation.js
+++ b/tests/db/model/sample/statusCalculation.js
@@ -783,7 +783,7 @@ describe('tests/db/model/sample/statusCalculation.js >', () => {
       .catch(done);
     });
 
-    it('calculate invoked on aspect update', (done) => {
+    it.skip('calculate invoked on aspect update', (done) => {
       sample.update({ value: '7' })
       .should.eventually.have.property('value', '7')
       .then(() => Sample.findOne({

--- a/tests/db/model/sample/statusDuration.js
+++ b/tests/db/model/sample/statusDuration.js
@@ -172,7 +172,7 @@ describe('tests/db/model/sample/statusDuration.js >', () => {
       .catch(done);
     });
 
-    it('previousStatus change with Aspect Range changes', (done) => {
+    it.skip('previousStatus change with Aspect Range changes', (done) => {
       sample.update({ value: '.25' })
       .then((samp) => {
         expect(samp.status).to.equal(constants.statuses.Critical);

--- a/tests/db/model/subject/utils.js
+++ b/tests/db/model/subject/utils.js
@@ -27,11 +27,11 @@ const subjectPrototype = {
 module.exports = {
   forceDelete(done) {
     Promise.join(rcli.flushallAsync(),
-    tu.forceDelete(tu.db.Sample, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+      tu.forceDelete(tu.db.Sample, testStartTime)
+      .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+      .then(() => tu.forceDelete(tu.db.User, testStartTime))
+      .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
     )
     .then(() => done())
     .catch(done);

--- a/tests/jobQueue/v1/bulkUpsert.js
+++ b/tests/jobQueue/v1/bulkUpsert.js
@@ -37,7 +37,7 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
     tu.createToken()
     .then((returnedToken) => {
       token = returnedToken;
-      done();
+      return done();
     })
     .catch((err) => done(err));
   });

--- a/tests/jobQueue/v1/getBulkUpsertStatus.js
+++ b/tests/jobQueue/v1/getBulkUpsertStatus.js
@@ -35,7 +35,7 @@ describe('tests/jobQueue/v1/getBulkUpsertStatus.js, ' +
     tu.createToken()
     .then((returnedToken) => {
       token = returnedToken;
-      done();
+      return done();
     })
     .catch((err) => done(err));
   });

--- a/tests/jobQueue/v1/utils.js
+++ b/tests/jobQueue/v1/utils.js
@@ -7,25 +7,22 @@
  */
 
 /**
- * tests/api/v1/samples/utils.js
+ * tests/jobQueue/v1/utils.js
  */
 'use strict';
 
 const tu = require('../../testUtils');
 const testStartTime = new Date();
-const samstoinit = require('../../../cache/sampleStoreInit');
+const rcli = require('../../../cache/redisCache').client.sampleStore;
+const Promise = require('bluebird');
 
 module.exports = {
   forceDelete(done) {
-    samstoinit.eradicate()
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
-    .then(() => done())
-    .catch((err) => done(err));
-  },
-
-  populateRedis(done) {
-    samstoinit.populate()
+    Promise.join(
+      rcli.flushallAsync(),
+      tu.forceDelete(tu.db.Aspect, testStartTime)
+      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+    )
     .then(() => done())
     .catch(done);
   },

--- a/tests/jobQueue/v1/utils.js
+++ b/tests/jobQueue/v1/utils.js
@@ -14,6 +14,7 @@
 const tu = require('../../testUtils');
 const testStartTime = new Date();
 const rcli = require('../../../cache/redisCache').client.sampleStore;
+const samstoinit = require('../../../cache/sampleStoreInit');
 const Promise = require('bluebird');
 
 module.exports = {
@@ -23,6 +24,12 @@ module.exports = {
       tu.forceDelete(tu.db.Aspect, testStartTime)
       .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
     )
+    .then(() => done())
+    .catch(done);
+  },
+
+  populateRedis(done) {
+    samstoinit.populate()
     .then(() => done())
     .catch(done);
   },

--- a/tests/logging/enableWorkerLog.js
+++ b/tests/logging/enableWorkerLog.js
@@ -19,7 +19,7 @@ const constants = require('../../api/v1/constants');
 const Aspect = tu.db.Aspect;
 const path = '/v1/samples/upsert/bulk';
 const jobQueue = require('../../jobQueue/setup').jobQueue;
-const Sample = tu.db.Sample;
+const Sample = tu.Sample;
 const Subject = tu.db.Subject;
 
 describe('tests/logging/enableWorkerLog.js >', () => {
@@ -171,16 +171,9 @@ describe('tests/logging/enableWorkerLog.js >', () => {
         { name: `${tu.namePrefix}Subject|${tu.namePrefix}ThreeHours`, value: 2 },
         { name: `${tu.namePrefix}Subject|${tu.namePrefix}NinetyDays`, value: 3 },
       ]))
-      .then(() => Sample.findAll({
-        attributes: ['name', 'updatedAt'],
-        where: {
-          name: {
-            $ilike: `${tu.namePrefix}Subject|%`,
-          },
-        },
-      })
+      .then(() => Sample.findAll()
       .each((s) => {
-        updatedAt = s.updatedAt;
+        updatedAt = new Date(s.updatedAt);
       }))
       .then(() => done())
       .catch(done);
@@ -200,13 +193,7 @@ describe('tests/logging/enableWorkerLog.js >', () => {
         expect(res).to.contains({ numberEvaluated: 4, numberTimedOut: 2 });
         expect(res.timedOutSamples.length).to.equal(res.numberTimedOut);
       })
-      .then(() => Sample.findAll({
-        where: {
-          name: {
-            $ilike: `${tu.namePrefix}Subject|%`,
-          },
-        },
-      })
+      .then(() => Sample.findAll()
       .each((s) => {
         switch (s.name) {
           case `${tu.namePrefix}Subject|${tu.namePrefix}OneSecond`:

--- a/tests/logging/utils.js
+++ b/tests/logging/utils.js
@@ -12,12 +12,16 @@
 
 const tu = require('../testUtils');
 const testStartTime = new Date();
+const rcli = require('../../cache/redisCache').client.sampleStore;
+const Promise = require('bluebird');
 
 module.exports = {
   forceDelete(done) {
-    tu.forceDelete(tu.db.Sample, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+    Promise.join(
+      rcli.flushallAsync(),
+      tu.forceDelete(tu.db.Aspect, testStartTime)
+      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+    )
     .then(() => done())
     .catch(done);
   },

--- a/tests/realtime/realtimeUtils.js
+++ b/tests/realtime/realtimeUtils.js
@@ -302,48 +302,33 @@ describe('tests/realtime/realtimeUtils.js, realtime utils Tests >', () => {
 
     // need done in these tests, otherwise tests pass before promise returns
     describe('attachAspectSubject tests', () => {
+      const copySample = JSON.parse(JSON.stringify(looksLikeSampleObjNA));
       it('useSampleStore = true', (done) => {
-        realtimeUtils.attachAspectSubject(looksLikeSampleObjNA, true)
+        realtimeUtils.attachAspectSubject(looksLikeSampleObjNA)
         .then((sample) => {
           expect(sample).deep.equal(looksLikeSampleObjNA);
           done();
         })
         .catch(done);
       });
-
-      it('useSampleStore = false', (done) => {
-        let sampleFromDb = {
-          get: () => looksLikeSampleObjNA,
-        };
-        realtimeUtils.attachAspectSubject(sampleFromDb, false)
+      it('same output with upper sample name', (done) => {
+        copySample.name = copySample.name.toUpperCase();
+        realtimeUtils.attachAspectSubject(copySample, tu.db.Subject, tu.db.Aspect)
         .then((sample) => {
-          expect(sample).deep.equal(looksLikeSampleObjNA);
+          expect(sample.name).equal(copySample.name);
           done();
         })
         .catch(done);
       });
 
-      describe('case insensitive tests', () => {
-        const copySample = JSON.parse(JSON.stringify(looksLikeSampleObjNA));
-        it('same output with upper sample name', (done) => {
-          copySample.name = copySample.name.toUpperCase();
-          realtimeUtils.attachAspectSubject(copySample, false, tu.db.Subject, tu.db.Aspect)
-          .then((sample) => {
-            expect(sample.name).equal(copySample.name);
-            done();
-          })
-          .catch(done);
-        });
-
-        it('same output with lower sample name', (done) => {
-          copySample.name = copySample.name.toLowerCase();
-          realtimeUtils.attachAspectSubject(copySample, false, tu.db.Subject, tu.db.Aspect)
-          .then((sample) => {
-            expect(sample.name).equal(copySample.name);
-            done();
-          })
-          .catch(done);
-        });
+      it('same output with lower sample name', (done) => {
+        copySample.name = copySample.name.toLowerCase();
+        realtimeUtils.attachAspectSubject(copySample, tu.db.Subject, tu.db.Aspect)
+        .then((sample) => {
+          expect(sample.name).equal(copySample.name);
+          done();
+        })
+        .catch(done);
       });
     });
   });

--- a/tests/realtime/realtimeUtils.js
+++ b/tests/realtime/realtimeUtils.js
@@ -303,7 +303,7 @@ describe('tests/realtime/realtimeUtils.js, realtime utils Tests >', () => {
     // need done in these tests, otherwise tests pass before promise returns
     describe('attachAspectSubject tests', () => {
       const copySample = JSON.parse(JSON.stringify(looksLikeSampleObjNA));
-      it('useSampleStore = true', (done) => {
+      it('without passing in subject and aspect models', (done) => {
         realtimeUtils.attachAspectSubject(looksLikeSampleObjNA)
         .then((sample) => {
           expect(sample).deep.equal(looksLikeSampleObjNA);

--- a/tests/realtime/utils.js
+++ b/tests/realtime/utils.js
@@ -17,6 +17,7 @@ const testStartTime = new Date();
 const rt = `${tu.namePrefix}TestRoomType`;
 const r = `${tu.namePrefix}TestRoom`;
 const bd = `${tu.namePrefix}TestBotData`;
+const samstoinit = require('../../cache/sampleStoreInit');
 
 const standardRoom = {
   name: r,
@@ -216,10 +217,9 @@ module.exports = {
       },
       force: true,
     })
+    .then(() => samstoinit.eradicate())
     .then(() => tu.forceDelete(tu.db.Perspective, testStartTime))
     .then(() => tu.forceDelete(tu.db.Lens, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Sample, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
     .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
     .then(() => tu.forceDelete(tu.db.BotAction, testStartTime))
     .then(() => tu.forceDelete(tu.db.BotData, testStartTime))


### PR DESCRIPTION
This PR just removes the sampleStore flag from the realTime module. The rest of the changes are just clean up (removing unused code, removing redundant blocks etc...). The second commit is the only real change. 

This is the last PR for any change related to the sampleStore.