### PR TITLE
stop sending array argument to HMSET

### DIFF
--- a/cache/redisOps.js
+++ b/cache/redisOps.js
@@ -33,6 +33,7 @@ function capitalizeFirstLetter(str) {
 /**
  * Creates or updates the hash specified by the name argument, with values
  * specified by the value argument.
+ *
  * @param  {String} objectName - Name of the object.
  * @param  {String} name  - Name used to identify the hash
  * @param  {Object} value - The value object's key/value are set as the
@@ -41,7 +42,7 @@ function capitalizeFirstLetter(str) {
  */
 function hmSet(objectName, name, value) {
   const cleanobj =
-          redisStore['clean' + capitalizeFirstLetter(objectName)](value);
+    redisStore['clean' + capitalizeFirstLetter(objectName)](value);
   const nameKey = redisStore.toKey(objectName, name);
   logInvalidHmsetValues(nameKey, cleanobj);
   return redisClient.hmsetAsync(nameKey, cleanobj)

--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -35,8 +35,14 @@ const constants = {
       'user', // an object
     ],
     sample: ['relatedLinks', 'user'],
-    subject: ['aspectNames', 'tags', 'relatedLinks', 'geolocation', 'user',
-      'children'],
+    subject: [
+      'aspectNames',
+      'children',
+      'geolocation',
+      'relatedLinks',
+      'tags',
+      'user',
+    ],
   },
   indexKey: {
     aspect: PFX + SEP + 'aspects',

--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -35,7 +35,8 @@ const constants = {
       'user', // an object
     ],
     sample: ['relatedLinks', 'user'],
-    subject: ['aspectNames', 'tags', 'relatedLinks', 'geolocation', 'user'],
+    subject: ['aspectNames', 'tags', 'relatedLinks', 'geolocation', 'user',
+      'children'],
   },
   indexKey: {
     aspect: PFX + SEP + 'aspects',

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -205,8 +205,7 @@ module.exports = function subject(seq, dataTypes) {
 
         if (isSubjectUnpublished) {
           promiseArr.push(
-            subjectUtils.removeRelatedSamples(inst.dataValues, seq)
-          );
+            subjectUtils.removeRelatedSamples(inst.dataValues, seq));
         }
 
         if (inst.changed('absolutePath')) {
@@ -219,8 +218,7 @@ module.exports = function subject(seq, dataTypes) {
 
           // remove all the related samples
           promiseArr.push(
-            subjectUtils.removeRelatedSamples(inst._previousDataValues, seq)
-          );
+            subjectUtils.removeRelatedSamples(inst._previousDataValues, seq));
         }
 
         if (inst.changed('parentAbsolutePath') ||
@@ -257,8 +255,8 @@ module.exports = function subject(seq, dataTypes) {
           instDataObj));
 
         /*
-         * Once all the data related changes are done and the sample realtime
-         * events have been sent. Send the corresponding subject realtime event
+         * Once all the data-related changes are done and the sample realtime
+         * events have been sent, send the corresponding subject realtime event.
          */
         return Promise.all(promiseArr)
         .then(() => {

--- a/utils/common.js
+++ b/utils/common.js
@@ -25,7 +25,7 @@ function logInvalidHmsetValues(key, obj) {
     for (let _key in obj) {
       if ((obj[_key] === undefined) || Array.isArray(obj[_key])) {
         console.trace('Invalid hmset params: key ' + key +
-          ' with undefined field: ' + _key + ', received: ' +
+          ' with undefined or array field: ' + _key + ', received: ' +
           JSON.stringify(obj));
         break;
       }


### PR DESCRIPTION
Redis has been complaining about this with deprecation warnings for a while... we were missing stringifying subject.children.

clears up this error in our tests AND in prod logs:
  node_redis: Deprecated: The HMSET command contains a argument of type Array.
    at Object.hmSet (/app/cache/redisOps.js:46:3)