### PR TITLE
Tighten up who can delete a user

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -9518,8 +9518,9 @@ paths:
       summary: Delete user
       tags: [ users ]
       description: >-
-        Delete the specified user. Beware! Deleting a user also deletes all the
-        perspectives associated with this user.
+        Delete the specified user. An admin user may delete any user;
+        non-admin users may only delete themselves. Beware! Deleting a user
+        also deletes all the perspectives associated with this user.
       operationId: deleteUser
       parameters:
         -

--- a/tests/api/v1/users/delete.js
+++ b/tests/api/v1/users/delete.js
@@ -14,68 +14,203 @@ const supertest = require('supertest');
 const api = supertest(require('../../../../index').app);
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
-const jwtUtil = require('../../../../utils/jwtUtil');
 const u = require('./utils');
 const path = '/v1/users';
 const expect = require('chai').expect;
-const Token = tu.db.Token;
-const registerPath = '/v1/register';
-const tokenPath = '/v1/tokens';
+const jwtUtil = require('../../../../utils/jwtUtil');
+const Profile = tu.db.Profile;
+const User = tu.db.User;
+const OBAdminProfile = require('../../../../config').db.adminProfile;
+const OBAdminUser = require('../../../../config').db.adminUser;
+const Op = require('sequelize').Op;
 
-describe(`tests/api/v1/users/delete.js, DELETE ${path}/:id >`, () => {
-  const uname = `${tu.namePrefix}test@refocus.com`;
+describe(`tests/api/v1/users/delete.js >`, () => {
+  const ZERO = 0;
+  const ONE = 1;
+  const TWO = 2;
+  let profileOneId = '';
+  let profileTwoId = '';
+  const userOne = `${tu.namePrefix}test@refocus.com`;
+  const userTwo = `${tu.namePrefix}poop@refocus.com`;
+  const userThree = `${tu.namePrefix}quote@refocus.com`;
+  const userFour = `${tu.namePrefix}marvin@refocus.com`;
+  const userFive = `${tu.namePrefix}jan@refocus.com`;
+  const userSix = `${tu.namePrefix}rachel@refocus.com`;
   const tname = `${tu.namePrefix}Voldemort`;
-  let userId;
-  let testUserToken = '';
+  const pname = `${tu.namePrefix}testProfile`;
+  const normalUserToken = jwtUtil.createToken(userOne, userOne);
+  const user3Token = jwtUtil.createToken(userThree, userThree);
+  const user4Token = jwtUtil.createToken(userFour, userFour);
+  const user5Token = jwtUtil.createToken(userFive, userFive);
+  let user1id;
+  let user2id;
+  let user3id;
+  let user4id;
+  let user5id;
+  let user6id;
+
+  // out of the box admin user token
+  const OBAdminUserToken = tu.createAdminToken();
 
   before((done) => {
-    // create user __test@refocus.com
-    api.post(registerPath)
-    .send({
-      email: uname,
-      password: 'fakePasswd',
-      username: uname,
+    Profile.create({ name: pname + ONE })
+    .then((profile) => {
+      profileOneId = profile.id;
+      return Profile.create({
+        name: pname + TWO,
+      });
     })
+    .then((profile) => {
+      profileTwoId = profile.id;
+      return User.create({
+        profileId: profileOneId,
+        name: userOne,
+        email: userOne,
+        password: userOne,
+      });
+    })
+    .then((u) => user1id = u.id)
+
+    // another normal user
+    .then(() => User.create({
+      profileId: profileTwoId,
+      name: userTwo,
+      email: userTwo,
+      password: userTwo,
+    }))
+    .then((u) => user2id = u.id)
+
+    // another normal user
+    .then(() => User.create({
+      profileId: profileTwoId,
+      name: userThree,
+      email: userThree,
+      password: userThree,
+    }))
+    .then((u) => user3id = u.id)
+
+    // another normal user
+    .then(() => User.create({
+      profileId: profileTwoId,
+      name: userFour,
+      email: userFour,
+      password: userFour,
+    }))
+    .then((u) => user4id = u.id)
+
+    // another normal user
+    .then(() => User.create({
+      profileId: profileTwoId,
+      name: userFive,
+      email: userFive,
+      password: userFive,
+    }))
+    .then((u) => user5id = u.id)
+
+    // another normal user
+    .then(() => User.create({
+      profileId: profileTwoId,
+      name: userSix,
+      email: userSix,
+      password: userSix,
+    }))
+    .then((u) => user6id = u.id)
+
+    .then(() => done())
+    .catch(done);
+  });
+
+  after(u.forceDelete);
+
+  it('no user with this id exists', (done) => {
+    api.delete(`${path}/a3d89333-4c2c-48e2-9124-d37ea6ec0fbc`)
+    .set('Authorization', OBAdminUserToken)
+    .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
-
-      userId = res.body.id;
-      testUserToken = res.body.token;
-
-      // create token ___Voldemort
-      api.post(tokenPath)
-      .set('Authorization', testUserToken)
-      .send({ name: tname })
-      .end(done);
+      if (err) return done(err);
+      return done();
     });
   });
 
-  afterEach(u.forceDelete);
-
-  it('deletion of user does not return default token', (done) => {
-    api.delete(`${path}/${uname}`)
-    .set('Authorization', testUserToken)
-    .expect(constants.httpStatus.OK)
+  it('no user with this name exists', (done) => {
+    api.delete(`${path}/usernot@found.com`)
+    .set('Authorization', OBAdminUserToken)
+    .expect(constants.httpStatus.NOT_FOUND)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+      if (err) return done(err);
+      return done();
+    });
+  });
 
-      expect(res.body).to.have.property('name', uname);
-      expect(res.body).to.not.have.property('password');
-      expect(res.body.isDeleted).to.not.equal(0);
+  describe('admin user >', () => {
+    it('can delete another user by name', (done) => {
+      api.delete(`${path}/${userOne}`)
+      .set('Authorization', OBAdminUserToken)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.body).to.have.property('name', userOne);
+        expect(res.body.isDeleted).to.be.greaterThan(ZERO);
+        return done();
+      });
+    });
 
-      Token.findOne({ where: { name: uname, createdBy: userId } })
-      .then((tobj) => {
-        if (tobj) {
-          return done(new Error('Default token should have been deleted'));
-        }
+    it('can delete another user by id', (done) => {
+      api.delete(`${path}/${user2id}`)
+      .set('Authorization', OBAdminUserToken)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.body).to.have.property('name', userTwo);
+        expect(res.body.isDeleted).to.be.greaterThan(ZERO);
+        return done();
+      });
+    });
+  });
 
