### PR TITLE
Track generator changes for current collector only

### DIFF
--- a/api/v1/controllers/generators.js
+++ b/api/v1/controllers/generators.js
@@ -151,18 +151,14 @@ module.exports = {
     apiUtils.noReadOnlyFieldsInReq(req, helper.readOnlyFields);
     const resultObj = { reqStartTime: req.timestamp };
     const requestBody = req.swagger.params.queryBody.value;
-    let oldCollectors;
     validateGeneratorAspectsPermissions(requestBody.aspects, req)
     .then(() => u.findByKey(helper, req.swagger.params))
     .then((o) => u.isWritable(req, o))
     .then((o) => {
       u.patchArrayFields(o, requestBody, helper);
-      oldCollectors = o.collectors.map(collector => collector.name);
       return o.updateWithCollectors(requestBody, u.whereClauseForNameInArr);
     })
     .then((retVal) => {
-      const newCollectors = retVal.collectors.map(collector => collector.name);
-      heartbeatUtils.trackGeneratorChanges(retVal, oldCollectors, newCollectors);
       return u.handleUpdatePromise(resultObj, req, retVal, helper, res);
     })
     .catch((err) => u.handleError(next, err, helper.modelName));
@@ -190,9 +186,6 @@ module.exports = {
     .then((o) => o.reload())
     .then((o) => {
       resultObj.dbTime = new Date() - resultObj.reqStartTime;
-      const oldCollectors = [];
-      const newCollectors = o.collectors.map(collector => collector.name);
-      heartbeatUtils.trackGeneratorChanges(o, oldCollectors, newCollectors);
       u.sortArrayObjectsByField(helper, o); // order collectors by name
       u.logAPI(req, resultObj, o);
       res.status(constants.httpStatus.CREATED)
@@ -238,9 +231,6 @@ module.exports = {
     })
     .then((_updatedInstance) => {
       instance = _updatedInstance;
-      const oldCollectors = instance.collectors.map(c => c.name);
-      const newCollectors = collectors.map(c => c.name);
-      heartbeatUtils.trackGeneratorChanges(instance, oldCollectors, newCollectors);
       return instance.setCollectors(collectors);
     }) // need reload instance to attach associations
     .then(() => instance.reload())

--- a/api/v1/controllers/generators.js
+++ b/api/v1/controllers/generators.js
@@ -158,9 +158,7 @@ module.exports = {
       u.patchArrayFields(o, requestBody, helper);
       return o.updateWithCollectors(requestBody, u.whereClauseForNameInArr);
     })
-    .then((retVal) => {
-      return u.handleUpdatePromise(resultObj, req, retVal, helper, res);
-    })
+    .then((retVal) => u.handleUpdatePromise(resultObj, req, retVal, helper, res))
     .catch((err) => u.handleError(next, err, helper.modelName));
   },
 

--- a/api/v1/helpers/verbs/heartbeatUtils.js
+++ b/api/v1/helpers/verbs/heartbeatUtils.js
@@ -102,28 +102,27 @@ function getKey(collectorName, changeType) {
  * collector.
  *
  * @param {Object} generator - The Generator that has been changed
- * @param {Array} oldCollectors - The names of the collectors that were associated
- *  with this generator before the update.
- * @param {Array} newCollectors - The names of the collectors that are associated
- *  with this generator now, after the update has been applied.
+ * @param {Array} oldCollector - The name of the Collector this Generator was
+ *  assigned to before the update.
+ * @param {Array} newCollector - The name of the Collector this Generator is
+ *  assigned to after the update.
  */
-function trackGeneratorChanges(generator, oldCollectors, newCollectors) {
-  const genId = generator.id;
-  const allCollectors = Array.from(new Set([...oldCollectors, ...newCollectors]));
+function trackGeneratorChanges(generator, oldCollector, newCollector) {
+  if (oldCollector === newCollector) {
+    return trackChangesForCollector(oldCollector, UPDATED, generator);
+  }
+  else {
+    return Promise.all([
+      trackChangesForCollector(oldCollector, DELETED, generator),
+      trackChangesForCollector(newCollector, ADDED, generator),
+    ]);
+  }
 
-  Promise.all(allCollectors.map(name => getChangedIds(name)))
-  .then((collectorChanges) => {
-    let promises = [];
-    collectorChanges.forEach((changedIds, i) => {
-      const collectorName = allCollectors[i];
-
-      // determine the change type
-      let change;
-      const inOld = oldCollectors.includes(collectorName);
-      const inNew = newCollectors.includes(collectorName);
-      if (inOld && !inNew) change = DELETED;
-      if (!inOld && inNew) change = ADDED;
-      if (inOld && inNew) change = UPDATED;
+  function trackChangesForCollector(collectorName, change, generator) {
+    const genId = generator.id;
+    if (!collectorName) return Promise.resolve();
+    return getChangedIds(collectorName)
+    .then((changedIds) => {
 
       // determine if this generator has already been changed since the last heartbeat
       const alreadyAdded = changedIds.added.includes(genId);
@@ -149,12 +148,13 @@ function trackGeneratorChanges(generator, oldCollectors, newCollectors) {
       }
 
       // update redis
-      promises.push(removeFromSet(collectorName, undoChange, genId));
-      promises.push(addToSet(collectorName, change, genId));
+      return Promise.all([
+        removeFromSet(collectorName, undoChange, genId),
+        addToSet(collectorName, change, genId),
+      ]);
     });
+  }
 
-    return Promise.all(promises);
-  });
 } // trackGeneratorChanges
 
 module.exports = {

--- a/api/v1/helpers/verbs/heartbeatUtils.js
+++ b/api/v1/helpers/verbs/heartbeatUtils.js
@@ -110,8 +110,7 @@ function getKey(collectorName, changeType) {
 function trackGeneratorChanges(generator, oldCollector, newCollector) {
   if (oldCollector === newCollector) {
     return trackChangesForCollector(oldCollector, UPDATED, generator);
-  }
-  else {
+  } else {
     return Promise.all([
       trackChangesForCollector(oldCollector, DELETED, generator),
       trackChangesForCollector(newCollector, ADDED, generator),

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -292,7 +292,8 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         .catch(done);
       });
 
-      describe('make sure updating a nonexistent collector doesnt modify ' +
+      //TODO: need to add DB validation that Generator.currentCollector exists
+      describe.skip('make sure updating a nonexistent collector doesnt modify ' +
       'the collectorMap >', () => {
         const collector4 = u.getCollectorToCreate();
         collector4.name += '4';
@@ -302,9 +303,9 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           done();
         });
 
-        it('post with collector that doesnt exist', (done) => {
+        it('create with collector that doesnt exist', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector4], 404))
+          .then(() => u.createGenerator(generator1, userId, collector4, 404))
           .then(() => u.startCollector(collector4, collectorTokens, userToken))
           .then(() => u.sendHeartbeat(collector4, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 },
@@ -312,10 +313,10 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('patch with collector that doesnt exist', (done) => {
+        it('update with collector that doesnt exist', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, []))
-          .then(() => u.patchGenerator(generator1, userToken, [collector4], 404))
+          .then(() => u.createGenerator(generator1, userId, null))
+          .then(() => u.updateGenerator(generator1, userToken, collector4, 404))
           .then(() => u.startCollector(collector4, collectorTokens, userToken))
           .then(() => u.sendHeartbeat(collector4, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 },
@@ -323,22 +324,12 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('put with collector that doesnt exist', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, []))
-          .then(() => u.putGenerator(generator1, userToken, [collector4], 404))
-          .then(() => u.startCollector(collector4, collectorTokens, userToken))
-          .then(() => u.sendHeartbeat(collector4, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 },
-            res))
-          .then(done).catch(done);
-        });
       });
 
-      describe('basic updates >', () => {
-        it('post', (done) => {
+      describe('basic changes >', () => {
+        it('create', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => {
             u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res);
@@ -348,44 +339,22 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('patch', (done) => {
+        it('update', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator1, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 },
             res))
           .then(done).catch(done);
         });
 
-        it('patch add', (done) => {
+        it('update move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken, [collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put move', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -393,103 +362,127 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('no updates', (done) => {
+        it('no changes', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
           .then(done).catch(done);
         });
 
-        it('post with no collectors', (done) => {
+        it('create with no collectors', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken))
+          .then(() => u.createGenerator(generator1, userId))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
-          .then(() => u.patchGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator1, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
-          .then(() => u.patchGenerator(generator1, userToken, [collector1]))
+          .then(() => u.updateGenerator(generator1, userToken, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
           .then(done).catch(done);
         });
 
-        it('patch with duplicate names', (done) => {
+      });
+
+      describe('isActive', () => {
+        it('false - no change', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1, false))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken, [collector1]))
+          .then((res) => {
+            u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res);
+          })
+          .then(done).catch(done);
+        });
+
+        it('true - added', (done) => {
+          Promise.resolve()
+          .then(() => u.createGenerator(generator1, userId, collector1, true))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.patchGenerator(generator1, userToken, [collector1, collector2]))
+          .then((res) => {
+            u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res);
+          })
+          .then(done).catch(done);
+        });
+
+        it('false -> false: no change', (done) => {
+          Promise.resolve()
+          .then(() => u.createGenerator(generator1, userId, collector1, false))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
+          .then(() => u.updateGenerator(generator1, userToken, null, false))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 },
+            res))
+          .then(done).catch(done);
+        });
+
+        it('false -> true: added', (done) => {
+          Promise.resolve()
+          .then(() => u.createGenerator(generator1, userId, collector1, false))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then(() => u.updateGenerator(generator1, userToken, null, true))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 },
+            res))
+          .then(done).catch(done);
+        });
+
+        it('true -> false: deleted', (done) => {
+          Promise.resolve()
+          .then(() => u.createGenerator(generator1, userId, collector1, true))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then(() => u.updateGenerator(generator1, userToken, null, false))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 },
+            res))
+          .then(done).catch(done);
+        });
+
+        it('true -> true: updated', (done) => {
+          Promise.resolve()
+          .then(() => u.createGenerator(generator1, userId, collector1, true))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then(() => u.updateGenerator(generator1, userToken, null, true))
+          .then(() => u.sendHeartbeat(collector1, collectorTokens))
+          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 },
+            res))
           .then(done).catch(done);
         });
       });
 
