### PR TITLE
update jwtUtils token verification for generators and collectors

### DIFF
--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -176,7 +176,9 @@ function patchCollector(req, res, next) {
 
   // If patching restricted fields, make sure this is collector token.
   if (verifyCtrToken && !req.headers.IsCollector) {
-    const err = new apiErrors.ForbiddenError({ explanation: 'Forbidden' });
+    const err = new apiErrors.ForbiddenError({
+      explanation: 'Authentication Failed',
+    });
     return u.handleError(next, err, helper.modelName);
   };
 
@@ -240,8 +242,7 @@ function heartbeat(req, res, next) {
   const resultObj = { reqStartTime: req.timestamp };
   if (!req.headers.IsCollector) {
     throw new apiErrors.ForbiddenError({
-      explanation: `The token: ${req.headers.TokenName} does not belong to ' +
-        'a collector`,
+      explanation: 'Authentication Failed',
     });
   }
 
@@ -267,7 +268,7 @@ function heartbeat(req, res, next) {
      */
     if (collectorNameFromToken !== o.name) {
       throw new apiErrors.ForbiddenError({
-        explanation: 'Token does not match the specified collector',
+        explanation: 'Authentication Failed',
       });
     } else if (o.status !== 'Running' && o.status !== 'Paused') {
       throw new apiErrors.ForbiddenError({

--- a/api/v1/controllers/generators.js
+++ b/api/v1/controllers/generators.js
@@ -86,7 +86,7 @@ function validateGeneratorAspectsPermissions(aspects, req) {
       const error = results[i].error;
       if (error) {
         if (error.name === 'ForbiddenError' &&
-         error.message === 'Resource not writable for provided token') {
+         error.message === 'Insufficient Privileges') {
           aspInvalidPerm.push(results[i].aspectName);
         } else {
           // aspect name added to all errors already
@@ -97,12 +97,9 @@ function validateGeneratorAspectsPermissions(aspects, req) {
     }
 
     if (aspInvalidPerm.length > 0) {
-      return Promise.reject(
-        new apiErrors.ValidationError(
-          'User does not have permission to upsert samples for the ' +
-          'following aspects:' + aspInvalidPerm
-        )
-      );
+      return Promise.reject(new apiErrors.ForbiddenError({
+        explanation: 'Insufficient Privileges',
+      }));
     }
 
     return Promise.resolve();

--- a/api/v1/controllers/userTokens.js
+++ b/api/v1/controllers/userTokens.js
@@ -83,7 +83,7 @@ module.exports = {
 
       if (token.name === token.user.name) { // Default token cannot be deleted!
         throw new apiErrors.ForbiddenError({
-          explanation: 'Forbidden.',
+          explanation: 'Insufficient Privileges',
         });
       }
 
@@ -97,7 +97,7 @@ module.exports = {
 
       // else forbidden
       throw new apiErrors.ForbiddenError({
-        explanation: 'Forbidden.',
+        explanation: 'Insufficient Privileges',
       });
     })
     .then((o) => {

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -274,7 +274,7 @@ function isWritable(req, modelInst) {
     if (req.user) {
       modelInst.isWritableBy(req.user.name)
       .then((ok) => ok ? resolve(modelInst) : reject(new apiErrors
-        .ForbiddenError('Resource not writable for provided token')))
+        .ForbiddenError('Insufficient Privileges')))
       .catch(reject);
     } else {
       /*
@@ -284,7 +284,7 @@ function isWritable(req, modelInst) {
        */
       modelInst.isWritableBy()
       .then((ok) => ok ? resolve(modelInst) :
-        reject(new apiErrors.ForbiddenError('Resource is write protected'))
+        reject(new apiErrors.ForbiddenError('Insufficient Privileges'))
       )
       .catch(reject);
     }
@@ -724,8 +724,7 @@ function handleError(next, err, modelName) {
 }
 
 /**
- * Attaches the resource type to the error and passes it on to the next
- * handler.
+ * Handles forbidden errors.
  *
  * @param {Function} next - The next middleware function in the stack
  * @param {String} modelName - The DB model name, used to disambiguate field
@@ -733,7 +732,7 @@ function handleError(next, err, modelName) {
  */
 function forbidden(next, modelName) {
   const err = new apiErrors.ForbiddenError({
-    explanation: 'Forbidden.',
+    explanation: 'Insufficient Privileges',
   });
   handleError(next, err, modelName);
 } // forbidden

--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -291,8 +291,7 @@ module.exports = function sample(seq, dataTypes) {
     .then((ok) => {
       if (!ok) {
         throw new dbErrors.ForbiddenError({
-          explanation: `The user: ${user}, does not have write permission` +
-          'on the sample',
+          explanation: 'Insufficient Privileges',
         });
       }
 

--- a/realtime/setupSocketIO.js
+++ b/realtime/setupSocketIO.js
@@ -197,11 +197,9 @@ function init(io, redisStore) {
 
     // check if connection using an authorization header
     } else if (socket.handshake.headers.authorization) {
-      const token = socket.handshake.headers.authorization;
-
-      jwtUtils.verifyBotToken(token)
-      .then((check) => {
-        if (!check) {
+      jwtUtils.verifyBotToken(socket.handshake.headers.authorization)
+      .then((isValid) => {
+        if (!isValid) {
           socket.disconnect();
           return;
         }

--- a/tests/api/v1/collectors/heartbeat.js
+++ b/tests/api/v1/collectors/heartbeat.js
@@ -164,7 +164,7 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
         .end(done);
       });
 
-      it('valid user token', (done) => {
+      it('valid user token but needs collector token', (done) => {
         api.post(`/v1/collectors/${collector1.name}/heartbeat`)
         .set('Authorization', userToken)
         .send({ timestamp: Date.now() })
@@ -905,14 +905,11 @@ describe('tests/api/v1/collectors/heartbeat.js >', () => {
     describe('added generator >', () => {
       const initialFeatureState = featureToggles
         .isFeatureEnabled('returnUser');
-      before(() => {
-        tu.toggleOverride('returnUser', true);
-      });
-      after(() => tu.toggleOverride('returnUser',
-        initialFeatureState));
+      before(() => tu.toggleOverride('returnUser', true));
+      after(() => tu.toggleOverride('returnUser', initialFeatureState));
 
       // setup and create a new generator with the createdBy field
-      it('contains the user token', (done) => {
+      it('contains the user', (done) => {
         const gtPath = '/v1/generatorTemplates';
         const sgtCopy = JSON.parse(JSON.stringify(sgt));
         sgtCopy.name = 'iAmNew';

--- a/tests/api/v1/collectors/patch.js
+++ b/tests/api/v1/collectors/patch.js
@@ -37,7 +37,8 @@ describe('tests/api/v1/collectors/patch.js >', () => {
   beforeEach((done) => {
     Collector.create(u.getCollectorToCreate())
     .then((c) => {
-      collectorToken = jwtUtil.createToken(c.name, c.name);
+      collectorToken = jwtUtil.createToken(c.name, tu.userName,
+        { IsCollector: true });
       i = c.id;
       done();
     })
@@ -77,13 +78,9 @@ describe('tests/api/v1/collectors/patch.js >', () => {
     .send({ version: '1.1.1' })
     .expect(constants.httpStatus.FORBIDDEN)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
-
-      expect(res.body.errors[0].description).to.be.equal(
-        'Invalid/No Token provided.'
-      );
+      if (err) return done(err);
+      expect(res.body.errors[0])
+        .to.contain.property('description', 'Forbidden');
       done();
     });
   });
@@ -93,22 +90,8 @@ describe('tests/api/v1/collectors/patch.js >', () => {
     .set('Authorization', collectorToken)
     .send({ version: '1.1.1' })
     .expect(constants.httpStatus.OK)
-    .expect((res) => {
-      if (tu.gotExpectedLength(res.body, 0)) {
-        throw new Error('expecting collector');
-      }
-
-      if (res.body.version !== '1.1.1') {
-        throw new Error('Incorrect version');
-      }
-    })
-    .end((err /* , res */) => {
-      if (err) {
-        return done(err);
-      }
-
-      done();
-    });
+    .expect((res) => expect(res.body).to.have.property('version', '1.1.1'))
+    .end((err) => err ? done(err) : done());
   });
 
   it('error - resource not found', (done) => {

--- a/tests/api/v1/collectors/patch.js
+++ b/tests/api/v1/collectors/patch.js
@@ -80,7 +80,7 @@ describe('tests/api/v1/collectors/patch.js >', () => {
     .end((err, res) => {
       if (err) return done(err);
       expect(res.body.errors[0])
-        .to.contain.property('description', 'Forbidden');
+        .to.contain.property('description', 'Authentication Failed');
       done();
     });
   });

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -116,7 +116,8 @@ describe('tests/api/v1/collectors/start.js >', () => {
       .send(defaultCollector)
       .expect(constants.httpStatus.FORBIDDEN)
       .expect((res) => {
-        expect(res.body.errors[0].description).to.equal('Forbidden');
+        expect(res.body.errors[0].description)
+          .to.equal('Authentication Failed');
       })
       .end(done);
     });
@@ -128,7 +129,8 @@ describe('tests/api/v1/collectors/start.js >', () => {
     .send({})
     .expect(constants.httpStatus.FORBIDDEN)
     .expect((res) => {
-      expect(res.body.errors[0].description).to.equal('Forbidden');
+      expect(res.body.errors[0].description)
+        .to.equal('Authentication Failed');
     })
     .end(done);
   });

--- a/tests/api/v1/collectors/start.js
+++ b/tests/api/v1/collectors/start.js
@@ -116,7 +116,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
       .send(defaultCollector)
       .expect(constants.httpStatus.FORBIDDEN)
       .expect((res) => {
-        expect(res.body.errors[0].description).to.equal('Invalid Token.');
+        expect(res.body.errors[0].description).to.equal('Forbidden');
       })
       .end(done);
     });
@@ -128,7 +128,7 @@ describe('tests/api/v1/collectors/start.js >', () => {
     .send({})
     .expect(constants.httpStatus.FORBIDDEN)
     .expect((res) => {
-      expect(res.body.errors[0].description).to.equal('Invalid Token.');
+      expect(res.body.errors[0].description).to.equal('Forbidden');
     })
     .end(done);
   });

--- a/tests/api/v1/generators/post.js
+++ b/tests/api/v1/generators/post.js
@@ -265,9 +265,8 @@ describe('tests/api/v1/generators/post.js >', () => {
       .then(() => validateGeneratorAspectsPermissions(aspects, req))
       .then(() => done(new Error('Expecting a Forbidden error')))
       .catch((err) => {
-        expect(err.name).to.be.equal('ValidationError');
-        expect(err.message).to.be.equal('User does not have permission to ' +
-          'upsert samples for the following aspects:___ASPECT2');
+        expect(err.name).to.be.equal('ForbiddenError');
+        expect(err.explanation).to.be.equal('Insufficient Privileges');
         done();
       })
       .catch((e) => done(e));
@@ -306,9 +305,8 @@ describe('tests/api/v1/generators/post.js >', () => {
       .then(() => validateGeneratorAspectsPermissions(aspects, req))
       .then(() => done(new Error('Expecting a Forbidden error')))
       .catch((err) => {
-        expect(err.name).to.be.equal('ValidationError');
-        expect(err.message).to.be.equal('User does not have permission to ' +
-          'upsert samples for the following aspects:___ASPECT1,___ASPECT2');
+        expect(err.name).to.be.equal('ForbiddenError');
+        expect(err.explanation).to.be.equal('Insufficient Privileges');
         done();
       })
       .catch((e) => done(e));
@@ -387,14 +385,13 @@ describe('tests/api/v1/generators/post.js >', () => {
         return asp1.addWriter(user); // asign user as writer to aspect1
       })
       .then(() => validateGeneratorAspectsPermissions(aspects, req))
-      .then(() => done()) // Validation successful
+      .then(() => done(new Error('expecting ForbiddenError')))
       .catch((err) => {
+        console.log('HOW DID I GET HERE???', err);
         expect(err.name).to.be.equal('ForbiddenError');
-        expect(err.message).to.be.equal('Resource is write protected');
-        expect(err.info).to.be.equal('___ASPECT1');
+        expect(err.explanation).to.be.equal('Insufficient Privileges');
         done();
-      })
-      .catch((e) => done(e));
+      });
     });
 
     it('aspects argument null', (done) => {

--- a/tests/enforceToken/createToken.js
+++ b/tests/enforceToken/createToken.js
@@ -38,7 +38,7 @@ describe('tests/enforceToken/createToken.js, api: createToken >', () => {
     api.post(tokenPath)
     .send({ name: 'newToken' })
     .expect(constants.httpStatus.FORBIDDEN)
-    .expect(/No authorization token was found/)
+    .expect(/Authentication Failed/)
     .end(done);
   });
 
@@ -47,6 +47,7 @@ describe('tests/enforceToken/createToken.js, api: createToken >', () => {
     .set('Authorization', `${defaultToken}xyz`)
     .send({ name: 'newToken' })
     .expect(constants.httpStatus.FORBIDDEN)
+    .expect(/Authentication Failed/)
     .end(done);
   });
 

--- a/tests/enforceToken/createToken.js
+++ b/tests/enforceToken/createToken.js
@@ -47,7 +47,6 @@ describe('tests/enforceToken/createToken.js, api: createToken >', () => {
     .set('Authorization', `${defaultToken}xyz`)
     .send({ name: 'newToken' })
     .expect(constants.httpStatus.FORBIDDEN)
-    .expect(/Invalid Token/)
     .end(done);
   });
 

--- a/tests/enforceToken/revoke.js
+++ b/tests/enforceToken/revoke.js
@@ -59,7 +59,8 @@ describe('tests/enforceToken/revoke.js, enforceToken: revoke >', () => {
         .expect(constants.httpStatus.FORBIDDEN)
         .end((err3, res3) => {
           if (err3) return done(err3);
-          expect(res3.body.errors[0].description).to.eql('Forbidden');
+          expect(res3.body.errors[0].description)
+            .to.eql('Authentication Failed');
           return done();
         });
       });

--- a/tests/enforceToken/revoke.js
+++ b/tests/enforceToken/revoke.js
@@ -58,13 +58,8 @@ describe('tests/enforceToken/revoke.js, enforceToken: revoke >', () => {
         .set('Authorization', newToken)
         .expect(constants.httpStatus.FORBIDDEN)
         .end((err3, res3) => {
-          if (err3) {
-            return done(err3);
-          }
-
-          expect(res3.body.errors[0].description)
-          .to.eql('Token was revoked. Please contact your Refocus ' +
-            'administrator.');
+          if (err3) return done(err3);
+          expect(res3.body.errors[0].description).to.eql('Forbidden');
           return done();
         });
       });

--- a/tests/enforceToken/verbs.js
+++ b/tests/enforceToken/verbs.js
@@ -107,7 +107,6 @@ describe('tests/enforceToken/verbs.js, API verb token enforced tests', () => {
           call
           .set('Authorization', `${defaultToken}xyz`)
           .expect(FORBIDDEN)
-          .expect(/Invalid Token/)
           .end(done);
         });
 

--- a/tests/enforceToken/verbs.js
+++ b/tests/enforceToken/verbs.js
@@ -87,14 +87,8 @@ describe('tests/enforceToken/verbs.js, API verb token enforced tests', () => {
 
           call
           .expect(FORBIDDEN)
-          .expect(/No authorization token was found/)
-          .end((err /* res */) => {
-            if (err) {
-              done(err);
-            }
-
-            done();
-          });
+          .expect(/Authentication Failed/)
+          .end(done);
         });
 
         it(`${VERB} ${path} wrong token provided returns FORBIDDEN`,
@@ -107,6 +101,7 @@ describe('tests/enforceToken/verbs.js, API verb token enforced tests', () => {
           call
           .set('Authorization', `${defaultToken}xyz`)
           .expect(FORBIDDEN)
+          .expect(/Authentication Failed/)
           .end(done);
         });
 

--- a/tests/utils/jwtUtil.js
+++ b/tests/utils/jwtUtil.js
@@ -161,7 +161,7 @@ describe('tests/utils/jwtUtil.js >', () => {
       jwtUtil.verifyToken(req, dummyCallback)
       .then(() => {
         expect(req.headers.UserName).to.equal(userInst.name);
-        // expect(req.headers.ProfileName).to.equal('___myProfile');
+        expect(req.headers.ProfileName).to.equal(profile.name);
         expect(req.headers.TokenName).to.equal(generator.name);
         expect(req.headers.IsAdmin).to.equal(false);
         expect(req.headers.IsBot).to.equal(false);

--- a/utils/jwtUtil.js
+++ b/utils/jwtUtil.js
@@ -214,7 +214,7 @@ function setUser(payload, req) {
     }
 
     req.user = user.get();
-    
+
     /*
      * For tokens with no ProfileName and IsAdmin set (e.g. old existing
      * tokens) we set IsAdmin and ProfileName after decoding the payload.
@@ -282,7 +282,7 @@ function verifyToken(req, cb) {
     })
     .catch((err) => {
       const e = new apiErrors.ForbiddenError({ explanation: 'Forbidden' });
-      return handleError(cb, e, 'ApiToken')
+      return handleError(cb, e, 'ApiToken');
     });
   }
 


### PR DESCRIPTION
**utils/jwtUtil.js**
- add new "IsGenerator" header
- minor formatting and var name cleanup
- do user check for user/generator/collector token types
- unnest the nested "try to verify me as a person first and if that fails then try to verify me as a collector and so on..." -- identify the type of user but fall back to trying to verify as a person if the type is not available (e.g. from an old token generated before we were adding that information to the token payload)
- when verifying a collector token, the token name must match a collector name and the user must exist
- when verifying a generator token, the token name must match a generator name and the user must exist
- simplify error message when token is invalid to just "Forbidden" -- we shouldn't be giving a potential attacker more details about why it was forbidden

**api/v1/controllers/collectors.js**
- update the patch algorithm when patching restricted fields to just use the "IsCollector" header which is set by the authentication process
- collector tokens will have collector name as the token name and user name as user name
- create collector tokens with { IsCollector: true }
- generator tokens will have generator name as the token name and user name as user name
- create generator tokens with { IsGenerator: true }

**realtime/setupSocketIO.js**
- minor cleanup and var name changes for clarification

**tests/api/v1/collectors/heartbeat.js**
- minor formatting and test name clarification only

**tests/api/v1/collectors/patch.js**
- create collector tokens with collector name, user name and { IsCollector: true }
- rewrite tests to expect "Forbidden" message
- minor formatting

**tests/api/v1/collectors/start.js**
- rewrite tests to expect "Forbidden" message

**tests/enforceToken/createToken.js**
- rewrite tests to expect "Forbidden" message

**tests/utils/jwtUtil.js**
- bots require version
- minor formatting, var name cleanup, test name cleanup
- create collector tokens with collector name, user name and { IsCollector: true }
- add tests for generator tokens
- update tests to check for IsGenerator header