### PR TITLE
log out values of env vars on startup

### DIFF
--- a/clock/index.js
+++ b/clock/index.js
@@ -26,6 +26,7 @@ if (conf.newRelicKey) {
 }
 
 const featureToggles = require('feature-toggles');
+const logEnvVars = require('../utils/logEnvVars');
 const kueStatsActivityLogs = require('./scheduledJobs/kueStatsActivityLogs');
 const pubStatsLogs = require('./scheduledJobs/pubStatsLogs');
 const persistSampleStoreJob = require('./scheduledJobs/persistSampleStoreJob');
@@ -36,6 +37,8 @@ const jobCleanup = require('./scheduledJobs/jobCleanup');
 const deactivateRooms = require('./scheduledJobs/deactivateRooms');
 const checkMissedCollectorHeartbeatJob =
   require('./scheduledJobs/checkMissedCollectorHeartbeatJob');
+
+logEnvVars.log(process.env); // eslint-disable-line no-process-env
 
 /*
  * Add all the scheduled work here.

--- a/config.js
+++ b/config.js
@@ -274,6 +274,11 @@ module.exports = {
   expressLimiterExpire2,
   botEventLimit,
   deactivateRoomsInterval,
+  logEnvVars: {
+    MASK_LIST: pe.LOG_ENV_VARS_MASK_LIST ?
+      pe.LOG_ENV_VARS_MASK_LIST.split(',') : [],
+    MAX_LEN: +pe.LOG_ENV_VARS_MAX_LEN || 512,
+  },
   minRoomDeactivationAge,
   kueStatsInactiveWarning: pe.KUESTATS_INACTIVE_WARNING,
   newRelicKey,

--- a/config/activityLog.js
+++ b/config/activityLog.js
@@ -27,6 +27,11 @@ module.exports = {
     uri: 'None',
     user: 'None',
   },
+  env: {
+    activity: 'env',
+    name: 'None',
+    value: 'None',
+  },
   job: {
     activity: 'job',
     description: 'None',

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -82,6 +82,7 @@ function envVarIncludes(env, envVarName, str) {
 const longTermToggles = {
   // Activity logging
   enableApiActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'api'),
+  enableEnvActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'env'),
   enableJobActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'job'),
   enableJobCleanupActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
     'jobCleanup'),

--- a/index.js
+++ b/index.js
@@ -70,17 +70,15 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
 
   const app = express();
 
-  if (featureToggles.isFeatureEnabled('enableEnvActivityLogs')) {
-    /*
-     * If clusterProcessId is 0, we're running in single-process mode (i.e.
-     * non-throng), so log the env vars out.
-     * If clusterProcessId > 0, we have multiple throng workers, and in that
-     * case we only want to log out the env vars once, since they're all the
-     * same across all the throng workers, so in this case just do the logging
-     * if clusterProcessId is 1.
-     */
-    if (clusterProcessId < 2) logEnvVars.log(process.env);
-  }
+  /*
+   * If clusterProcessId is 0, we're running in single-process mode (i.e.
+   * non-throng), so log the env vars out.
+   * If clusterProcessId > 0, we have multiple throng workers, and in that case
+   * we only want to log out the env vars once, since they're all the same
+   * across all the throng workers, so in this case just do the logging if
+   * clusterProcessId is 1.
+   */
+  if (clusterProcessId < 2) logEnvVars.log(process.env);
 
   /*
    * Call this *before* the static pages and the API routes so that both the

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
   // SegfaultHandler.registerHandler('crash.log');
 
   const featureToggles = require('feature-toggles');
+  const logEnvVars = require('./utils/logEnvVars');
 
   if (conf.newRelicKey) {
     require('newrelic');
@@ -68,6 +69,14 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
   const enforcesSSL = require('express-enforces-ssl');
 
   const app = express();
+
+  if (featureToggles.isFeatureEnabled('enableEnvActivityLogs')) {
+    /*
+     * Environment variables are the same for every worker in the cluster so
+     * log them just once, just for the first worker in the cluster.
+     */
+    if (clusterProcessId === 0) logEnvVars.log(process.env);
+  }
 
   /*
    * Call this *before* the static pages and the API routes so that both the

--- a/index.js
+++ b/index.js
@@ -72,10 +72,14 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
 
   if (featureToggles.isFeatureEnabled('enableEnvActivityLogs')) {
     /*
-     * Environment variables are the same for every worker in the cluster so
-     * log them just once, just for the first worker in the cluster.
+     * If clusterProcessId is 0, we're running in single-process mode (i.e.
+     * non-throng), so log the env vars out.
+     * If clusterProcessId > 0, we have multiple throng workers, and in that
+     * case we only want to log out the env vars once, since they're all the
+     * same across all the throng workers, so in this case just do the logging
+     * if clusterProcessId is 1.
      */
