### PR TITLE
change resetJobCounter default

### DIFF
--- a/config.js
+++ b/config.js
@@ -126,7 +126,7 @@ const clockJobConfig = {
     kueStatsActivityLogs: '1m',
     pubStatsLogs: '1m',
     queueStatsActivityLogs: '1m',
-    resetJobCounter: '24h',
+    resetJobCounter: '2h',
     sampleTimeout: '30s',
   },
   useWorker: {
@@ -153,6 +153,10 @@ Object.keys(clockJobConfig.intervals).forEach((jobName) => {
   const defaultValue = clockJobConfig.intervals[jobName];
   const envValue = pe[`CLOCK_JOB_INTERVAL:${jobName}`];
   const value = envValue || defaultValue;
+  console.log('Configuring clock job intervals: ' +
+    `jobName="${jobName}" defaultValue="${defaultValue}" ` +
+    `envValue="${envValue}" envValueType="${typeof envValue}" ` +
+    `value="${value}" ms-value="${ms(value)}"`);
   clockJobConfig.intervals[jobName] = ms(value);
 });
 

--- a/config.js
+++ b/config.js
@@ -153,10 +153,6 @@ Object.keys(clockJobConfig.intervals).forEach((jobName) => {
   const defaultValue = clockJobConfig.intervals[jobName];
   const envValue = pe[`CLOCK_JOB_INTERVAL:${jobName}`];
   const value = envValue || defaultValue;
-  console.log('Configuring clock job intervals: ' +
-    `jobName="${jobName}" defaultValue="${defaultValue}" ` +
-    `envValue="${envValue}" envValueType="${typeof envValue}" ` +
-    `value="${value}" ms-value="${ms(value)}"`);
   clockJobConfig.intervals[jobName] = ms(value);
 });
 

--- a/tests/clock/clock.js
+++ b/tests/clock/clock.js
@@ -26,7 +26,7 @@ describe('tests/clock/clock.js >', function () {
       checkMissedCollectorHeartbeat: intervalsInDay('15s'),
       deactivateRooms: intervalsInDay('5m'),
       jobCleanup: intervalsInDay('30m'),
-      resetJobCounter: intervalsInDay('24h'),
+      resetJobCounter: intervalsInDay('2h'),
       sampleTimeout: intervalsInDay('30s'),
     };
 
@@ -47,7 +47,7 @@ describe('tests/clock/clock.js >', function () {
       checkMissedCollectorHeartbeat: intervalsInHour('15s'),
       deactivateRooms: intervalsInHour('5m'),
       jobCleanup: intervalsInHour('30m'),
-      resetJobCounter: intervalsInHour('24h'),
+      resetJobCounter: intervalsInHour('2h'),
       sampleTimeout: intervalsInHour('30s'),
     };
 
@@ -72,7 +72,7 @@ describe('tests/clock/clock.js >', function () {
       kueStatsActivityLogs: intervalsInHour('1m'),
       pubStatsLogs: intervalsInHour('1m'),
       queueStatsActivityLogs: intervalsInHour('1m'),
-      resetJobCounter: intervalsInHour('24h'),
+      resetJobCounter: intervalsInHour('2h'),
       sampleTimeout: intervalsInHour('30s'),
     };
 


### PR DESCRIPTION
The problem was that it was just too small of an interval. The reset has to be several times the cleanup or it will delete active jobs, which causes the test to timeout as it waits for completion.