### PR TITLE
reconstruct sample name if needed

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -348,7 +348,10 @@ function upsertOneSample(sampleQueryBodyObj, isBulk, user) {
   }))
   .then(() => redisClient.hgetallAsync(sampleKey))
   .then((updatedSamp) => {
-    parseName(updatedSamp.name); // throw if invalid name
+    if (!updatedSamp.name) {
+      updatedSamp.name = subject.absolutePath + '|' + aspectObj.name;
+    }
+
     return cleanAddAspectToSample(updatedSamp, aspectObj);
   })
   .catch((err) => {


### PR DESCRIPTION
We were calling parseName here which would throw exception if name missing and log out errors, but rather than do that, if sample name missing, just reconstruct it from subject and aspect and move on. No harm no foul.