-    if (clusterProcessId === 0) logEnvVars.log(process.env);
+    if (clusterProcessId < 2) logEnvVars.log(process.env);
   }
 
   /*

--- a/tests/utils/logEnvVars.js
+++ b/tests/utils/logEnvVars.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/utils/logEnvVars.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const logEnvVars = require('../../utils/logEnvVars');
+
+describe('tests/utils/logEnvVars.js >', () => {
+  describe('prepareObjectsToLog >', () => {
+    it('hides values for exact (case-sensitive) match of key name for ' +
+    'hidden keys', () => {
+      const data = {
+        SECRET_TOKEN: 'This is a SECRET_TOKEN, should be hidden',
+        SESSION_SECRET: 'This is a SESSION_SECRET, should be hidden',
+        SECURITYSESSIONID: 'This is a SECURITYSESSIONID, should be hidden',
+        SECRET_TOKEN1: '1',
+        SESSION_SECRET2: '2',
+        SECURITYSESSIONID3: '3',
+        '4SECRET_TOKEN': '4',
+        '5SESSION_SECRET': '5',
+        '6SECURITYSESSIONID': '6',
+        _SECRET_TOKEN: '7',
+        _SESSION_SECRET2: '8',
+        _SECURITYSESSIONID3: '9',
+        SECRET_Token: '10',
+        SESSION_Secret: '11',
+        SecuritySESSIONId: '12',
+      };
+      expect(logEnvVars.prepareObjectsToLog(data)).to.deep.equal([
+        { name: '4SECRET_TOKEN', value: '"4"' },
+        { name: '5SESSION_SECRET', value: '"5"' },
+        { name: '6SECURITYSESSIONID', value: '"6"' },
+        { name: 'SECRET_TOKEN', value: '"hidden"' },
+        { name: 'SECRET_TOKEN1', value: '"1"' },
+        { name: 'SECRET_Token', value: '"10"' },
+        { name: 'SECURITYSESSIONID', value: '"hidden"' },
+        { name: 'SECURITYSESSIONID3', value: '"3"' },
+        { name: 'SESSION_SECRET', value: '"hidden"' },
+        { name: 'SESSION_SECRET2', value: '"2"' },
+        { name: 'SESSION_Secret', value: '"11"' },
+        { name: 'SecuritySESSIONId', value: '"12"' },
+        { name: '_SECRET_TOKEN', value: '"7"' },
+        { name: '_SECURITYSESSIONID3', value: '"9"' },
+        { name: '_SESSION_SECRET2', value: '"8"' },
+      ]);
+    });
+
+    it('skips keys starting with HEROKU_ or REDIS_BASTION or npm_, ' +
+    'case sensitive', () => {
+      const data = {
+        HEROKU_: '1',
+        HEROKU_2: '2',
+        Heroku_3: '3',
+        REDIS_BASTION: '4',
+        REDIS_BASTION5: '5',
+        Redis_BASTION6: '6',
+        npm_7: '7',
+        NPM_8: '8',
+        npm_: '9',
+      };
+      expect(logEnvVars.prepareObjectsToLog(data)).to.deep.equal([
+        { name: 'Heroku_3', value: '"3"' },
+        { name: 'NPM_8', value: '"8"' },
+        { name: 'Redis_BASTION6', value: '"6"' },
+      ]);
+    });
+
+    it('unexpected or empty env returns empty array', () => {
+      expect(logEnvVars.prepareObjectsToLog({})).to.deep.equal([]);
+      expect(logEnvVars.prepareObjectsToLog(undefined)).to.deep.equal([]);
+      expect(logEnvVars.prepareObjectsToLog(null)).to.deep.equal([]);
+      expect(logEnvVars.prepareObjectsToLog([1, 2, 'abc'])).to.deep.equal([]);
+    });
+  });
+});

--- a/tests/utils/logEnvVars.js
+++ b/tests/utils/logEnvVars.js
@@ -14,70 +14,61 @@ const expect = require('chai').expect;
 const logEnvVars = require('../../utils/logEnvVars');
 
 describe('tests/utils/logEnvVars.js >', () => {
+  describe('truncate >', () => {
+    it('over the maxlen, truncated', () => {
+      expect(logEnvVars.truncate('abcdefgh', 6)).to.equal('abc...');
+    });
+
+    it('equal maxlen', () => {
+      expect(logEnvVars.truncate('abcdef', 6)).to.equal('abcdef');
+    });
+
+    it('under maxlen', () => {
+      expect(logEnvVars.truncate('abc', 6)).to.equal('abc');
+    });
+
+    it('false-y strings', () => {
+      expect(logEnvVars.truncate('', 5)).to.equal('');
+      expect(logEnvVars.truncate(null, 5)).to.equal('');
+      expect(logEnvVars.truncate(undefined, 5)).to.equal('');
+    });
+  });
+
   describe('prepareObjectsToLog >', () => {
-    it('hides values for exact (case-sensitive) match of key name for ' +
-    'hidden keys', () => {
-      const data = {
-        SECRET_TOKEN: 'This is a SECRET_TOKEN, should be hidden',
-        SESSION_SECRET: 'This is a SESSION_SECRET, should be hidden',
-        SECURITYSESSIONID: 'This is a SECURITYSESSIONID, should be hidden',
-        SECRET_TOKEN1: '1',
-        SESSION_SECRET2: '2',
-        SECURITYSESSIONID3: '3',
-        '4SECRET_TOKEN': '4',
-        '5SESSION_SECRET': '5',
-        '6SECURITYSESSIONID': '6',
-        _SECRET_TOKEN: '7',
-        _SESSION_SECRET2: '8',
-        _SECURITYSESSIONID3: '9',
-        SECRET_Token: '10',
-        SESSION_Secret: '11',
-        SecuritySESSIONId: '12',
+    describe('with mask list >', () => {
+      const opts = {
+        MASK_LIST: 'ABC,DEF',
       };
-      expect(logEnvVars.prepareObjectsToLog(data)).to.deep.equal([
-        { name: '4SECRET_TOKEN', value: '"4"' },
-        { name: '5SESSION_SECRET', value: '"5"' },
-        { name: '6SECURITYSESSIONID', value: '"6"' },
-        { name: 'SECRET_TOKEN', value: '"hidden"' },
-        { name: 'SECRET_TOKEN1', value: '"1"' },
-        { name: 'SECRET_Token', value: '"10"' },
-        { name: 'SECURITYSESSIONID', value: '"hidden"' },
-        { name: 'SECURITYSESSIONID3', value: '"3"' },
-        { name: 'SESSION_SECRET', value: '"hidden"' },
-        { name: 'SESSION_SECRET2', value: '"2"' },
-        { name: 'SESSION_Secret', value: '"11"' },
-        { name: 'SecuritySESSIONId', value: '"12"' },
-        { name: '_SECRET_TOKEN', value: '"7"' },
-        { name: '_SECURITYSESSIONID3', value: '"9"' },
-        { name: '_SESSION_SECRET2', value: '"8"' },
-      ]);
-    });
 
-    it('skips keys starting with HEROKU_ or REDIS_BASTION or npm_, ' +
-    'case sensitive', () => {
-      const data = {
-        HEROKU_: '1',
-        HEROKU_2: '2',
-        Heroku_3: '3',
-        REDIS_BASTION: '4',
-        REDIS_BASTION5: '5',
-        Redis_BASTION6: '6',
-        npm_7: '7',
-        NPM_8: '8',
-        npm_: '9',
-      };
-      expect(logEnvVars.prepareObjectsToLog(data)).to.deep.equal([
-        { name: 'Heroku_3', value: '"3"' },
-        { name: 'NPM_8', value: '"8"' },
-        { name: 'Redis_BASTION6', value: '"6"' },
-      ]);
-    });
+      it('hides exact, case-sensitive matches', () => {
+        const data = {
+          ABC: '1',
+          _ABC: '2',
+          ABC_: '3',
+          $ABC: '4',
+          abc: '5',
+          ab: '6',
+          DEF: '7',
+        };
+        expect(logEnvVars.prepareObjectsToLog(data, opts)).to.deep.equal([
+          { name: '$ABC', value: '"4"' },
+          { name: 'ABC', value: '"hidden"' },
+          { name: 'ABC_', value: '"3"' },
+          { name: 'DEF', value: '"hidden"' },
+          { name: '_ABC', value: '"2"' },
+          { name: 'ab', value: '"6"' },
+          { name: 'abc', value: '"5"' },
+        ]);
+      });
 
-    it('unexpected or empty env returns empty array', () => {
-      expect(logEnvVars.prepareObjectsToLog({})).to.deep.equal([]);
-      expect(logEnvVars.prepareObjectsToLog(undefined)).to.deep.equal([]);
-      expect(logEnvVars.prepareObjectsToLog(null)).to.deep.equal([]);
-      expect(logEnvVars.prepareObjectsToLog([1, 2, 'abc'])).to.deep.equal([]);
+      it('unexpected or empty env returns empty array', () => {
+        expect(logEnvVars.prepareObjectsToLog({}, opts)).to.deep.equal([]);
+        expect(logEnvVars.prepareObjectsToLog(undefined, opts))
+        .to.deep.equal([]);
+        expect(logEnvVars.prepareObjectsToLog(null, opts)).to.deep.equal([]);
+        expect(logEnvVars.prepareObjectsToLog([1, 2, 'abc'], opts))
+        .to.deep.equal([]);
+      });
     });
   });
 });

--- a/utils/logEnvVars.js
+++ b/utils/logEnvVars.js
@@ -11,31 +11,68 @@
  */
 'use strict'; // eslint-disable-line strict
 const featureToggles = require('feature-toggles');
