### PR TITLE
fix associations bug

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -641,16 +641,12 @@ function findByKey(props, params, extraAttributes) {
   opts.where = {};
   opts.where[props.nameFinder || 'name'] = keyClause;
 
-  const attrArr = [];
-  if (opts.attributes && Array.isArray(opts.attributes)) {
-    for (let i = 0; i < opts.attributes.length; i++) {
-      attrArr.push(opts.attributes[i]);
-    }
-  }
-
-  if (extraAttributes && Array.isArray(extraAttributes)) {
-    for (let i = 0; i < extraAttributes.length; i++) {
-      attrArr.push(extraAttributes[i]);
+  let attrArr = opts.attributes;
+  if (extraAttributes && Array.isArray(extraAttributes) && extraAttributes.length) {
+    if (attrArr) {
+      attrArr.push(...extraAttributes);
+    } else {
+      attrArr = extraAttributes;
     }
   }
 

--- a/tests/api/v1/common/testAssociations.js
+++ b/tests/api/v1/common/testAssociations.js
@@ -98,6 +98,20 @@ function testAssociations(path, associations, joiSchema, conf) {
     });
   });
 
+  associations.forEach((assoc) => {
+    it(`get by key: an association can be specified as a field param (${assoc})`, (done) => {
+      api.get(`${path}/${recordId}?fields=name,${assoc}`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.keys('id', 'name', assoc, 'apiLinks');
+        expect(Joi.validate(res.body[assoc], joiSchema[assoc]).error).to.be.null;
+      })
+      .end(done);
+    });
+  });
+
   /*
    * These tests fail because of a bug in sequelize.
    * It doesn't properly handle multiple associations when a limit is applied:
@@ -106,21 +120,7 @@ function testAssociations(path, associations, joiSchema, conf) {
    * I think it was fixed in https://github.com/sequelize/sequelize/pull/9188
    * Skipping until we upgrade Sequelize...
    */
-  describe.skip('sequelize bug', () => {
-    associations.forEach((assoc) => {
-      it(`get by key: an association can be specified as a field param (${assoc})`, (done) => {
-        api.get(`${path}/${recordId}?fields=name,${assoc}`)
-        .set('Authorization', token)
-        .expect(constants.httpStatus.OK)
-        .expect((res) => {
-          expect(res.body).to.be.an('object');
-          expect(res.body).to.have.keys('id', 'name', assoc, 'apiLinks');
-          expect(Joi.validate(res.body[assoc], joiSchema[assoc]).error).to.be.null;
-        })
-        .end(done);
-      });
-    });
-
+  describe('sequelize bug', () => {
     if (associations.length > 1) {
       it('find: multiple associations can be specified as field params', (done) => {
         const fields = ['name', ...associations].toString();

--- a/tests/api/v1/tokens/associations.js
+++ b/tests/api/v1/tokens/associations.js
@@ -93,21 +93,13 @@ describe(`tests/api/v1/tokens/associations.js, GET ${path} >`, () => {
     .end(done);
   });
 
-  /*
-   * This test fails because of a bug in sequelize.
-   * It doesn't properly handle multiple associations when a limit is applied:
-   * It selects the attributes before doing the join for the association, which
-   * causes an error when the foreign key is not included in the fields.
-   * I think it was fixed in https://github.com/sequelize/sequelize/pull/9188
-   * Skipping until we upgrade Sequelize...
-   */
-  it.skip(`get by key: an association can be specified as a field param (user)`, (done) => {
+  it(`get by key: an association can be specified as a field param (user)`, (done) => {
     api.get(`${path}/${token1.name}?fields=name,user`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .expect((res) => {
       expect(res.body).to.be.an('object');
-      expect(res.body).to.have.keys('id', 'name', 'user', 'apiLinks');
+      expect(res.body).to.have.keys('id', 'name', 'user', 'isRevoked', 'apiLinks');
       expect(Joi.validate(res.body.user, joiSchema.user).error).to.be.null;
     })
     .end(done);


### PR DESCRIPTION
This is a fix for some of the failing associations tests. When I saw these were failing, I assumed it was the same cause as the issue that I had already investigated and determined was a sequelize bug, so I skipped them as well. It was actually an unrelated bug in my changes, which is fixed here.

The original issue is still occurring, it was not fixed by the sequelize upgrade.
I created W-5026622 to investigate further.