### PR TITLE
Passing pubOpts as arg

### DIFF
--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -44,6 +44,7 @@ module.exports = (io) => {
       const key = Object.keys(mssgObj)[0];
       const parsedObj = rtUtils.parseObject(mssgObj[key], key);
       let { pubOpts } = parsedObj;
+
       // Deleting pubOpts from parsedObj before passing it to the emitter
       delete parsedObj.pubOpts;
 

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -51,7 +51,6 @@ module.exports = (io) => {
         trackPublishKey(key);
       }
 
-
       /*
        * pass on the message received through the redis subscriber to the socket
        * io emitter to send data to the browser clients.

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -44,7 +44,7 @@ module.exports = (io) => {
       const key = Object.keys(mssgObj)[0];
       const parsedObj = rtUtils.parseObject(mssgObj[key], key);
       let { pubOpts } = parsedObj;
-      // Deleting pubOpts before passing to the emitter
+      // Deleting pubOpts from parsedObj before passing it to the emitter
       delete parsedObj.pubOpts;
 
       if (featureToggles.isFeatureEnabled('enablePubStatsLogs')) {

--- a/realtime/redisSubscriber.js
+++ b/realtime/redisSubscriber.js
@@ -43,16 +43,20 @@ module.exports = (io) => {
       const mssgObj = JSON.parse(mssgStr);
       const key = Object.keys(mssgObj)[0];
       const parsedObj = rtUtils.parseObject(mssgObj[key], key);
+      let { pubOpts } = parsedObj;
+      // Deleting pubOpts before passing to the emitter
+      delete parsedObj.pubOpts;
 
       if (featureToggles.isFeatureEnabled('enablePubStatsLogs')) {
         trackPublishKey(key);
       }
 
+
       /*
        * pass on the message received through the redis subscriber to the socket
        * io emitter to send data to the browser clients.
        */
-      emitter(io, key, parsedObj);
+      emitter(io, key, parsedObj, pubOpts);
     });
   });
 };

--- a/realtime/socketIOEmitter.js
+++ b/realtime/socketIOEmitter.js
@@ -17,7 +17,7 @@ const initBotEvent = 'refocus.internal.realtime.bot.namespace.initialize';
 
 module.exports = (io, key, obj, pubOpts) => {
   // newObjectAsString contains { key: {new: obj }}
-  let newObjectAsString = rtUtils.getNewObjAsString(key, obj);
+  const newObjectAsString = rtUtils.getNewObjAsString(key, obj);
 
   // Initialize namespace when perspective initialize namespace event is sent
   if (key.startsWith(initPerspectiveEvent)) {

--- a/realtime/socketIOEmitter.js
+++ b/realtime/socketIOEmitter.js
@@ -15,8 +15,11 @@ const initPerspectiveEvent =
   'refocus.internal.realtime.perspective.namespace.initialize';
 const initBotEvent = 'refocus.internal.realtime.bot.namespace.initialize';
 
-module.exports = (io, key, obj) => {
+module.exports = (io, key, obj, pubOpts) => {
   // newObjectAsString contains { key: {new: obj }}
+  if ()
+
+
   let newObjectAsString = rtUtils.getNewObjAsString(key, obj);
 
   // Initialize namespace when perspective initialize namespace event is sent
@@ -49,12 +52,7 @@ module.exports = (io, key, obj) => {
     const connections = Object.keys(namespace.connected);
     if (connections.length > 0) {
       /* Check the perspective/room filters before emitting. */
-      if (rtUtils.shouldIEmitThisObj(nsp, obj)) {
-        if (obj.pubOpts) {
-          delete obj.pubOpts;
-          newObjectAsString = rtUtils.getNewObjAsString(key, obj);
-        }
-
+      if (rtUtils.shouldIEmitThisObj(n, obj, pubOpts)) {
         namespace.emit(key, newObjectAsString);
       }
     }

--- a/realtime/socketIOEmitter.js
+++ b/realtime/socketIOEmitter.js
@@ -17,9 +17,6 @@ const initBotEvent = 'refocus.internal.realtime.bot.namespace.initialize';
 
 module.exports = (io, key, obj, pubOpts) => {
   // newObjectAsString contains { key: {new: obj }}
-  if ()
-
-
   let newObjectAsString = rtUtils.getNewObjAsString(key, obj);
 
   // Initialize namespace when perspective initialize namespace event is sent

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -220,15 +220,16 @@ function perspectiveEmit(nspComponents, obj) {
  * variable happens here. The nspComponents are decoded to various filters and the
  * filters are compared with the obj to decide whether this object should be
  * emitted over the namespace identified by the nspComponents variable
- * @param  {String} nspComponents - array of namespace strings for filtering
- * @param  {Object} obj - Object that is to be emitted to the client
+ * @param {String} nspComponents - array of namespace strings for filtering
+ * @param {Object} obj - Object that is to be emitted to the client
+ * @param {Object} pubOpts - Options for client and channel to publish with.
  * @returns {Boolean} - true if this obj is to be emitted over this namespace
  * identified by this namespace string.
  */
-function botEmit(nspComponents, obj) {
-  if (obj.pubOpts) {
-    const objFilter = nspComponents[obj.pubOpts.filterIndex];
-    return applyFilter(objFilter, obj[obj.pubOpts.filterField]);
+function botEmit(nspComponents, obj, pubOpts) {
+  if (pubOpts) {
+    const objFilter = nspComponents[pubOpts.filterIndex];
+    return applyFilter(objFilter, obj[pubOpts.filterField]);
   }
 
   return false;
@@ -237,13 +238,14 @@ function botEmit(nspComponents, obj) {
 /**
   * Splits up the nspString into its components and decides if it is a bot
   * or a perspective that needs to be emitted
-  * @param  {String} nspString - A namespace string, that identifies a
+  * @param {String} nspString - A namespace string, that identifies a
   * socketio namespace
-  * @param  {Object} obj - Object that is to be emitted to the client
+  * @param {Object} obj - Object that is to be emitted to the client
+  * @param {Object} pubOpts - Options for client and channel to publish with.
   * @returns {Boolean} - true if this obj is to be emitted over this namespace
   * identified by this namespace string.
   */
-function shouldIEmitThisObj(nspString, obj) {
+function shouldIEmitThisObj(nspString, obj, pubOpts) {
   // extract all the components that makes up a namespace.
   const nspComponents = nspString.split(constants.filterSeperator);
   const absPathNsp = nspComponents[constants.asbPathIndex];
@@ -252,7 +254,7 @@ function shouldIEmitThisObj(nspString, obj) {
   if ((absolutePathObj).startsWith(absPathNsp)) {
     return perspectiveEmit(nspComponents, obj);
   } else if (absPathNsp === botAbsolutePath) {
-    return botEmit(nspComponents, obj);
+    return botEmit(nspComponents, obj, pubOpts);
   }
 
   return false;


### PR DESCRIPTION
- Passing pubOpts as a separate argument so we don't need to call rtUtils.getNewObjAsString(key, obj) twice, which is expensive