### PR TITLE
fixed sampleStore logic for subjects

### DIFF
--- a/tests/api/v1/subjects/post.js
+++ b/tests/api/v1/subjects/post.js
@@ -452,7 +452,8 @@ describe(`tests/api/v1/subjects/post.js, POST ${path} >`, () => {
       .set('Authorization', token)
       .send(n0)
       .expect(constants.httpStatus.BAD_REQUEST)
-      .expect(res => expect(res.body.errors[0].type).to.equal(tu.uniErrorName))
+      .expect((res) => expect(res.body.errors[0].type).to.be
+        .oneOf([tu.uniErrorName, tu.duplicateResourceErrorName]))
       .end(done);
     });
 

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -160,6 +160,7 @@ module.exports = {
   looksLikeId,
   dbErrorName: 'SequelizeDatabaseError',
   dbError: new Error('expecting SequelizeDatabaseError'),
+  duplicateResourceErrorName: 'DuplicateResourceError',
   fkErrorName: 'SequelizeForeignKeyConstraintError',
   fkError: new Error('expecting SequelizeForeignKeyConstraintError'),
   namePrefix: pfx,


### PR DESCRIPTION
1. Cleanup the sampleStore logic for Subjects. Make sure that the state of a subject in postgres and redis is
exactly the same. Add/delete subjects to/from the sampleStore even if it is not published.
2. Fix the comments. 