### PR TITLE
Make dyno and/or cluster process id available for logging

### DIFF
--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -17,6 +17,7 @@ module.exports = {
     dbTime: '0ms',
     ipAddress: 'None',
     method: 'None', // one of HTTP verbs
+    process: 'None',
     recordCount: 0,
     requestBytes: 0,
     request_id: 'None',
@@ -31,7 +32,7 @@ module.exports = {
     description: 'None',
     jobId: 'None',
     jobType: 'None',
-    pid: 'None',
+    process: 'None',
     totalTime: '0ms',
   },
   kueStats: {
@@ -91,6 +92,7 @@ module.exports = {
     ipAddress: 'None',
     jobId: 'None',
     jobType: 'None',
+    process: 'None',
     queueTime: 'None',
     queueResponseTime: 'None',
     recordCount: 0,

--- a/index.js
+++ b/index.js
@@ -179,6 +179,16 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
         req.request_id = req.headers['x-request-id'];
       }
 
+      /*
+       * Add dyno and/or clusterProcessId to request--helpful to have when
+       * logging. "process.env.DYNO" is only available when deployed to heroku,
+       * so ignore if it's not available. "clusterProcessId" represents the
+       * cluster worker id if the process is started from throng (it is zero if
+       * the process is not started from throng).
+       */
+      if (process.env.DYNO) req.dyno = process.env.DYNO;
+      req.process = (req.dyno ? req.dyno + ':' : '') + clusterProcessId;
+
       next();
     });
 

--- a/jobQueue/jobWrapper.js
+++ b/jobQueue/jobWrapper.js
@@ -130,6 +130,7 @@ function logJobOnComplete(req, job) {
        */
       logObject.user = req.headers.UserName;
       logObject.token = req.headers.TokenName;
+      logObject.process = req.process;
     }
 
     // continue to update and print logObject on job completion.

--- a/utils/apiLog.js
+++ b/utils/apiLog.js
@@ -100,9 +100,10 @@ function logAPI(req, resultObj, retval, recordCountOverride) {
     // create api activity log object
     const logObject = {
       ipAddress: activityLogUtil.getIPAddrFromReq(req),
+      method: req.method,
+      process: req.process,
       requestBytes: getSize(req.body),
       uri: req.url,
-      method: req.method,
     };
 
     // Add "request_id" if header is available

--- a/worker/jobLog.js
+++ b/worker/jobLog.js
@@ -17,10 +17,10 @@ module.exports = (startTime, job, description) => {
     const jobLog = {
       jobId: job.id,
       jobType: job.type,
-      pid: process.pid,
+      process: process.env.DYNO || process.pid,
       totalTime: `${Date.now() - startTime}ms`,
     };
-    if (description) jobLog.description = description;
+    if (description) jobLog.description = `"${description}"`;
     activityLogUtil.printActivityLogString(jobLog, 'job');
   }
 };


### PR DESCRIPTION
- In middleware in index.js, set req.process as dyno + cluster process id. Just use cluster process id if not on heroku. Cluster process id will be zero if process not started from throng.
- In config/activityLog.js, add "process" to activity=api and activity=worker log lines, and rename "pid" in activity=job log line to "process".
- In jobQueue/jobWrapper.js, set "process" on the object being logged, using req.process.
- In utils/apiLog.js, set "process" on the object being logged, using req.process.
- In worker/jobLog.js, set "process" on the object being logged, using process.env.DYNO or process.pid if not on heroku