-      describe('basic updates to multiple generators >', () => {
-        it('post', (done) => {
+      describe('basic changes to multiple generators >', () => {
+        it('create', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
           .then(done).catch(done);
         });
 
-        it('patch', (done) => {
+        it('update', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.patchGenerator(generator2, userToken))
+          .then(() => u.updateGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator2, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 2 }, res))
           .then(done).catch(done);
         });
 
-        it('patch add', (done) => {
+        it('update move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
-          .then(() => u.patchGenerator(generator1, userToken, [collector2]))
-          .then(() => u.patchGenerator(generator2, userToken, [collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 2 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator2, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 2 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put move', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator2, userToken, [collector2]))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
+          .then(() => u.updateGenerator(generator2, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 2, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -498,117 +491,20 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('basic updates with multiple collectors >', () => {
-        it('post', (done) => {
+      describe('multiple changes to the same generator >', () => {
+        it('create + update', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('patch', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1, collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(done).catch(done);
-        });
-      });
-
-      describe('multiple updates to the same generator >', () => {
-        it('post + patch', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.patchGenerator(generator1, userToken))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.updateGenerator(generator1, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
           .then(done).catch(done);
         });
 
-        it('post + patch add', (done) => {
+        it('create + update move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.patchGenerator(generator1, userToken, [collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('patch + patch', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(done).catch(done);
-        });
-
-        it('patch + patch add', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.patchGenerator(generator1, userToken, [collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('patch add + patch add', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken, [collector2]))
-          .then(() => u.patchGenerator(generator1, userToken, [collector3]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('post + put', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('post + put move', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -616,23 +512,23 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('put + put', (done) => {
+        it('update + update', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
+          .then(() => u.updateGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator1, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
           .then(done).catch(done);
         });
 
-        it('put + put move', (done) => {
+        it('update + update move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
+          .then(() => u.updateGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -640,12 +536,12 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('put move + put move', (done) => {
+        it('update move + update move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator1, userToken, [collector3]))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
+          .then(() => u.updateGenerator(generator1, userToken, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -655,53 +551,20 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           .then(done).catch(done);
         });
 
-        it('put move + put move back', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-
-        it('put + patch', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(done).catch(done);
-        });
-
-        it('post + put + patch', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(done).catch(done);
-        });
       });
 
-      describe('updates to multiple generators >', () => {
+      describe('changes to multiple generators >', () => {
         it('update', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector2]))
-          .then(() => u.postGenerator(generator3, userToken, [collector3]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector2))
+          .then(() => u.createGenerator(generator3, userId, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
           .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.patchGenerator(generator2, userToken))
-          .then(() => u.patchGenerator(generator3, userToken))
+          .then(() => u.updateGenerator(generator1, userToken))
+          .then(() => u.updateGenerator(generator2, userToken))
+          .then(() => u.updateGenerator(generator3, userToken))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -713,15 +576,15 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
 
         it('update and move', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector1]))
-          .then(() => u.postGenerator(generator3, userToken, [collector3]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector1))
+          .then(() => u.createGenerator(generator3, userId, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
           .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator2, userToken, [collector2]))
-          .then(() => u.putGenerator(generator3, userToken, [collector1]))
+          .then(() => u.updateGenerator(generator1, userToken, collector1))
+          .then(() => u.updateGenerator(generator2, userToken, collector2))
+          .then(() => u.updateGenerator(generator3, userToken, collector1))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 1, deleted: 1, updated: 1 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -732,18 +595,18 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('multiple updates to multiple generators >', () => {
-        it('post then move all twice', (done) => {
+      describe('multiple changes to multiple generators >', () => {
+        it('create then move all twice', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector2]))
-          .then(() => u.postGenerator(generator3, userToken, [collector3]))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator2, userToken, [collector1]))
-          .then(() => u.putGenerator(generator3, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator2, userToken, [collector2]))
-          .then(() => u.putGenerator(generator3, userToken, [collector2]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector2))
+          .then(() => u.createGenerator(generator3, userId, collector3))
+          .then(() => u.updateGenerator(generator1, userToken, collector1))
+          .then(() => u.updateGenerator(generator2, userToken, collector1))
+          .then(() => u.updateGenerator(generator3, userToken, collector1))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
+          .then(() => u.updateGenerator(generator2, userToken, collector2))
+          .then(() => u.updateGenerator(generator3, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -755,18 +618,18 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
 
         it('move all twice', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector2]))
-          .then(() => u.postGenerator(generator3, userToken, [collector3]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector2))
+          .then(() => u.createGenerator(generator3, userId, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
           .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator2, userToken, [collector1]))
-          .then(() => u.putGenerator(generator3, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator2, userToken, [collector2]))
-          .then(() => u.putGenerator(generator3, userToken, [collector2]))
+          .then(() => u.updateGenerator(generator1, userToken, collector1))
+          .then(() => u.updateGenerator(generator2, userToken, collector1))
+          .then(() => u.updateGenerator(generator3, userToken, collector1))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
+          .then(() => u.updateGenerator(generator2, userToken, collector2))
+          .then(() => u.updateGenerator(generator3, userToken, collector2))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -778,21 +641,21 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
 
         it('move all - cycle collectors', (done) => {
           Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1]))
-          .then(() => u.postGenerator(generator2, userToken, [collector2]))
-          .then(() => u.postGenerator(generator3, userToken, [collector3]))
+          .then(() => u.createGenerator(generator1, userId, collector1))
+          .then(() => u.createGenerator(generator2, userId, collector2))
+          .then(() => u.createGenerator(generator3, userId, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
           .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator2, userToken, [collector3]))
-          .then(() => u.putGenerator(generator3, userToken, [collector1]))
-          .then(() => u.putGenerator(generator1, userToken, [collector3]))
-          .then(() => u.putGenerator(generator2, userToken, [collector1]))
-          .then(() => u.putGenerator(generator3, userToken, [collector2]))
-          .then(() => u.putGenerator(generator1, userToken, [collector1]))
-          .then(() => u.putGenerator(generator2, userToken, [collector2]))
-          .then(() => u.putGenerator(generator3, userToken, [collector3]))
+          .then(() => u.updateGenerator(generator1, userToken, collector2))
+          .then(() => u.updateGenerator(generator2, userToken, collector3))
+          .then(() => u.updateGenerator(generator3, userToken, collector1))
+          .then(() => u.updateGenerator(generator1, userToken, collector3))
+          .then(() => u.updateGenerator(generator2, userToken, collector1))
+          .then(() => u.updateGenerator(generator3, userToken, collector2))
+          .then(() => u.updateGenerator(generator1, userToken, collector1))
+          .then(() => u.updateGenerator(generator2, userToken, collector2))
+          .then(() => u.updateGenerator(generator3, userToken, collector3))
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
           .then(() => u.sendHeartbeat(collector2, collectorTokens))
@@ -803,36 +666,6 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         });
       });
 
-      describe('multiple generators multiple collectors >', () => {
-        it('update', (done) => {
-          Promise.resolve()
-          .then(() => u.postGenerator(generator1, userToken, [collector1, collector2]))
-          .then(() => u.postGenerator(generator2, userToken, [collector2, collector3]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 2, deleted: 0, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 0, updated: 0 }, res))
-          .then(() => u.patchGenerator(generator1, userToken))
-          .then(() => u.patchGenerator(generator2, userToken))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 2 }, res))
-          .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 1 }, res))
-          .then(() => u.putGenerator(generator1, userToken, [collector2]))
-          .then(() => u.putGenerator(generator2, userToken, [collector1, collector2]))
-          .then(() => u.sendHeartbeat(collector1, collectorTokens))
-          .then((res) => u.expectLengths({ added: 1, deleted: 1, updated: 0 }, res))
-          .then(() => u.sendHeartbeat(collector2, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 0, updated: 2 }, res))
-          .then(() => u.sendHeartbeat(collector3, collectorTokens))
-          .then((res) => u.expectLengths({ added: 0, deleted: 1, updated: 0 }, res))
-          .then(done).catch(done);
-        });
-      });
     });
 
     describe('config changes >', () => {
@@ -1033,7 +866,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         const timestamp = Date.now();
         const secretKeyColl = authToken + timestamp;
 
-        u.postGenerator(generator1, userToken, [collector1])
+        u.createGenerator(generator1, userId, collector1)
         .then(() => u.sendHeartbeat(collector1, collectorTokens, { timestamp }))
         .then((res) => {
           const reencryptedSG = res.body.generatorsAdded[0];
@@ -1097,7 +930,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
           }
 
           expect(res.body.createdBy).to.equal(userId);
-          return u.postGenerator(generator2, userToken, [collector1])
+          return u.createGenerator(generator2, userId, collector1)
           .then(() => u.sendHeartbeat(collector1, collectorTokens))
           .then((res) => {
             expect(res.body.generatorsAdded[0])

--- a/tests/api/v1/generators/utils.js
+++ b/tests/api/v1/generators/utils.js
@@ -18,6 +18,7 @@ const Aspect = tu.db.Aspect;
 const GENERATOR_SIMPLE = {
   name: 'refocus-ok-generator',
   description: 'Collect status data',
+  isActive: true,
   tags: [
     'status',
     'STATUS',


### PR DESCRIPTION
Previously the changes were tracked based on Generator.collectors. This uses Generator.currentCollector instead.

Because currentCollector can't be updated directly through the API the calls to trackGeneratorChanges are moved to db hooks, and the tests are updated to not go through the api.

Actually setting the currentCollector field will be done in the other story I have this sprint.