### PR TITLE
allow admin to prioritize/deprioritize jobs by user name and/or token

### DIFF
--- a/config.js
+++ b/config.js
@@ -106,10 +106,10 @@ const JOB_COUNTER_RESET_INTERVAL = 60 * 1000 *
 
 /*
  * If you're using worker dynos, you can set env vars PRIORITIZE_JOBS_FROM
- * and/or DEPRIORITIZE_JOBS_FROM to comma-separated lists of ip addresses if
- * you want to prioritize or deprioritize jobs from a particular user ip
- * address (or multiple users' ip addresses). Has no effect if you're not
- * using worker dynos.
+ * and/or DEPRIORITIZE_JOBS_FROM to comma-separated lists of user names, token
+ * names or ip addresses if you want to prioritize or deprioritize jobs from
+ * particular users and/or tokens and/or ip addresses. Has no effect if you're
+ * not using worker dynos.
  */
 const prioritizeJobsFrom = configUtil.csvToArray(pe.PRIORITIZE_JOBS_FROM);
 const deprioritizeJobsFrom = configUtil.csvToArray(pe.DEPRIORITIZE_JOBS_FROM);

--- a/tests/jobQueue/v1/jobWrapper.js
+++ b/tests/jobQueue/v1/jobWrapper.js
@@ -63,5 +63,87 @@ describe(`tests/jobQueue/v1/jobWrapper.js, api: POST ${path} >`, () => {
     })
     .catch((err) => done(err));
   });
-});
 
+  describe('calculateJobPriority >', () => {
+    const prioritize = [
+      'frodo.baggins@hobbiton.com',
+      '123.456.789',
+      'abcdefg',
+    ];
+    const deprioritize = [
+      'bilbo.baggins@hobbiton.com',
+      '456.789.123',
+      'hijklmnop',
+    ];
+
+    it('prioritize by name', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'frodo.baggins@hobbiton.com',
+          TokenName: 'Smaug',
+          'x-forwarded-for': '123.456.789',
+        },
+      })).to.equal('high');
+    });
+
+    it('prioritize by token', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'legolas@elf.com',
+          TokenName: 'abcdefg',
+          'x-forwarded-for': '456.789.123',
+        },
+      })).to.equal('high');
+    });
+
+    it('prioritize by ip address', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'legolas@elf.com',
+          TokenName: 'Smaug',
+          'x-forwarded-for': '123.456.789',
+        },
+      })).to.equal('high');
+    });
+
+    it('deprioritize by name', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'bilbo.baggins@hobbiton.com',
+          TokenName: 'Smaug',
+          'x-forwarded-for': '789.123.456',
+        },
+      })).to.equal('low');
+    });
+
+    it('deprioritize by token', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'legolas@elf.com',
+          TokenName: 'hijklmnop',
+          'x-forwarded-for': '789.123.456',
+        },
+      })).to.equal('low');
+    });
+
+    it('deprioritize by ip address', () => {
+      expect(jobWrapper.calculateJobPriority(prioritize, deprioritize, {
+        headers: {
+          UserName: 'legolas@elf.com',
+          TokenName: 'Smaug',
+          'x-forwarded-for': '456.789.123',
+        },
+      })).to.equal('low');
+    });
+
+    it('empty prioritize/deprioritize arrays', () => {
+      expect(jobWrapper.calculateJobPriority([], [], {
+        headers: {
+          UserName: 'frodo.baggins@hobbiton.com',
+          TokenName: 'Smaug',
+          'x-forwarded-for': '123.456.789',
+        },
+      })).to.equal('normal');
+    });
+  });
+});


### PR DESCRIPTION
in addition to just ip address

modified the calculateJobPriority function signature to get rid of args we aren't using, PLUS added args to pass in conf.prioritizeJobsFrom and conf.deprioritizeJobsFrom for better testability