### PR TITLE
disable acquire timeout

### DIFF
--- a/config.js
+++ b/config.js
@@ -168,6 +168,7 @@ module.exports = {
       max: pe.DB_CONNECTION_POOL_MAX || DEFAULT_DB_CONNECTION_POOL.max,
       min: pe.DB_CONNECTION_POOL_MIN || DEFAULT_DB_CONNECTION_POOL.min,
       idle: pe.DB_CONNECTION_POOL_IDLE || DEFAULT_DB_CONNECTION_POOL.idle,
+      acquire: null, // disable acquire timeout
     },
     modelDirName: 'model',
     passwordHashSaltNumRounds: 8,


### PR DESCRIPTION
This is to fix the "TimeoutError: ResourceRequest timed out" error.
It was caused by the recent upgrade to Sequelize v4, which includes changes to the connection pool handling. 

Sequelize 4 includes an update to generic-pool v3. Generic-pool v3 introduces a new option, "acquireTimeoutMillis", that will throw an error if it waits too long to acquire a resource. Generic-pool has this disabled by default, but Sequelize sets it to 10s by default.

When under load, a small percentage of upserts were taking longer than 10s and throwing the error. (about .1%) Presumably some requests were taking this long previously (with attachAspSubjFromDb enabled), they just didn't timeout.

I think the best solution is just to override the Sequelize default and disable the timeout.

This wouldn't be a change in functionality; it will give us the exact same behavior as before, and as is the default in Generic pool: resource requests will never timeout and will continue waiting until they acquire a resource.

It also wouldn't be ignoring the root cause; the root cause is the recent changes to attach the Subject from the DB, and that's a broader performance issue that is already being worked on separately. 