+const config = require('../config');
 const activityLog = require('./activityLog');
-const HIDE_ME_LIST = [
-  'DATABASE_BASTION_KEY',
-  'DATABASE_URL',
-  'REDIS_URL',
-  'SECRET_TOKEN',
-  'SESSION_SECRET',
-  'SECURITYSESSIONID',
-];
-const SKIP_ME_REGEX = /^(HEROKU_|REDIS_BASTION|npm_).*/;
+
+ /**
+  * Note: with node 8, assigning a property on process.env will implicitly
+  * convert the value to a string so we do not need to worry about non-string
+  * types here.
+  */
+function truncate(str = '', max) {
+  if (!str) return '';
+  if (str.length > max) {
+    str = str.substring(0, max - 3) + '...';
+  }
+
+  return str;
+} // truncate
+
+/**
+ * Set up the config options, starting from the values from config OR using
+ * override values from opts arg.
+ *
+ * @param {Object} conf - options from config.logEnvVars
+ * @param {Object} opts - options object containing optional MASK_LIST and
+ *  MAX_LEN attributes
+ * @returns {Object} config options
+ */
+function prepareConfOpts(conf, opts) {
+  const retval = {
+    maskList: conf.MASK_LIST,
+    maxValueLength: conf.MAX_LEN,
+  };
+
+  if (opts && opts.MAX_LEN) retval.maxValueLength = opts.MAX_LEN;
+  if (retval.maxValueLength < 4) retval.maxValueLength = 512;
+  if (opts && opts.MASK_LIST) retval.maskList = opts.MASK_LIST;
+  return retval;
+} // prepareConfOpts
 
 /**
  * Returns array of 'env' activity log objects, or returns an empty array if
  * env is not an object or is false-y or is an array.
+ *
+ * @param {Object} env - will be process.env, but exposing it as arg to make it
+ *  easier to test (assumes it has typeof "object")
+ * @param {Object} opts - will be config.logEnvVars, but exposing it as arg to
+ *  make it easier to test
  */
