### PR TITLE
Send sample realtime events when aspect tags change

### DIFF
--- a/cache/redisOps.js
+++ b/cache/redisOps.js
@@ -422,6 +422,29 @@ module.exports = {
     return redisClient.batch(cmds).execAsync();
   },
 
+  /**
+   * Get samples for a given aspect
+   * @param  {String} aspName - Aspect Name
+   * @returns {Promise} - Resolves to array of samples
+   */
+  getSamplesFromAspectName(aspName) {
+    const aspsubmapKey = redisStore.toKey(
+      redisStore.constants.objectType.aspSubMap, aspName
+    );
+    const promiseArr = [];
+    return redisClient.smembersAsync(aspsubmapKey)
+    .then((subjNames) => {
+      subjNames.forEach((subjName) => {
+        const sampleName = subjName + '|' + aspName;
+        promiseArr.push(redisClient.hgetallAsync(
+          redisStore.toKey(redisStore.constants.objectType.sample, sampleName)
+        ));
+      });
+
+      return Promise.all(promiseArr);
+    });
+  },
+
   renameKey,
 
   deleteKey,

--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -44,7 +44,7 @@ const constants = {
     subject: PFX + SEP + 'subjects',
   },
   objectType: { aspect: 'aspect', sample: 'sample', subject: 'subject',
-    subAspMap: 'subaspmap', },
+    subAspMap: 'subaspmap', aspSubMap: 'aspsubmap', },
   prefix: PFX,
   separator: SEP,
   previousStatusKey: PFX + SEP + 'previousSampleStoreStatus',


### PR DESCRIPTION
Here is how I tested this:
Created three aspects:
TooHot with tags ['too', 'hot', 'asp1']
TooCold with tags ['too', 'hot', 'asp1']
Aspect3 with tags ['asp3', 'random', 'tag3']

Then created a perspective with filter - include tag "too"
Result - shows samples only for TooHot and TooCold

PATCH /v1/aspects/Aspect3
{
	"tags": ["too"]
}
Result - Perspective shows all samples (Aspect3 is added)

DELETE /v1/aspects/Aspect3/tags/too
Result - shows samples only for TooHot and TooCold (Aspect3 is removed)

Let me know if I missed some use case.