### PR TITLE
Adding method to add FK for multiple association just when needed

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -255,8 +255,9 @@ function multipleAssociations(helperModule, requestedAttributes) {
      (createdBy, collectorId, etc)
      */
     const extraForeignKeys = associations
-      .map((assocName) => helperModule.model.associations[assocName].foreignKey)
-      .map((foreignKey) => {
+      .map((assocName) => {
+        const foreignKey = helperModule.model.associations[assocName]
+          .foreignKey;
         const attribute = helperModule.model.attributes[foreignKey];
         return attribute ? attribute.fieldName : '';
       })

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -237,9 +237,35 @@ function handleAssociations(reqObj, inst, props, method) {
   });
 } // handleAssociations
 
-function isMultipleAssociations(opts) {
-  const MULTIPLE_ASSOCIATIONS = 3;
-  return opts.attributes.length >= MULTIPLE_ASSOCIATIONS;
+/**
+ * When more than one association is required, Sequelize creates inner query
+ * but doesn't expose FK causing SQL failure.
+ *
+ * This method, in order to avoid Sequelize issue, will add all
+ * the foreign keys to the query when more than one association is required.
+ */
+function multipleAssociations(helperModule, requestedAttributes) {
+  // Filters all association just when requested
+  const associations = requestedAttributes
+    .filter((attribute) => helperModule.model.associations[attribute]);
+
+  if (associations.length > 1) {
+    /*
+     Maps association names (User, currentCollector, etc) to model.fk_names
+     (createdBy, collectorId, etc)
+     */
+    const extraForeignKeys = associations
+      .map((assocName) => helperModule.model.associations[assocName].foreignKey)
+      .map((foreignKey) => {
+        const attribute = helperModule.model.attributes[foreignKey];
+        return attribute ? attribute.fieldName : '';
+      })
+      .filter((it) => it !== '');
+
+    if (extraForeignKeys.length > 0) {
+      requestedAttributes.push(...extraForeignKeys);
+    }
+  }
 }
 
 /**
@@ -257,33 +283,8 @@ function buildFieldList(params, props) {
     opts.attributes = params.fields.value;
     if (!opts.attributes.includes('id')) opts.attributes.push('id');
 
-    if (props.model && isMultipleAssociations(opts)) {
-      /*
-      Sequelize workaround.
-      Includes all model's FK for an eventual outer join when it selects
-      the attributes before doing the join for the association, which
-      causes an error when the foreign key is not included in the fields.
-      */
-      const keys = Object.keys(props.model.attributes);
-      keys.forEach((key) => {
-        if (props.model.attributes[key].references) {
-          // model has FK, add to the SQL
-          opts.attributes.push(key);
-
-          /*
-            TODO - remove attributes before send back to the client
-            Keeping comment by now:
-            re-using props as above (The helpers/nouns module ) makes the test
-            fail when running all tests (runs properly one-by-one).
-            We must send back fieldsToExclude into opts (next sprint).
-            https://github.com/salesforce/refocus/pull/918
-          */
-
-          // Add to fields to exclude before sending response
-          // if (!props.fieldsToExclude) props.fieldsToExclude = [];
-          // props.fieldsToExclude.push(key);
-        }
-      });
+    if (props.model) {
+      multipleAssociations(props, opts.attributes);
     }
   }
 

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -251,17 +251,22 @@ function multipleAssociations(helperModule, requestedAttributes) {
 
   if (associations.length > 1) {
     /*
-     Maps association names (User, currentCollector, etc) to model.fk_names
-     (createdBy, collectorId, etc)
+     Transform association names (User, currentCollector, etc) to
+     model.fk_names (createdBy, collectorId, etc)
      */
     const extraForeignKeys = associations
-      .map((assocName) => {
-        const foreignKey = helperModule.model.associations[assocName]
-          .foreignKey;
-        const attribute = helperModule.model.attributes[foreignKey];
-        return attribute ? attribute.fieldName : '';
+      .filter((association) => {
+        // filter all associations with respective fk in the model attributes
+
+        const foreignKey = helperModule.model
+          .associations[association].foreignKey;
+        return helperModule.model.attributes[foreignKey] !== undefined;
       })
-      .filter((it) => it !== '');
+      .map((association) => {
+        const foreignKey = helperModule.model
+          .associations[association].foreignKey;
+        return helperModule.model.attributes[foreignKey].fieldName;
+      });
 
     if (extraForeignKeys.length > 0) {
       requestedAttributes.push(...extraForeignKeys);

--- a/tests/api/v1/aspects/associations.js
+++ b/tests/api/v1/aspects/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Aspect = tu.db.Aspect;
 const path = '/v1/aspects';
 const Joi = require('joi');

--- a/tests/api/v1/aspects/associations.js
+++ b/tests/api/v1/aspects/associations.js
@@ -12,7 +12,8 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Aspect = tu.db.Aspect;
 const path = '/v1/aspects';
 const Joi = require('joi');

--- a/tests/api/v1/collectors/associations.js
+++ b/tests/api/v1/collectors/associations.js
@@ -14,7 +14,8 @@ const tu = require('../../../testUtils');
 const cu = require('./utils');
 const gu = require('../generators/utils');
 const gtUtil = gu.gtUtil;
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Collector = tu.db.Collector;
 const Generator = tu.db.Generator;
 const GeneratorTemplate = tu.db.GeneratorTemplate;

--- a/tests/api/v1/collectors/associations.js
+++ b/tests/api/v1/collectors/associations.js
@@ -14,8 +14,7 @@ const tu = require('../../../testUtils');
 const cu = require('./utils');
 const gu = require('../generators/utils');
 const gtUtil = gu.gtUtil;
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Collector = tu.db.Collector;
 const Generator = tu.db.Generator;
 const GeneratorTemplate = tu.db.GeneratorTemplate;

--- a/tests/api/v1/common/testAssociations.js
+++ b/tests/api/v1/common/testAssociations.js
@@ -90,10 +90,9 @@ function testAssociations(path, associations, joiSchema, conf) {
       .expect((res) => {
         expect(res.body).to.be.an('array');
         res.body.forEach((record) => {
-          // TODO - change contains to have once second part of sequelize bug applied
-
-          expect(record).to.contains.keys('id', 'name', assoc, 'apiLinks');
-          expect(Joi.validate(record[assoc], joiSchema[assoc]).error).to.be.null;
+          expect(record).to.have.keys('id', 'name', assoc, 'apiLinks');
+          expect(Joi.validate(record[assoc], joiSchema[assoc]).error)
+            .to.be.null;
         });
       })
       .end(done);
@@ -107,45 +106,13 @@ function testAssociations(path, associations, joiSchema, conf) {
       .expect(constants.httpStatus.OK)
       .expect((res) => {
         expect(res.body).to.be.an('object');
-
-        // TODO - change contains to have once second part of sequelize bug applied
-        expect(res.body).to.contains.keys('id', 'name', assoc, 'apiLinks');
+        expect(res.body).to.have.keys('id', 'name', assoc, 'apiLinks');
         expect(Joi.validate(res.body[assoc], joiSchema[assoc]).error).to.be.null;
       })
       .end(done);
     });
   });
 
-  /*
-    These tests fail because of a bug in sequelize.
-    It doesn't properly handle multiple associations when a limit is applied:
-    It selects the attributes before doing the join for the association, which
-    causes an error when the foreign key is not included in the fields.
-
-    One thing we tried:
-      According to Sequelize team when limits are set, they enforce the
-    usage of sub-queries, however, when Generator has multiple
-    associations (ie.: Collectors and User) the sub-query does not
-    expose foreign keys (Generator.createdBy).
-      Sequelize by default will try to create subQuery even when there is
-    no subQuery configured because the duplication flag is true by
-    default.
-      So, flagging duplicating=false makes Sequelize avoid cartesian
-    product not generating sub-queries (further check in:
-    /sequelize/model.js, line 441).
-
-    However, setting "duplicating: false" has side effects that break other
-    functionality; it causes associations to not return all elements.
-    This causes the following tests to fail because only one possibleCollector
-    is returned:
-      "get by key includes associations"
-      "get by key: an association can be specified as a field param"
-      "multiple associations can be specified with key and field params"
-
-    These cases are much more common than the problem we were trying to solve,
-    so it's better to go back to how it was before and re-skip these tests
-    for now.
-  */
   describe('Checking multiple associations', () => {
     if (associations.length > 1) {
       it('multiple associations can be specified as field params', (done) => {

--- a/tests/api/v1/generatorTemplates/associations.js
+++ b/tests/api/v1/generatorTemplates/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const GeneratorTemplate = tu.db.GeneratorTemplate;
 const path = '/v1/generatorTemplates';
 const Joi = require('joi');

--- a/tests/api/v1/generatorTemplates/associations.js
+++ b/tests/api/v1/generatorTemplates/associations.js
@@ -12,7 +12,8 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const GeneratorTemplate = tu.db.GeneratorTemplate;
 const path = '/v1/generatorTemplates';
 const Joi = require('joi');

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -14,8 +14,7 @@ const tu = require('../../../testUtils');
 const cu = require('../collectors/utils');
 const gu = require('./utils');
 const gtUtil = gu.gtUtil;
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Collector = tu.db.Collector;
 const Generator = tu.db.Generator;
 const GeneratorTemplate = tu.db.GeneratorTemplate;

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -111,7 +111,7 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
 
   testAssociations(path, associations, schema, conf);
 
-  describe('Checking Sequelize extra FK when multiple associations', () => {
+  describe('Checking sequelize extra FK when multiple associations', () => {
     it('Extra IDs must be returned from API', (done) => {
       const fields = ['name', ...associations].toString();
       api.get(`${path}?fields=${fields}`)

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -123,8 +123,8 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
             associations.forEach((association) => {
               expect(record).to.have.property(association);
               /*
-               API is returning extra fields as a solution for Sequelize inner
-               query issue that doesn't not return FK when multiple associations.
+              API is returning extra fields as a solution for Sequelize inner
+              query issue that doesn't not return FK when multiple associations.
               */
               expect(record).to.have.property('collectorId');
               expect(record).to.have.property('createdBy');

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -14,7 +14,12 @@ const tu = require('../../../testUtils');
 const cu = require('../collectors/utils');
 const gu = require('./utils');
 const gtUtil = gu.gtUtil;
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const constants = require('../../../../api/v1/constants');
+const supertest = require('supertest');
+const expect = require('chai').expect;
+const api = supertest(require('../../../../index').app);
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Collector = tu.db.Collector;
 const Generator = tu.db.Generator;
 const GeneratorTemplate = tu.db.GeneratorTemplate;
@@ -106,4 +111,28 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
   };
 
   testAssociations(path, associations, schema, conf);
+
+  describe('Checking Sequelize extra FK when multiple associations', () => {
+    it('Extra IDs must be returned from API', (done) => {
+      const fields = ['name', ...associations].toString();
+      api.get(`${path}?fields=${fields}`)
+        .set('Authorization', conf.token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.be.an('array');
+          res.body.forEach((record) => {
+            associations.forEach((association) => {
+              expect(record).to.have.property(association);
+              /*
+              API is returning extra fields as a solution for Sequelize inner
+              query issue that doesn't not return FK when multiple associations.
+              */
+              expect(record).to.have.property('collectorId');
+              expect(record).to.have.property('createdBy');
+            });
+          });
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -18,8 +18,7 @@ const constants = require('../../../../api/v1/constants');
 const supertest = require('supertest');
 const expect = require('chai').expect;
 const api = supertest(require('../../../../index').app);
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Collector = tu.db.Collector;
 const Generator = tu.db.Generator;
 const GeneratorTemplate = tu.db.GeneratorTemplate;
@@ -124,8 +123,8 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
             associations.forEach((association) => {
               expect(record).to.have.property(association);
               /*
-              API is returning extra fields as a solution for Sequelize inner
-              query issue that doesn't not return FK when multiple associations.
+               API is returning extra fields as a solution for Sequelize inner
+               query issue that doesn't not return FK when multiple associations.
               */
               expect(record).to.have.property('collectorId');
               expect(record).to.have.property('createdBy');

--- a/tests/api/v1/lenses/associations.js
+++ b/tests/api/v1/lenses/associations.js
@@ -12,7 +12,8 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Lens = tu.db.Lens;
 const path = '/v1/lenses';
 const Joi = require('joi');

--- a/tests/api/v1/lenses/associations.js
+++ b/tests/api/v1/lenses/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Lens = tu.db.Lens;
 const path = '/v1/lenses';
 const Joi = require('joi');

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Perspective = tu.db.Perspective;
 const path = '/v1/perspectives';
 const Joi = require('joi');

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -16,8 +16,7 @@ const constants = require('../../../../api/v1/constants');
 const supertest = require('supertest');
 const expect = require('chai').expect;
 const api = supertest(require('../../../../index').app);
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Perspective = tu.db.Perspective;
 const path = '/v1/perspectives';
 const Joi = require('joi');
@@ -99,7 +98,7 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
               expect(record).to.have.property(association);
               /*
                API is returning extra fields as a solution for Sequelize inner
-              query issue that doesn't not return FK when multiple associations.
+               query issue that doesn't not return FK when multiple associations.
               */
               expect(record).to.have.property('lensId');
               expect(record).to.have.property('createdBy');

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -12,7 +12,12 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const constants = require('../../../../api/v1/constants');
+const supertest = require('supertest');
+const expect = require('chai').expect;
+const api = supertest(require('../../../../index').app);
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Perspective = tu.db.Perspective;
 const path = '/v1/perspectives';
 const Joi = require('joi');
@@ -80,4 +85,28 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
   };
 
   testAssociations(path, associations, schema, conf);
+
+  describe('Checking Sequelize extra FK when multiple associations', () => {
+    it('Extra IDs must be returned from API', (done) => {
+      const fields = ['name', ...associations].toString();
+      api.get(`${path}?fields=${fields}`)
+        .set('Authorization', conf.token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.be.an('array');
+          res.body.forEach((record) => {
+            associations.forEach((association) => {
+              expect(record).to.have.property(association);
+              /*
+              API is returning extra fields as a solution for Sequelize inner
+              query issue that doesn't not return FK when multiple associations.
+              */
+              expect(record).to.have.property('lensId');
+              expect(record).to.have.property('createdBy');
+            });
+          });
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -98,7 +98,7 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
             associations.forEach((association) => {
               expect(record).to.have.property(association);
               /*
-              API is returning extra fields as a solution for Sequelize inner
+               API is returning extra fields as a solution for Sequelize inner
               query issue that doesn't not return FK when multiple associations.
               */
               expect(record).to.have.property('lensId');

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -97,8 +97,8 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
             associations.forEach((association) => {
               expect(record).to.have.property(association);
               /*
-               API is returning extra fields as a solution for Sequelize inner
-               query issue that doesn't not return FK when multiple associations.
+              API is returning extra fields as a solution for Sequelize inner
+              query issue that doesn't not return FK when multiple associations.
               */
               expect(record).to.have.property('lensId');
               expect(record).to.have.property('createdBy');

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -85,7 +85,7 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
 
   testAssociations(path, associations, schema, conf);
 
-  describe('Checking Sequelize extra FK when multiple associations', () => {
+  describe('Checking sequelize extra FK when multiple associations', () => {
     it('Extra IDs must be returned from API', (done) => {
       const fields = ['name', ...associations].toString();
       api.get(`${path}?fields=${fields}`)

--- a/tests/api/v1/subjects/associations.js
+++ b/tests/api/v1/subjects/associations.js
@@ -12,7 +12,8 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const Subject = tu.db.Subject;
 const path = '/v1/subjects';
 const Joi = require('joi');

--- a/tests/api/v1/subjects/associations.js
+++ b/tests/api/v1/subjects/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const Subject = tu.db.Subject;
 const path = '/v1/subjects';
 const Joi = require('joi');

--- a/tests/api/v1/subjects/get.js
+++ b/tests/api/v1/subjects/get.js
@@ -341,9 +341,7 @@ describe(`tests/api/v1/subjects/get.js, GET ${path} >`, () => {
       expect(res.body.length).to.equal(ONE);
       expect(res.body[ZERO].name).to.eql(vt.name);
       expect(res.body[ZERO]).to.not.have.property('tags');
-
-      // TODO - change contains to have once second part of sequelize bug applied
-      expect(res.body[ZERO]).to.contains.all
+      expect(res.body[ZERO]).to.have.all
         .keys(['apiLinks', 'id', 'isPublished', 'name', 'sortBy']);
       done();
     });

--- a/tests/api/v1/subjects/getHierarchy.js
+++ b/tests/api/v1/subjects/getHierarchy.js
@@ -284,10 +284,8 @@ describe(`tests/api/v1/subjects/getHierarchy.js, GET ${path} >`, () => {
       .expect(constants.httpStatus.OK)
       .end((err, res) => {
         if (err) done(err);
-
-        // TODO - change contains to have once second part of sequelize bug applied
         expect(res.body)
-        .to.contains.all.keys(['name', 'id', 'samples', 'children', 'apiLinks']);
+          .to.have.all.keys(['name', 'id', 'samples', 'children', 'apiLinks']);
         done();
       });
     });
@@ -298,10 +296,8 @@ describe(`tests/api/v1/subjects/getHierarchy.js, GET ${path} >`, () => {
       .expect(constants.httpStatus.OK)
       .end((err, res) => {
         if (err) done(err);
-
-        // TODO - change contains to have once second part of sequelize bug applied
         expect(res.body)
-        .to.contains.all.keys(['name', 'id', 'samples', 'children', 'apiLinks']);
+          .to.have.all.keys(['name', 'id', 'samples', 'children', 'apiLinks']);
         done();
       });
     });

--- a/tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js
+++ b/tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js
@@ -260,10 +260,8 @@ describe('tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js, ' +
         // north america. Check to make sure it does not return the parOther
         expect(res.body.children).to.have.length(1);
         expect(res.body).to.not.have.property('tags');
-
-        // TODO - change contains to have once second part of sequelize bug applied
-        expect(res.body).to.contains.all
-        .keys(['name', 'id', 'samples', 'children', 'apiLinks']);
+        expect(res.body).to.have.all
+          .keys(['name', 'id', 'samples', 'children', 'apiLinks']);
 
         // canada
         expect(res.body.children[0].children).to.have.length(1);

--- a/tests/api/v1/tokens/associations.js
+++ b/tests/api/v1/tokens/associations.js
@@ -99,9 +99,8 @@ describe(`tests/api/v1/tokens/associations.js, GET ${path} >`, () => {
     .expect(constants.httpStatus.OK)
     .expect((res) => {
       expect(res.body).to.be.an('object');
-
-      // TODO - change contains to have once second part of sequelize bug applied
-      expect(res.body).to.contains.keys('id', 'name', 'user', 'isRevoked', 'apiLinks');
+      expect(res.body).to.have
+        .keys('id', 'name', 'user', 'isRevoked', 'apiLinks');
       expect(Joi.validate(res.body.user, joiSchema.user).error).to.be.null;
     })
     .end(done);

--- a/tests/api/v1/users/associations.js
+++ b/tests/api/v1/users/associations.js
@@ -12,7 +12,8 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js').testAssociations;
+const testAssociations = require('../common/testAssociations.js')
+  .testAssociations;
 const path = '/v1/users';
 const Joi = require('joi');
 

--- a/tests/api/v1/users/associations.js
+++ b/tests/api/v1/users/associations.js
@@ -12,8 +12,7 @@
 'use strict';
 const tu = require('../../../testUtils');
 const u = require('./utils');
-const testAssociations = require('../common/testAssociations.js')
-  .testAssociations;
+const testAssociations = require('../common/testAssociations.js').testAssociations;
 const path = '/v1/users';
 const Joi = require('joi');
 

--- a/tests/enableCache/perspectives.js
+++ b/tests/enableCache/perspectives.js
@@ -126,9 +126,7 @@ describe(`tests/enableCache/perspectives.js, api: GET ${path} >`, () => {
       }
 
       expect(res.body).to.have.length(ONE);
-
-      // TODO - remove comment once second part of sequelize bug applied
-      // expect(res.body[ZERO].lensId).to.not.exist;
+      expect(res.body[ZERO].lensId).to.not.exist;
       expect(res.body[ZERO].name).to.be.equal('___testPersp');
       expect(res.body[ZERO].rootSubject).to.be.equal('myMainSubject');
       return done();


### PR DESCRIPTION
The idea of this solution is adding the FK just when is really needed: user requires associations **and** the number of associations is more than 1.

* id, name doesn't need the extra FK;
* id, name, user doesn't need the extra FK;
*  id, name, currentCollector doesn't need the extra FK;
* id, name, user, currentCollector needs extra FK (createdBy & collectorId) otherwise the FKs won't be exposed in the inner query.

When limiting the case of manual FK the side effect is avoided for the other use cases since the multiple associations is a corner case.
