### PR TITLE
Fix bug: bulkUpsertSamples error when query body is empty

### DIFF
--- a/api/v1/controllers/aspects.js
+++ b/api/v1/controllers/aspects.js
@@ -250,19 +250,19 @@ module.exports = {
     const params = req.swagger.params;
     u.findByKey(helper, params)
     .then((o) => u.isWritable(req, o))
-      .then((o) => redisOps.getValue('aspect', o.name))
-      .then((cachedAspect) => {
-        if (cachedAspect) {
-          cachedAspect.writers = [];
-          return redisOps.hmSet('aspect', cachedAspect.name, cachedAspect);
-        }
+    .then((o) => redisOps.getValue('aspect', o.name))
+    .then((cachedAspect) => {
+      if (cachedAspect) {
+        cachedAspect.writers = [];
+        return redisOps.hmSet('aspect', cachedAspect.name, cachedAspect);
+      }
 
-        // reject the promise if the aspect is not found in the cache
-        return Promise.reject(new apiErrors.ResourceNotFoundError());
-      })
-      .then(() => doDeleteAllAssoc(req, res, next, helper,
-            helper.belongsToManyAssoc.users))
-      .catch((err) => u.handleError(next, err, helper.modelName));
+      // reject the promise if the aspect is not found in the cache
+      return Promise.reject(new apiErrors.ResourceNotFoundError());
+    })
+    .then(() => doDeleteAllAssoc(req, res, next, helper,
+          helper.belongsToManyAssoc.users))
+    .catch((err) => u.handleError(next, err, helper.modelName));
   },
 
   /**

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -1028,7 +1028,7 @@ module.exports = {
    */
   bulkUpsertByName(sampleQueryBody, user, readOnlyFields) {
     if (!sampleQueryBody || !Array.isArray(sampleQueryBody)) {
-      Promise.resolve([]);
+      return Promise.resolve([]);
     }
 
     const promises = sampleQueryBody.map((sampleReq) => {

--- a/tests/cache/models/samples/upsertBulk.js
+++ b/tests/cache/models/samples/upsertBulk.js
@@ -314,6 +314,30 @@ describe('tests/cache/models/samples/upsertBulk.js, ' +
     });
   });
 
+  it('bulkUpsert undefined sample query body', (done) => {
+    bulkUpsert(undefined)
+    .then((response) => {
+      expect(response).to.be.empty;
+      done();
+    });
+  });
+
+  it('bulkUpsert empty sample query body array', (done) => {
+    bulkUpsert([])
+    .then((response) => {
+      expect(response).to.be.empty;
+      done();
+    });
+  });
+
+  it('bulkUpsert null sample query body', (done) => {
+    bulkUpsert(null)
+    .then((response) => {
+      expect(response).to.be.empty;
+      done();
+    });
+  });
+
   describe('when sample already exists >', () => {
     it('check that duplication of sample is not happening', (done) => {
       api.post(path)


### PR DESCRIPTION
`return Promise.resolve([])` instead of just calling `Promise.resolve([])` to prevent this:

TypeError: Cannot read property 'map' of undefined
     at Object.bulkUpsertByName (/app/cache/models/samples.js:1034:38)
     at module.exports (/app/worker/jobs/bulkUpsertSamplesJob.js:45:20)

Add tests.