### PR TITLE
Update the generator model "updateForHeartbeat" fn to return the full sgt

### DIFF
--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -343,7 +343,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then((res) => {
             u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res);
             expect(res.body.generatorsAdded[0].aspects[0])
-              .to.contain.property('name', 'Temperature');
+              .to.contain.property('name', 'temperature');
           })
           .then(done).catch(done);
         });

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -103,7 +103,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
         expect(sg2.GeneratorCollectors).to.equal(undefined);
         expect(sg2.collectors).to.equal(undefined);
         expect(res.body.generatorsAdded[0].aspects[0])
-          .to.contain.property('name', 'Temperature');
+          .to.contain.property('name', 'temperature');
         return done();
       });
     });

--- a/tests/api/v1/collectors/utils.js
+++ b/tests/api/v1/collectors/utils.js
@@ -149,7 +149,26 @@ function expectGeneratorArray(res) {
   generatorsDeleted.forEach((gen) => {
     expect(gen).to.be.an('object').that.has.all.keys(expectedProps);
     expect(gen.context).to.be.an('object').that.has.all.keys(expectedCtxProps);
-    expect(gen.generatorTemplate).to.be.an('object').that.has.all.keys('name', 'version');
+    expect(gen.generatorTemplate).to.be.an('object').that.has.all.keys(
+      'author',
+      'connection',
+      'contextDefinition',
+      'createdAt',
+      'createdBy',
+      'deletedAt',
+      'description',
+      'helpEmail',
+      'helpUrl',
+      'id',
+      'isDeleted',
+      'isPublished',
+      'name',
+      'repository',
+      'tags',
+      'transform',
+      'updatedAt',
+      'user',
+      'version');
   });
   generatorsUpdated.forEach((gen) => {
     expect(gen).to.be.an('object').that.has.all.keys(expectedProps);

--- a/tests/db/model/generator/find.js
+++ b/tests/db/model/generator/find.js
@@ -83,66 +83,19 @@ describe('tests/db/model/generator/find.js >', () => {
   after(u.forceDelete);
   after(gtUtil.forceDelete);
 
-  it.skip('updateForHeartbeat - subject query', (done) => {
-    Generator.findById(generatorDBInstance.id)
-    .then((g) => {
-      expect(g.get().aspects).to.be.an('array')
-      .that.includes('temperature')
-      .that.includes('weather');
-      expect(g.get().subjectQuery).to.equal('?absolutePath=Foo.*');
-      return g;
-    })
-    .then((g) => g.updateForHeartbeat())
-    .then((g) => {
-      const asp = g.get().aspects;
-      expect(asp).to.be.an('array');
-      expect(asp[0]).to.contain.property('name', 'temperature');
-      expect(asp[1]).to.contain.property('name', 'weather');
-      const sub = g.get().subjects;
-      expect(sub).to.be.an('array');
-      expect(sub[0]).to.contain.property('absolutePath', 'foo.bar');
-      expect(sub[1]).to.contain.property('absolutePath', 'foo.baz');
-      done();
-    })
-    .catch(done);
-  });
-
-  it('updateForHeartbeat - array of subjects', (done) => {
-    Generator.findById(g2DBInstance.id)
-    .then((g) => {
-      expect(g.aspects).to.be.an('array').to.have.lengthOf(3)
-      .that.includes('temperature')
-      .that.includes('weather')
-      .that.includes('humidity');
-      expect(g.subjects).to.be.an('array')
-      .that.includes('foo.bar')
-      .that.includes('foo.baz');
-      return g;
-    })
-    .then((g) => g.updateForHeartbeat())
-    .then((g) => {
-      const asp = g.aspects;
-      expect(asp).to.be.an('array').to.have.lengthOf(2);
-      expect(asp[0]).to.contain.property('name', 'Temperature');
-      expect(asp[1]).to.contain.property('name', 'Weather');
-      const sub = g.subjects;
-      expect(sub).to.be.an('array');
-      expect(sub[0]).to.contain.property('absolutePath', 'foo.bar');
-      expect(sub[1]).to.contain.property('absolutePath', 'foo.baz');
-      done();
-    })
-    .catch(done);
-  });
-
   it('findForHeartbeat', (done) => {
     Generator.findForHeartbeat({
       where: { id: [generatorDBInstance.id, g2DBInstance.id] },
     })
     .then((res) => {
       expect(res).to.be.an('array').to.have.lengthOf(2);
-      expect(res[0].aspects[0]).to.contain.property('name', 'Temperature');
+      expect(res[0].aspects[0]).to.have.property('name', 'temperature');
 
-      // expect(res[0].subjects[0]).to.contain.property('absolutePath', 'foo.bar');
+      // Make sure we have the full SGT record here, not just the name/version
+      expect(res[0].generatorTemplate).to.have.property('connection');
+      expect(res[0].generatorTemplate).to.have.property('description');
+      expect(res[0].generatorTemplate).to.have.property('author');
+      expect(res[0].generatorTemplate).to.have.property('transform');
       done();
     })
     .catch(done);


### PR DESCRIPTION
The collector expects the generators returned from start & heartbeat to include the full SGT for each generator.

Also, while I'm here, I got rid of the full aspect stuff from updateForHeartbeat and just send back an array of aspect names in the form of [{ "name": "A1" }, { "name": "A2" }, ...].

Also, while I'm here, I got rid of the subject stuff from updateForHeartbeat.
