### PR TITLE
add jobCreate activity logging

### DIFF
--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -47,7 +47,7 @@ module.exports = {
     activity: 'jobCreate',
     jobId: 'None',
     jobPriority: 'None',
-    jobType: 'None',    
+    jobType: 'None',
     process: 'None',
     totalTime: '0ms',
   },

--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -35,6 +35,22 @@ module.exports = {
     process: 'None',
     totalTime: '0ms',
   },
+  jobCleanup: {
+    activity: 'jobCleanup',
+    iterations: 0,
+    errors: 0,
+    removed: 0,
+    skipped: 0,
+    totalTime: '0ms',
+  },
+  jobCreate: {
+    activity: 'jobCreate',
+    jobId: 'None',
+    jobPriority: 'None',
+    jobType: 'None',    
+    process: 'None',
+    totalTime: '0ms',
+  },
   kueStats: {
     activity: 'kueStats',
     activeCount: 0,
@@ -103,13 +119,5 @@ module.exports = {
     totalTime: 'None',
     user: 'None',
     workTime: 'None',
-  },
-  jobCleanup: {
-    activity: 'jobCleanup',
-    iterations: 0,
-    errors: 0,
-    removed: 0,
-    skipped: 0,
-    totalTime: '0ms',
   },
 };

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -83,6 +83,10 @@ const longTermToggles = {
   // Activity logging
   enableApiActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'api'),
   enableJobActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'job'),
+  enableJobCleanupActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
+    'jobCleanup'),
+  enableJobCreateActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
+    'jobCreate'),
   enableKueStatsActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
     'kueStats'),
   enableLimiterActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
@@ -96,8 +100,6 @@ const longTermToggles = {
     'unauthorized'),
   enableWorkerActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
     'worker'),
-  enableJobCleanupActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
-    'jobCleanup'),
 
   // Enable heroku clock dyno
   enableClockProcess: environmentVariableTrue(pe, 'ENABLE_CLOCK_PROCESS'),

--- a/jobQueue/jobWrapper.js
+++ b/jobQueue/jobWrapper.js
@@ -213,7 +213,7 @@ function createJob(jobName, data, req) {
   const jobPriority = calculateJobPriority(conf.prioritizeJobsFrom,
     conf.deprioritizeJobsFrom, req);
   const job = jobQueue.create(jobName, data);
-  return job.ttl(TIME_TO_LIVE)
+  job.ttl(TIME_TO_LIVE)
   .priority(jobPriority)
   .save((err) => {
     if (err) {
@@ -224,8 +224,9 @@ function createJob(jobName, data, req) {
 
     logJobOnComplete(req, job);
     logJobCreate(startTime, job);
-    return job;
   });
+
+  return job;
 } // createJob
 
 module.exports = {

--- a/jobQueue/logJobCreate.js
+++ b/jobQueue/logJobCreate.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * /jobQueue/logJobCreate.js
+ */
+const featureToggles = require('feature-toggles');
+const activityLogUtil = require('../utils/activityLog');
+
+module.exports = (startTime, job) => {
+  if (featureToggles.isFeatureEnabled('enableJobCreateActivityLogs')) {
+    const jc = {
+      jobId: job.id,
+      jobPriority: job._priority,
+      jobType: job.type,
+      process: process.env.DYNO || process.pid,
+      totalTime: `${Date.now() - startTime}ms`,
+    };
+    activityLogUtil.printActivityLogString(jc, 'jobCreate');
+  }
+};

--- a/utils/activityLog.js
+++ b/utils/activityLog.js
@@ -41,9 +41,9 @@ module.exports = {
    * Convert activity log object to String format and print.
    *
    * @param  {Object} logObject - Log Object
-   * @param  {string} logtype - @see /config/activityLog.js
-   * @param  {string} logLevel - Log Level info, warn, error
-   *  verbose, debug, silly. Default log info.
+   * @param  {String} logtype - @see /config/activityLog.js
+   * @param  {String} logLevel - info|warn|error|verbose|debug|silly
+   *  (default=info)
    */
   printActivityLogString(logObject, logtype, logLevel='info') {
     // example: activity=worker user="igoldstein@salesforce.com" token="Eleven"
@@ -57,7 +57,7 @@ module.exports = {
         logStr += `${param}=`;
 
         // if logObject has this param set, append the value
-        if (logObject[param]) {
+        if (logObject.hasOwnProperty(param)) {
           logStr += `${logObject[param]} `;
         } else {
           // append default value defined in config


### PR DESCRIPTION
- config/activityLog - add prototype for new jobCreate log line (also move jobCleanup def so it's in alphabetical order)
- config/toggles - add feature toggle definition (also move jobCleanup toggle def so it's in alphabetical order)
- jobQueue/jobWrapper - call logJobCreate from createPromisifiedJob and createJob
- jobQueue/logJobCreate - add new module, just a wrapper around calling activityLogUtil.printActivityLogString
- tests/jobQueue/v1/jobWrapper - add assert for jobCreate log line
- utils/activityLog - it was treating a value of 0 as false so not overriding the prototype, so instead of checking the value, now check whether the logObject hasOwnProperty