-        done();
-      })
-      .catch(done);
+  describe('non-admin user >', () => {
+    it('can delete self by name', (done) => {
+      api.delete(`${path}/${userThree}`)
+      .set('Authorization', user3Token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.body).to.have.property('name', userThree);
+        expect(res.body.isDeleted).to.be.greaterThan(ZERO);
+        return done();
+      });
+    });
+
+    it('can delete self by id', (done) => {
+      api.delete(`${path}/${user4id}`)
+      .set('Authorization', user4Token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res.body).to.have.property('name', userFour);
+        expect(res.body.isDeleted).to.be.greaterThan(ZERO);
+        return done();
+      });
+    });
+
+    it('cannot delete other user by name', (done) => {
+      api.delete(`${path}/${userSix}`)
+      .set('Authorization', user5Token)
+      .expect(constants.httpStatus.FORBIDDEN)
+      .end((err, res) => {
+        if (err) return done(err);
+        return done();
+      });
+    });
+
+    it('cannot delete other user by id', (done) => {
+      api.delete(`${path}/${user6id}`)
+      .set('Authorization', user5Token)
+      .expect(constants.httpStatus.FORBIDDEN)
+      .end((err, res) => {
+        if (err) return done(err);
+        return done();
+      });
     });
   });
 });


### PR DESCRIPTION
An admin user may delete any user; non-admin users may only delete themselves.
- api/v1/swagger - update the description of the operation
- api/v1/controllers/user - check whether user is admin or deleting self before doing delete
- tests/api/v1/users/delete - add tests