### PR TITLE
Fixing Sequelize issue using duplicating=false on Generator.Collectors scope definition.

### DIFF
--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -316,6 +316,21 @@ module.exports = function generator(seq, dataTypes) {
     Generator.addScope('collectors', {
       include: [
         {
+
+          /*
+            According to Sequelize team when limits are set, they enforce the
+            usage of sub-queries, however, when Generator has multiple
+            associations (ie.: Collectors and User) the sub-query does not
+            expose foreign keys (Generator.createdBy).
+
+            Sequelize by default will try to create subQuery even when there is
+            no subQuery configured because the duplication flag is true by
+            default.
+
+            So, flagging duplication=false makes Sequelize avoid cartesian
+            product not generating sub-queries (further check in:
+            /sequelize/model.js, line 441).
+          */
           duplicating: false,
           association: assoc.collectors,
           attributes: [

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -316,6 +316,7 @@ module.exports = function generator(seq, dataTypes) {
     Generator.addScope('collectors', {
       include: [
         {
+          duplicating: false,
           association: assoc.collectors,
           attributes: [
             'id',

--- a/tests/api/v1/common/testAssociations.js
+++ b/tests/api/v1/common/testAssociations.js
@@ -112,17 +112,9 @@ function testAssociations(path, associations, joiSchema, conf) {
     });
   });
 
-  /*
-   * These tests fail because of a bug in sequelize.
-   * It doesn't properly handle multiple associations when a limit is applied:
-   * It selects the attributes before doing the join for the association, which
-   * causes an error when the foreign key is not included in the fields.
-   * I think it was fixed in https://github.com/sequelize/sequelize/pull/9188
-   * Skipping until we upgrade Sequelize...
-   */
-  describe.skip('sequelize bug', () => {
+  describe('Checking multiple associations', () => {
     if (associations.length > 1) {
-      it('find: multiple associations can be specified as field params', (done) => {
+      it('multiple associations can be specified as field params', (done) => {
         const fields = ['name', ...associations].toString();
         api.get(`${path}?fields=${fields}`)
         .set('Authorization', token)
@@ -132,14 +124,16 @@ function testAssociations(path, associations, joiSchema, conf) {
           res.body.forEach((record) => {
             associations.forEach((assoc) => {
               expect(record).to.have.property(assoc);
-              expect(Joi.validate(record[assoc], joiSchema[assoc]).error).to.be.null;
+              expect(Joi.validate(record[assoc],
+                joiSchema[assoc]).error).to.be.null;
             });
           });
         })
         .end(done);
       });
 
-      it('get by key: multiple associations can be specified as field params', (done) => {
+      it('multiple associations can be specified with key and field' +
+        ' params', (done) => {
         const fields = ['name', ...associations].toString();
         api.get(`${path}/${recordId}?fields=${fields}`)
         .set('Authorization', token)
@@ -147,7 +141,8 @@ function testAssociations(path, associations, joiSchema, conf) {
         .expect((res) => {
           associations.forEach((assoc) => {
             expect(res.body).to.have.property(assoc);
-            expect(Joi.validate(res.body[assoc], joiSchema[assoc]).error).to.be.null;
+            expect(Joi.validate(res.body[assoc],
+              joiSchema[assoc]).error).to.be.null;
           });
         })
         .end(done);
@@ -159,4 +154,3 @@ function testAssociations(path, associations, joiSchema, conf) {
 module.exports = {
   testAssociations,
 };
-


### PR DESCRIPTION
According to Sequelize team, when limits are set they enforce the use of subqueries and JOINed tables (FK) are missing in sub-query in the generated SQL (issues opened since 2015).

Apparently, the Sequelize [PR](https://github.com/sequelize/sequelize/pull/9188) (2018 March) solved, but unfortunately, we were still having the issue.

I have created a previous Refocus [PR](https://github.com/salesforce/refocus/pull/918) forcing the FK to be in the subquery, however, it also required a (few changes in order to avoid those FK to be returned to the client)[https://github.com/salesforce/refocus/pull/918/files/bf29c7c4dfb881e324aaac892ff47ac3be2c9ac0].

So I've got a reading on Sequelize (issues/code) and found the attribute ``duplicating=false`` which tells to sequelize to never return a duplication and saw many users saying that they could solve the issue.

I have added the flag in Generator.User and Generator.Collector, but seems just adding to collector it solves the problem.

```javascript
Generator.addScope('collectors', {
      include: [
        {
          duplicating: false, -- Added here!
          association: assoc.collectors,
```
As you can see below we have the generated SQL before and now. They are the same, the difference is that now we are enforcing to return all the attributes from the sub-query.

The application still the same and there is no any extra "remove from response" back to the client API.

```sql
-- BEFORE: without duplicating, sub query doesn't return createdBy (User fk)

FROM 
    (
        SELECT "Generator"."name", "Generator"."id"
          FROM "Generators" AS "Generator"
         WHERE ("Generator"."deletedAt" > '2018-07-06 13:34:11.276 +00:00' OR "Generator"."deletedAt" IS NULL) 
         ORDER BY "Generator"."name" LIMIT 10000 OFFSET 0
    ) AS "Generator" 
      LEFT OUTER JOIN "Users" AS "user" 
        ON "Generator"."createdBy" = "user"."id"
        AND ("user"."deletedAt" > '2018-06-25 14:56:34.957 +00:00' OR "user"."deletedAt" IS NULL) 
    LEFT OUTER JOIN "Profiles" AS "user->profile" 
        ON "user"."profileId" = "user->profile"."id" 
        AND ("user->profile"."deletedAt" > '2018-06-25 14:56:34.957 +00:00' OR "user->profile"."deletedAt" IS NULL) 
    LEFT OUTER JOIN ( 
        "GeneratorCollectors" AS "collectors->GeneratorCollectors" 
        INNER JOIN "Collectors" AS "collectors" 
        ON "collectors"."id" = "collectors->GeneratorCollectors"."collectorId"
    ) 
    ON "Generator"."id" = "collectors->GeneratorCollectors"."generatorId" 
    AND ("collectors"."deletedAt" > '2018-06-25 14:56:34.957 +00:00' OR "collectors"."deletedAt" IS NULL)
ORDER BY "Generator"."name";

-- THEN: With duplicating

FROM 
	(
		SELECT "Generator"."description", "Generator"."helpEmail", "Generator"."helpUrl", "Generator"."id", "Generator"."intervalSecs", 
		"Generator"."isDeleted", "Generator"."isActive", "Generator"."name", "Generator"."subjectQuery", "Generator"."subjects", 
		"Generator"."aspects", "Generator"."tags", "Generator"."generatorTemplate", "Generator"."connection", "Generator"."context", 
		"Generator"."currentCollector", "Generator"."createdAt", "Generator"."updatedAt", "Generator"."deletedAt", "Generator"."createdBy" 
		FROM "Generators" AS "Generator" 
		WHERE ("Generator"."deletedAt" > '2018-07-06 13:34:11.276 +00:00' OR "Generator"."deletedAt" IS NULL) 
		ORDER BY "Generator"."name" LIMIT 10000 OFFSET 0
	) AS "Generator" 
	LEFT OUTER JOIN "Users" AS "user" 
		ON "Generator"."createdBy" = "user"."id" 
		AND ("user"."deletedAt" > '2018-07-06 13:34:11.276 +00:00' OR "user"."deletedAt" IS NULL) 
	LEFT OUTER JOIN "Profiles" AS "user->profile" 
		ON "user"."profileId" = "user->profile"."id" 
		AND ("user->profile"."deletedAt" > '2018-07-06 13:34:11.276 +00:00' OR "user->profile"."deletedAt" IS NULL)
	LEFT OUTER JOIN (
		"GeneratorCollectors" AS "collectors->GeneratorCollectors" 
		INNER JOIN "Collectors" AS "collectors" 
		ON "collectors"."id" = "collectors->GeneratorCollectors"."collectorId"
	) 
	ON "Generator"."id" = "collectors->GeneratorCollectors"."generatorId" 
	AND ("collectors"."deletedAt" > '2018-07-06 13:34:11.276 +00:00' OR "collectors"."deletedAt" IS NULL) 
 ORDER BY "Generator"."name";
```

**Sources:**
https://github.com/sequelize/sequelize/issues/3007
https://github.com/sequelize/sequelize/issues/6073
https://www.thelacunablog.com/5-things-learned-sequelize.html
https://github.com/sequelize/sequelize/issues/222



