### PR TITLE
Log out the number of events per key for real-time events published, …

### DIFF
--- a/clock/index.js
+++ b/clock/index.js
@@ -26,6 +26,7 @@ if (conf.newRelicKey) {
 
 const featureToggles = require('feature-toggles');
 const kueStatsActivityLogs = require('./scheduledJobs/kueStatsActivityLogs');
+const pubStatsLogs = require('./scheduledJobs/pubStatsLogs');
 const persistSampleStoreJob = require('./scheduledJobs/persistSampleStoreJob');
 const queueStatsActivityLogs =
   require('./scheduledJobs/queueStatsActivityLogs');
@@ -53,6 +54,11 @@ if (featureToggles.isFeatureEnabled('enableKueStatsActivityLogs')) {
 if (featureToggles.isFeatureEnabled('enableQueueStatsActivityLogs')) {
   setInterval(queueStatsActivityLogs.execute,
     conf.queueStatsActivityLogsInterval);
+}
+
+// If enablePubStatsLogs is true then write log
+if (featureToggles.isFeatureEnabled('enablePubStatsLogs')) {
+  setInterval(pubStatsLogs.execute, conf.pubStatsLogsIntervalMillis);
 }
 
 // Clean up completed jobs

--- a/clock/scheduledJobs/pubStatsLogs.js
+++ b/clock/scheduledJobs/pubStatsLogs.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * clock/scheduledJobs/pubStatsLogs.js
+ *
+ * Activity logging to track the number of real-time events published per key
+ * since the last logging interval.
+ */
+const aType = 'pubStats';
+const prototype = require('../../config/activityLog').activityType[aType];
+const activityLog = require('../../utils/activityLog');
+const PUB_STATS_HASH = require('../../realtime/constants').pubStatsHash;
+const redis = require('../../cache/redisCache').client.cache;
+
+/**
+ * Generate a pubStats logging object.
+ *
+ * @param {String} key - The "publish" event key
+ * @param {Integer} count - The number of events published to that key since
+ *  the last logging interval
+ * @returns {Object} a new pubStats logging object
+ */
+function toLogObj(key, count) {
+  const obj = JSON.parse(JSON.stringify(prototype));
+  if (typeof key === 'string' && key.length > 0) obj.key = key;
+  if (typeof +count === 'number' && count > 0) obj.count = +count;
+  return obj;
+} // toLogObj
+
+/**
+ * Generate the logging objects, one per publish "key". Look up the pubStats
+ * hash in redis and "reset" it by deleting it; generate and return an array of
+ * pubStats activity type logging objects. 
+ *
+ * @returns {Array} array of pubStats activity type logging objects
+ */
+function generateLogObjects() {
+  return Promise.all([
+    redis.hgetallAsync(PUB_STATS_HASH),
+    redis.delAsync(PUB_STATS_HASH),
+  ])
+  .then((res) => {
+    const p = res[0];
+    return Object.keys(p).map((key) => toLogObj(key, p[key]));
+  });
+} // generateLogObjects
+
+/**
+ * Generate and write out the pub stats logs (one log entry per publish "key").
+ */
+function execute() {
+  generateLogObjects()
+  .then((arr) =>
+    arr.forEach((a) => activityLog.printActivityLogString(a, aType)));
+} // execute
+
+module.exports = {
+  execute,
+  generateLogObjects, // export for testing only
+  toLogObj, // export for testing only
+};

--- a/clock/scheduledJobs/pubStatsLogs.js
+++ b/clock/scheduledJobs/pubStatsLogs.js
@@ -41,14 +41,11 @@ function toLogObj(key, count) {
  * @returns {Array} array of pubStats activity type logging objects
  */
 function generateLogObjects() {
-  return Promise.all([
-    redis.hgetallAsync(PUB_STATS_HASH),
-    redis.delAsync(PUB_STATS_HASH),
-  ])
-  .then((res) => {
-    const p = res[0];
-    return Object.keys(p).map((key) => toLogObj(key, p[key]));
-  });
+  let p;
+  return redis.hgetallAsync(PUB_STATS_HASH)
+  .then((res) => p = res)
+  .then(() => redis.delAsync(PUB_STATS_HASH))
+  .then(() => Object.keys(p).map((key) => toLogObj(key, p[key])));
 } // generateLogObjects
 
 /**

--- a/clock/scheduledJobs/pubStatsLogs.js
+++ b/clock/scheduledJobs/pubStatsLogs.js
@@ -36,7 +36,7 @@ function toLogObj(key, count) {
 /**
  * Generate the logging objects, one per publish "key". Look up the pubStats
  * hash in redis and "reset" it by deleting it; generate and return an array of
- * pubStats activity type logging objects. 
+ * pubStats activity type logging objects.
  *
  * @returns {Array} array of pubStats activity type logging objects
  */

--- a/config.js
+++ b/config.js
@@ -271,6 +271,7 @@ module.exports = {
     DEFAULT_PERSIST_REDIS_SAMPLE_STORE_MILLISECONDS,
   port,
   prioritizeJobsFrom,
+  pubStatsLogsIntervalMillis: +pe.PUB_STATS_LOGS_INTERVAL_MILLIS || 60000,
   queueStatsActivityLogsInterval,
   queueTime95thMillis: pe.QUEUESTATS_95TH_WARNING_MILLIS,
   readReplicas,

--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -35,6 +35,11 @@ module.exports = {
       inactiveCount: 0,
       workTimeMillis: 0,
     },
+    pubStats: {
+      activity: 'pubStats',
+      key: 'None',
+      count: 0,
+    },
     queueStats: {
       activity: 'queueStats',
       averageQueueTimeMillis: 0,

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -60,6 +60,7 @@ const longTermToggles = {
   enableKueStatsActivityLogs:
     environmentVariableTrue(pe, 'ENABLE_KUESTATS_ACTIVITY_LOGS'),
 
+  // Enable logging for real-time publish stats
   enablePubStatsLogs: environmentVariableTrue(pe, 'ENABLE_PUB_STATS_LOGS'),
 
   // Enable queueStatsActivityLogs

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -60,6 +60,8 @@ const longTermToggles = {
   enableKueStatsActivityLogs:
     environmentVariableTrue(pe, 'ENABLE_KUESTATS_ACTIVITY_LOGS'),
 
+  enablePubStatsLogs: environmentVariableTrue(pe, 'ENABLE_PUB_STATS_LOGS'),
+
   // Enable queueStatsActivityLogs
   enableQueueStatsActivityLogs:
     environmentVariableTrue(pe, 'ENABLE_QUEUESTATS_ACTIVITY_LOGS'),

--- a/realtime/constants.js
+++ b/realtime/constants.js
@@ -63,4 +63,5 @@ module.exports = {
     botEventFilterIndex: 3,
   },
 
+  pubStatsHash: 'pubstats',
 };

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -11,11 +11,24 @@
  */
 'use strict'; // eslint-disable-line strict
 const emitter = require('./socketIOEmitter');
+const rcache = require('../cache/redisCache').client.cache;
 const subPerspective = require('../cache/redisCache').client.subPerspective;
 const subBot = require('../cache/redisCache').client.subBot;
 const featureToggles = require('feature-toggles');
 const rtUtils = require('./utils');
+const PUB_STATS_HASH = require('./constants').pubStatsHash;
 const logger = require('winston');
+
+/**
+ * Store pub stats in redis cache, count by key. Note that we're using the
+ * async redis command here; we don't require the hincrby command to complete
+ * before moving on to other work, so we're not wrapping it in a promise.
+ *
+ * @param {String} key - The publish key
+ */
+function trackPublishKey(key) {
+  rcache.hincrbyAsync(PUB_STATS_HASH, key, 1);
+}
 
 /**
  * Redis subscriber uses socket.io to broadcast.
@@ -24,41 +37,27 @@ const logger = require('winston');
  * @param {Object} sub - Redis subscriber instance
  */
 module.exports = (io) => {
-  // Broadcast messages to Perspectives
-  subPerspective.on('message', (channel, mssgStr) => {
-    if (featureToggles.isFeatureEnabled('enableRealtimeActivityLogs')) {
-      logger.info('Size of the sample received by the subscriber',
-        mssgStr.length);
-    }
+  // Broadcast messages to Perspectives and Bots
+  [subBot, subPerspective].forEach((s) => {
+    s.on('message', (channel, mssgStr) => {
+      if (featureToggles.isFeatureEnabled('enableRealtimeActivityLogs')) {
+        logger.info('Size of message received by subscriber', mssgStr.length);
+      }
 
-    // message object to be sent to the clients
-    const mssgObj = JSON.parse(mssgStr);
-    const key = Object.keys(mssgObj)[0];
-    const parsedObj = rtUtils.parseObject(mssgObj[key], key);
+      // message object to be sent to the clients
+      const mssgObj = JSON.parse(mssgStr);
+      const key = Object.keys(mssgObj)[0];
+      const parsedObj = rtUtils.parseObject(mssgObj[key], key);
 
-    /*
-     * pass on the message received through the redis subscriber to the socket
-     * io emitter to send data to the browser clients.
-     */
-    emitter(io, key, parsedObj);
-  });
+      if (featureToggles.isFeatureEnabled('enablePubStatsLogs')) {
+        trackPublishKey(key);
+      }
 
-  // Broadcast messages to Bots
-  subBot.on('message', (channel, mssgStr) => {
-    if (featureToggles.isFeatureEnabled('enableRealtimeActivityLogs')) {
-      logger.info('Size of the bot received by the subscriber',
-        mssgStr.length);
-    }
-
-    // message object to be sent to the clients
-    const mssgObj = JSON.parse(mssgStr);
-    const key = Object.keys(mssgObj)[0];
-    const parsedObj = rtUtils.parseObject(mssgObj[key], key);
-
-    /*
-     * pass on the message received through the redis subscriber to the socket
-     * io emitter to send data
-     */
-    emitter(io, key, parsedObj);
+      /*
+       * pass on the message received through the redis subscriber to the socket
+       * io emitter to send data to the browser clients.
+       */
+      emitter(io, key, parsedObj);
+    });
   });
 };

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -40,11 +40,6 @@ module.exports = (io) => {
   // Broadcast messages to Perspectives and Bots
   [subBot, subPerspective].forEach((s) => {
     s.on('message', (channel, mssgStr) => {
-      if (featureToggles.isFeatureEnabled('enableRealtimeActivityLogs')) {
-        logger.info('Size of message received by subscriber', mssgStr.length);
-      }
-
-      // message object to be sent to the clients
       const mssgObj = JSON.parse(mssgStr);
       const key = Object.keys(mssgObj)[0];
       const parsedObj = rtUtils.parseObject(mssgObj[key], key);

--- a/tests/clock/pubStatsLogs.js
+++ b/tests/clock/pubStatsLogs.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/clock/pubStatsLogs.js
+ */
+const expect = require('chai').expect;
+const p = require('../../clock/scheduledJobs/pubStatsLogs');
+const rcache = require('../../cache/redisCache').client.cache;
+const PUB_STATS_HASH = require('../../realtime/constants').pubStatsHash;
+
+describe('tests/clock/pubStatsLogs >', () => {
+  describe('toLogObj >', () => {
+    it('ok', () => {
+      expect(p.toLogObj('x.y.z', 1)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'x.y.z',
+        count: 1,
+      });
+    });
+
+    it('null key', () => {
+      expect(p.toLogObj(null, 100)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'None',
+        count: 100,
+      });
+    });
+
+    it('non-string key', () => {
+      expect(p.toLogObj(3.1415927, 100)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'None',
+        count: 100,
+      });
+    });
+
+    it('zero-length key', () => {
+      expect(p.toLogObj('', 100)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'None',
+        count: 100,
+      });
+    });
+
+    it('null count', () => {
+      expect(p.toLogObj('ab.cd.ef', null)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'ab.cd.ef',
+        count: 0,
+      });
+    });
+
+    it('non-numeric count', () => {
+      expect(p.toLogObj('ab.cd.ef', 'yellow')).to.deep.equal({
+        activity: 'pubStats',
+        key: 'ab.cd.ef',
+        count: 0,
+      });
+    });
+
+    it('negative count', () => {
+      expect(p.toLogObj('ab.cd.ef', -47)).to.deep.equal({
+        activity: 'pubStats',
+        key: 'ab.cd.ef',
+        count: 0,
+      });
+    });
+  });
+
+  describe('generateLogObjects >', () => {
+    beforeEach(() => {
+      rcache.hincrby(PUB_STATS_HASH, 'a.a.a', 1);
+      rcache.hincrby(PUB_STATS_HASH, 'b.b.b', 10);
+      rcache.hincrby(PUB_STATS_HASH, 'c.c.c', 100);
+    });
+
+    afterEach(() => rcache.del(PUB_STATS_HASH));
+
+    it('ok', (done) => {
+      p.generateLogObjects()
+      .then((arr) => {
+        expect(arr).to.deep.equal([
+          { activity: 'pubStats', key: 'a.a.a', count: 1 },
+          { activity: 'pubStats', key: 'b.b.b', count: 10 },
+          { activity: 'pubStats', key: 'c.c.c', count: 100 },
+        ]);
+        return rcache.existsAsync(PUB_STATS_HASH);
+      })
+      .then((exists) => expect(exists).to.deep.equal(0))
+      .then(() => done())
+      .catch(done);
+    });
+  });
+});


### PR DESCRIPTION
…for perspectives and bots.

- (config/toggles.js) Define new toggle "enablePubStatsLogs" based on env var ENABLE_PUB_STATS_LOGS.
- (config.js) Define new config var pubStatsLogsIntervalMillis, default to 60000 (1 min.), override with env var PUB_STATS_LOGS_INTERVAL_MILLIS. When enablePubStatsLogs is enabled, we will write out "activity=pubStats" log lines every minute (unless admin overrides the default).
- (config/activityLog.js) Define new "activity=pubStats" log type
- (clock/scheduledJobs/pubStatsLogs.js) New scheduled job to generate the "activity=pubStats" log lines and reset the counters every <pubStatsLogsIntervalMillis>.
- (clock/index.js) When enablePubStatsLogs is enabled, add the new pubStatsLogs scheduled job to the list of jobs managed by the clock dyno.
- (realtime/constants.js) - Define a constant to use as the key to the redis cache hash object where we will store the published event counts.
- (realtime/redisSubscriber.js) - When enablePubStatsLogs is enabled, track the number of real-time events in redis cache.
- (tests/clock/pubStatsLogs.js) - Unit test the clock/pubStatsLogs.js functions