### PR TITLE
Bot Object -> Version field -> PUT request bug

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -2209,6 +2209,9 @@ paths:
               active:
                 type: boolean
                 description: If the bot is active
+              version:
+                type: string
+                description: The version of the bot. Use Semantic Versioning 2.0.0
               actions:
                 type: array
                 description: Array of objects that contain the name of actions a bot can take and an array of parameters needed for that action
@@ -2267,6 +2270,11 @@ paths:
           name: url
           in: formData
           description: The URL of the bot server
+          type: string
+        -
+          name: version
+          in: formData
+          description: The version of the bot. Use Semantic Versioning 2.0.0
           type: string
         -
           name: ui

--- a/tests/api/v1/bots/put.js
+++ b/tests/api/v1/bots/put.js
@@ -68,6 +68,23 @@ describe('tests/api/v1/bots/put.js >', () => {
     });
   });
 
+  it('Pass, put bot version & url', (done) => {
+    api.put(`${path}/${testBot.id}`)
+    .set('Authorization', token)
+    .field('version', '9.9.9')
+    .field('url', 'https://newUrl.com')
+    .expect(constants.httpStatus.CREATED)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.version).to.equal('9.9.9');
+      expect(res.body.url).to.equal('https://newUrl.com');
+      done();
+    });
+  });
+
   it('Fail, put bot invalid name', (done) => {
     const newName = '~!invalidName';
     api.put(`${path}/${testBot.id}`)


### PR DESCRIPTION
Issue: PUT requests aren't updating `version` field for Bots
This PR fixes the bug