### PR TITLE
Revert "Give rooms a namespace to Sockets"

### DIFF
--- a/view/rooms/app.js
+++ b/view/rooms/app.js
@@ -671,8 +671,7 @@ function setupSocketIOClient(bots) {
     botInfo[bot.body.id] = bot.body.name;
   });
 
-  const namespace = `/refocus.room?room=${ROOM_ID}&roomType=${_roomTypeName}`;
-  const socket = _io(namespace, { transports: ['websocket'] });
+  const socket = _io('/', { transports: ['websocket'] });
 
   // Socket Event Names
   const settingsChangedEventName =


### PR DESCRIPTION
- I pulled master this morning and I don't think this should have been merged yet until we make changes in bdk @tausifmuzaffar .. With these changes no bots will render.

<img width="1440" alt="screen shot 2018-09-27 at 11 14 42" src="https://user-images.githubusercontent.com/17026751/46139517-a7972580-c246-11e8-818d-16791e06f5c0.png">
Reverts salesforce/refocus#993