-function prepareObjectsToLog(env) {
-  if (env && Array.isArray(env)) return [];
+function prepareObjectsToLog(env, opts) {
+  /* Short circuit - do nothing if env is false-y or if it's an array. */
+  if (!env || Array.isArray(env)) return []; 
 
+  opts = prepareConfOpts(config.logEnvVars, opts);
   return Object.keys(env || {})
-  .filter((name) => !name.match(SKIP_ME_REGEX))
   .sort()
-  .map((name) => ({
-    name,
-    value: HIDE_ME_LIST.includes(name) ? '"hidden"' : `"${env[name]}"`,
-  }));
+  .map((name) => {
+    const val = opts.maskList.includes(name) ? 'hidden' :
+      truncate(env[name], opts.maxValueLength);
+    return {
+      name,
+      value: `"${val}"`,
+    };
+  });
 } // prepareObjectsToLog
 
 function log(env) {
@@ -47,5 +84,7 @@ function log(env) {
 
 module.exports = {
   log,
+  prepareConfOpts, // for testing only
   prepareObjectsToLog, // for testing only
+  truncate, // for testing only
 };

--- a/utils/logEnvVars.js
+++ b/utils/logEnvVars.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * ./utils/logEnvVars.js
+ */
+'use strict'; // eslint-disable-line strict
+const activityLog = require('./activityLog');
+const HIDE_ME_LIST = ['SECRET_TOKEN', 'SESSION_SECRET', 'SECURITYSESSIONID'];
+const SKIP_ME_REGEX = /^(HEROKU_|REDIS_BASTION|npm_).*/;
+
+/**
+ * Returns array of 'env' activity log objects, or returns an empty array if
+ * env is not an object or is false-y or is an array.
+ */
+function prepareObjectsToLog(env) {
+  if (env && Array.isArray(env)) return [];
+
+  return Object.keys(env || {})
+  .filter((name) => !name.match(SKIP_ME_REGEX))
+  .sort()
+  .map((name) => ({
+    name,
+    value: HIDE_ME_LIST.includes(name) ? '"hidden"' : `"${env[name]}"`,
+  }));
+} // prepareObjectsToLog
+
+function log(env) {
+  prepareObjectsToLog(env)
+  .forEach((obj) => activityLog.printActivityLogString(obj, 'env'));
+} // log
+
+module.exports = {
+  log,
+  prepareObjectsToLog, // for testing only
+};

--- a/utils/logEnvVars.js
+++ b/utils/logEnvVars.js
@@ -14,11 +14,11 @@ const featureToggles = require('feature-toggles');
 const config = require('../config');
 const activityLog = require('./activityLog');
 
- /**
-  * Note: with node 8, assigning a property on process.env will implicitly
-  * convert the value to a string so we do not need to worry about non-string
-  * types here.
-  */
+/**
+ * Note: with node 8, assigning a property on process.env will implicitly
+ * convert the value to a string so we do not need to worry about non-string
+ * types here.
+ */
 function truncate(str = '', max) {
   if (!str) return '';
   if (str.length > max) {
@@ -60,7 +60,7 @@ function prepareConfOpts(conf, opts) {
  */
 function prepareObjectsToLog(env, opts) {
   /* Short circuit - do nothing if env is false-y or if it's an array. */
-  if (!env || Array.isArray(env)) return []; 
+  if (!env || Array.isArray(env)) return [];
 
   opts = prepareConfOpts(config.logEnvVars, opts);
   return Object.keys(env || {})

--- a/utils/logEnvVars.js
+++ b/utils/logEnvVars.js
@@ -10,8 +10,16 @@
  * ./utils/logEnvVars.js
  */
 'use strict'; // eslint-disable-line strict
+const featureToggles = require('feature-toggles');
 const activityLog = require('./activityLog');
-const HIDE_ME_LIST = ['SECRET_TOKEN', 'SESSION_SECRET', 'SECURITYSESSIONID'];
+const HIDE_ME_LIST = [
+  'DATABASE_BASTION_KEY',
+  'DATABASE_URL',
+  'REDIS_URL',
+  'SECRET_TOKEN',
+  'SESSION_SECRET',
+  'SECURITYSESSIONID',
+];
 const SKIP_ME_REGEX = /^(HEROKU_|REDIS_BASTION|npm_).*/;
 
 /**
@@ -31,8 +39,10 @@ function prepareObjectsToLog(env) {
 } // prepareObjectsToLog
 
 function log(env) {
-  prepareObjectsToLog(env)
-  .forEach((obj) => activityLog.printActivityLogString(obj, 'env'));
+  if (featureToggles.isFeatureEnabled('enableEnvActivityLogs')) {
+    prepareObjectsToLog(env)
+    .forEach((obj) => activityLog.printActivityLogString(obj, 'env'));
+  }
 } // log
 
 module.exports = {

--- a/worker/jobProcessor.js
+++ b/worker/jobProcessor.js
@@ -21,6 +21,8 @@ if (conf.newRelicKey) {
 }
 
 const logger = require('winston');
+const featureToggles = require('feature-toggles');
+const logEnvVars = require('../utils/logEnvVars');
 const jobSetup = require('../jobQueue/setup');
 const jobConcurrency = jobSetup.jobConcurrency;
 const jobType = jobSetup.jobType;
@@ -37,6 +39,8 @@ const checkMissedCollectorHeartbeatJob =
 
 const workerStarted = 'Worker Process Started';
 logger.info(workerStarted);
+
+logEnvVars.log(process.env); // eslint-disable-line no-process-env
 
 jobQueue.process(jobType.BULKUPSERTSAMPLES, jobConcurrency.BULKUPSERTSAMPLES,
   bulkUpsertSamplesJob);


### PR DESCRIPTION
Define new feature toggle "enableEnvActivityLogs".
Define new log activity type "env".
When enabled, on server start, one "activity=env" log line is printed for each environment variable. Some env variables are skipped altogether, others are not skipped but are "hidden", where we print out the log line for the env var but we mask the value (i.e. to indicate that the variable has been set, but the value is secret).
When running multiple node processes in a single dyno, each of the node processes has the same env, so we only print out the env vars once.