### PR TITLE
Update the perspective page to handle and enqueue new real-time event…

### DIFF
--- a/view/perspective/app.js
+++ b/view/perspective/app.js
@@ -133,6 +133,9 @@ function handleEvent(eventData, eventTypeName) {
   } else if (eventTypeName === eventsQueue.eventType.INTRNL_SMPL_DEL) {
     const sample = j[eventTypeName];
     updateDeletedTimeoutValues(sample.aspect.timeout);
+  } else if (eventTypeName === eventsQueue.eventType.INTRNL_SMPL_NC) {
+    const sample = j[eventTypeName];
+    updateTimeoutValues(sample.aspect.timeout);
   }
 } // handleEvent
 
@@ -192,6 +195,9 @@ function setupSocketIOClient(persBody) {
   });
   socket.on(eventsQueue.eventType.INTRNL_SMPL_UPD, (data) => {
     handleEvent(data, eventsQueue.eventType.INTRNL_SMPL_UPD);
+  });
+  socket.on(eventsQueue.eventType.INTRNL_SMPL_NC, (data) => {
+    handleEvent(data, eventsQueue.eventType.INTRNL_SMPL_NC);
   });
 } // setupSocketIOClient
 

--- a/view/perspective/eventsQueue.js
+++ b/view/perspective/eventsQueue.js
@@ -23,6 +23,7 @@ const eventType = {
   INTRNL_SMPL_ADD: 'refocus.internal.realtime.sample.add',
   INTRNL_SMPL_DEL: 'refocus.internal.realtime.sample.remove',
   INTRNL_SMPL_UPD: 'refocus.internal.realtime.sample.update',
+  INTRNL_SMPL_NC: 'refocus.internal.realtime.sample.nochange',
   LENS_CHANGE: 'refocus.lens.realtime.change',
 };
 
@@ -44,6 +45,8 @@ function enqueueEvent(eventName, eventData) {
     queue.push({ 'sample.remove': eventData });
   } else if (eventName === eventType.INTRNL_SMPL_UPD) {
     queue.push({ 'sample.update': eventData });
+  } else if (eventName === eventType.INTRNL_SMPL_NC) {
+    queue.push({ 'sample.nochange': eventData });
   }
 }
 


### PR DESCRIPTION
… type

for samples which have not changed (except their last updated timestamp)

(Note: this is a "no-op" if no events of this type are sent, so this is safe to deploy even if the back-end changes are not deployed.)