### PR TITLE
Fix createSampHsetCommand logic

### DIFF
--- a/tests/cache/models/samples/createSampHsetCommand.js
+++ b/tests/cache/models/samples/createSampHsetCommand.js
@@ -1,0 +1,334 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/cache/models/samples/createSampHsetCommand.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const model = require('../../../../cache/models/samples');
+const createSampHsetCommand = model.createSampHsetCommand;
+
+describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
+  let clock;
+
+  before(() => {
+    clock = sinon.useFakeTimers(new Date('2018-10-29T20:24:37.053Z').getTime());
+  });
+
+  it('no sampObj', () => {
+    const qb = {
+      name: '___Subject|___ThreeHours',
+      value: 2,
+      subjectId: '323ef102-3b64-458d-b134-29d2cd840bb2',
+      aspectId: '1979b734-bece-446e-9cb1-03917f60788e',
+    };
+    const samp = null;
+    const asp = {
+      id: '1979b734-bece-446e-9cb1-03917f60788e',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      isPublished: 'true',
+      name: '___ThreeHours',
+      timeout: '3H',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 0 ],
+      warningRange: [ 1, 1 ],
+      infoRange: [ 2, 2 ],
+      okRange: [ 3, 3 ],
+      updatedAt: '2018-10-29T20:24:37.044Z',
+      createdAt: '2018-10-29T20:24:37.044Z',
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___Subject|___ThreeHours',
+      value: 2,
+      subjectId: '323ef102-3b64-458d-b134-29d2cd840bb2',
+      aspectId: '1979b734-bece-446e-9cb1-03917f60788e',
+      previousStatus: 'Invalid',
+      statusChangedAt: '2018-10-29T20:24:37.053Z',
+      status: 'Invalid',
+      relatedLinks: '[]',
+      createdAt: '2018-10-29T20:24:37.053Z',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+
+  it('has value, new status', () => {
+    const qb = {
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '100',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+    };
+    const samp = {
+      status: 'Critical',
+      value: '1',
+      previousStatus: 'Invalid',
+      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      createdAt: '2018-10-29T22:42:30.938Z',
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: '[]',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
+      updatedAt: '2018-10-29T22:42:30.938Z',
+    }
+    const asp = {
+      id: '50513365-f24f-455c-8d47-c507d1c62a96',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      description: 'this is a0 description',
+      imageUrl: 'http://www.bar.com/a0.jpg',
+      isPublished: 'true',
+      name: '___TEST_ASPECT',
+      timeout: '30s',
+      valueLabel: 's',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 1 ],
+      warningRange: [ 2, 3 ],
+      infoRange: [ 4, 5 ],
+      okRange: [ 6, 7 ],
+      updatedAt: '2018-10-29T22:42:30.918Z',
+      createdAt: '2018-10-29T22:42:30.918Z',
+      writers: [],
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '100',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      previousStatus: 'Critical',
+      statusChangedAt: '2018-10-29T20:24:37.053Z',
+      status: 'Invalid',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+
+  it('no value', () => {
+    const qb = {
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+    };
+    const samp = {
+      status: 'Critical',
+      value: '1',
+      previousStatus: 'Invalid',
+      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      createdAt: '2018-10-29T22:42:30.938Z',
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: '[]',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
+      updatedAt: '2018-10-29T22:42:30.938Z',
+    }
+    const asp = {
+      id: '50513365-f24f-455c-8d47-c507d1c62a96',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      description: 'this is a0 description',
+      imageUrl: 'http://www.bar.com/a0.jpg',
+      isPublished: 'true',
+      name: '___TEST_ASPECT',
+      timeout: '30s',
+      valueLabel: 's',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 1 ],
+      warningRange: [ 2, 3 ],
+      infoRange: [ 4, 5 ],
+      okRange: [ 6, 7 ],
+      updatedAt: '2018-10-29T22:42:30.918Z',
+      createdAt: '2018-10-29T22:42:30.918Z',
+      writers: [],
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      previousStatus: 'Critical',
+      statusChangedAt: '2018-10-29T20:24:37.053Z',
+      status: 'Invalid',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+
+  it('value is undefined', () => {
+    const qb = {
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: undefined,
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+    };
+    const samp = {
+      status: 'Critical',
+      value: '1',
+      previousStatus: 'Invalid',
+      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      createdAt: '2018-10-29T22:42:30.938Z',
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: '[]',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
+      updatedAt: '2018-10-29T22:42:30.938Z',
+    }
+    const asp = {
+      id: '50513365-f24f-455c-8d47-c507d1c62a96',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      description: 'this is a0 description',
+      imageUrl: 'http://www.bar.com/a0.jpg',
+      isPublished: 'true',
+      name: '___TEST_ASPECT',
+      timeout: '30s',
+      valueLabel: 's',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 1 ],
+      warningRange: [ 2, 3 ],
+      infoRange: [ 4, 5 ],
+      okRange: [ 6, 7 ],
+      updatedAt: '2018-10-29T22:42:30.918Z',
+      createdAt: '2018-10-29T22:42:30.918Z',
+      writers: [],
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      previousStatus: 'Critical',
+      statusChangedAt: '2018-10-29T20:24:37.053Z',
+      status: 'Invalid',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+
+  it('has value, same status', () => {
+    const qb = {
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '0',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+    };
+    const samp = {
+      status: 'Critical',
+      value: '1',
+      previousStatus: 'Invalid',
+      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      createdAt: '2018-10-29T22:42:30.938Z',
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: '[]',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
+      updatedAt: '2018-10-29T22:42:30.938Z',
+    }
+    const asp = {
+      id: '50513365-f24f-455c-8d47-c507d1c62a96',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      description: 'this is a0 description',
+      imageUrl: 'http://www.bar.com/a0.jpg',
+      isPublished: 'true',
+      name: '___TEST_ASPECT',
+      timeout: '30s',
+      valueLabel: 's',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 1 ],
+      warningRange: [ 2, 3 ],
+      infoRange: [ 4, 5 ],
+      okRange: [ 6, 7 ],
+      updatedAt: '2018-10-29T22:42:30.918Z',
+      createdAt: '2018-10-29T22:42:30.918Z',
+      writers: [],
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '0',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      previousStatus: 'Critical',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      status: 'Critical',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+
+  it('adds related links', () => {
+    const qb = {
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '0',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: [{ name : 'a', url: 'bcd' }],
+    };
+    const samp = {
+      status: 'Critical',
+      value: '1',
+      previousStatus: 'Invalid',
+      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      createdAt: '2018-10-29T22:42:30.938Z',
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      relatedLinks: '[]',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
+      updatedAt: '2018-10-29T22:42:30.938Z',
+    }
+    const asp = {
+      id: '50513365-f24f-455c-8d47-c507d1c62a96',
+      isDeleted: '0',
+      relatedLinks: [],
+      tags: [],
+      description: 'this is a0 description',
+      imageUrl: 'http://www.bar.com/a0.jpg',
+      isPublished: 'true',
+      name: '___TEST_ASPECT',
+      timeout: '30s',
+      valueLabel: 's',
+      valueType: 'NUMERIC',
+      criticalRange: [ 0, 1 ],
+      warningRange: [ 2, 3 ],
+      infoRange: [ 4, 5 ],
+      okRange: [ 6, 7 ],
+      updatedAt: '2018-10-29T22:42:30.918Z',
+      createdAt: '2018-10-29T22:42:30.918Z',
+      writers: [],
+    };
+    createSampHsetCommand(qb, samp, asp);
+    expect(qb).to.deep.equal({
+      name: '___TEST_SUBJECT|___TEST_ASPECT',
+      value: '0',
+      subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
+      aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
+      previousStatus: 'Critical',
+      statusChangedAt: '2018-10-29T22:42:30.938Z',
+      status: 'Critical',
+      relatedLinks: '[{\"name\":\"a\",\"url\":\"bcd\"}]',
+      updatedAt: '2018-10-29T20:24:37.053Z',
+    });
+  });
+});

--- a/tests/cache/models/samples/createSampHsetCommand.js
+++ b/tests/cache/models/samples/createSampHsetCommand.js
@@ -39,10 +39,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       name: '___ThreeHours',
       timeout: '3H',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 0 ],
-      warningRange: [ 1, 1 ],
-      infoRange: [ 2, 2 ],
-      okRange: [ 3, 3 ],
+      criticalRange: [0, 0],
+      warningRange: [1, 1],
+      infoRange: [2, 2],
+      okRange: [3, 3],
       updatedAt: '2018-10-29T20:24:37.044Z',
       createdAt: '2018-10-29T20:24:37.044Z',
     };
@@ -72,7 +72,9 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       status: 'Critical',
       value: '1',
       previousStatus: 'Invalid',
-      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      user: '{"name":"___testUser@refocus.com",' +
+        '"email":"___testUser@refocus.com",' +
+        '"profile":{"name":"___testProfile"}}',
       createdAt: '2018-10-29T22:42:30.938Z',
       name: '___TEST_SUBJECT|___TEST_ASPECT',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
@@ -81,7 +83,7 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       statusChangedAt: '2018-10-29T22:42:30.938Z',
       provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
       updatedAt: '2018-10-29T22:42:30.938Z',
-    }
+    };
     const asp = {
       id: '50513365-f24f-455c-8d47-c507d1c62a96',
       isDeleted: '0',
@@ -94,10 +96,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       timeout: '30s',
       valueLabel: 's',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 1 ],
-      warningRange: [ 2, 3 ],
-      infoRange: [ 4, 5 ],
-      okRange: [ 6, 7 ],
+      criticalRange: [0, 1],
+      warningRange: [2, 3],
+      infoRange: [4, 5],
+      okRange: [6, 7],
       updatedAt: '2018-10-29T22:42:30.918Z',
       createdAt: '2018-10-29T22:42:30.918Z',
       writers: [],
@@ -125,7 +127,9 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       status: 'Critical',
       value: '1',
       previousStatus: 'Invalid',
-      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      user: '{"name":"___testUser@refocus.com",' +
+        '"email":"___testUser@refocus.com",' +
+        '"profile":{"name":"___testProfile"}}',
       createdAt: '2018-10-29T22:42:30.938Z',
       name: '___TEST_SUBJECT|___TEST_ASPECT',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
@@ -134,7 +138,7 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       statusChangedAt: '2018-10-29T22:42:30.938Z',
       provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
       updatedAt: '2018-10-29T22:42:30.938Z',
-    }
+    };
     const asp = {
       id: '50513365-f24f-455c-8d47-c507d1c62a96',
       isDeleted: '0',
@@ -147,10 +151,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       timeout: '30s',
       valueLabel: 's',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 1 ],
-      warningRange: [ 2, 3 ],
-      infoRange: [ 4, 5 ],
-      okRange: [ 6, 7 ],
+      criticalRange: [0, 1],
+      warningRange: [2, 3],
+      infoRange: [4, 5],
+      okRange: [6, 7],
       updatedAt: '2018-10-29T22:42:30.918Z',
       createdAt: '2018-10-29T22:42:30.918Z',
       writers: [],
@@ -179,7 +183,9 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       status: 'Critical',
       value: '1',
       previousStatus: 'Invalid',
-      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      user: '{"name":"___testUser@refocus.com",' +
+        '"email":"___testUser@refocus.com",' +
+        '"profile":{"name":"___testProfile"}}',
       createdAt: '2018-10-29T22:42:30.938Z',
       name: '___TEST_SUBJECT|___TEST_ASPECT',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
@@ -188,7 +194,7 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       statusChangedAt: '2018-10-29T22:42:30.938Z',
       provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
       updatedAt: '2018-10-29T22:42:30.938Z',
-    }
+    };
     const asp = {
       id: '50513365-f24f-455c-8d47-c507d1c62a96',
       isDeleted: '0',
@@ -201,10 +207,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       timeout: '30s',
       valueLabel: 's',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 1 ],
-      warningRange: [ 2, 3 ],
-      infoRange: [ 4, 5 ],
-      okRange: [ 6, 7 ],
+      criticalRange: [0, 1],
+      warningRange: [2, 3],
+      infoRange: [4, 5],
+      okRange: [6, 7],
       updatedAt: '2018-10-29T22:42:30.918Z',
       createdAt: '2018-10-29T22:42:30.918Z',
       writers: [],
@@ -233,7 +239,9 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       status: 'Critical',
       value: '1',
       previousStatus: 'Invalid',
-      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      user: '{"name":"___testUser@refocus.com",' +
+        '"email":"___testUser@refocus.com",' +
+        '"profile":{"name":"___testProfile"}}',
       createdAt: '2018-10-29T22:42:30.938Z',
       name: '___TEST_SUBJECT|___TEST_ASPECT',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
@@ -242,7 +250,7 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       statusChangedAt: '2018-10-29T22:42:30.938Z',
       provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
       updatedAt: '2018-10-29T22:42:30.938Z',
-    }
+    };
     const asp = {
       id: '50513365-f24f-455c-8d47-c507d1c62a96',
       isDeleted: '0',
@@ -255,10 +263,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       timeout: '30s',
       valueLabel: 's',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 1 ],
-      warningRange: [ 2, 3 ],
-      infoRange: [ 4, 5 ],
-      okRange: [ 6, 7 ],
+      criticalRange: [0, 1],
+      warningRange: [2, 3],
+      infoRange: [4, 5],
+      okRange: [6, 7],
       updatedAt: '2018-10-29T22:42:30.918Z',
       createdAt: '2018-10-29T22:42:30.918Z',
       writers: [],
@@ -282,13 +290,15 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       value: '0',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
       aspectId: '50513365-f24f-455c-8d47-c507d1c62a96',
-      relatedLinks: [{ name : 'a', url: 'bcd' }],
+      relatedLinks: [{ name: 'a', url: 'bcd' }],
     };
     const samp = {
       status: 'Critical',
       value: '1',
       previousStatus: 'Invalid',
-      user: '{"name":"___testUser@refocus.com","email":"___testUser@refocus.com","profile":{"name":"___testProfile"}}',
+      user: '{"name":"___testUser@refocus.com",' +
+        '"email":"___testUser@refocus.com",' +
+        '"profile":{"name":"___testProfile"}}',
       createdAt: '2018-10-29T22:42:30.938Z',
       name: '___TEST_SUBJECT|___TEST_ASPECT',
       subjectId: 'd2dfc000-5498-4bf0-a8c4-9c42c4569f05',
@@ -297,7 +307,7 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       statusChangedAt: '2018-10-29T22:42:30.938Z',
       provider: '84f3560b-1b68-4868-bea3-8dd0ad8aa8f3',
       updatedAt: '2018-10-29T22:42:30.938Z',
-    }
+    };
     const asp = {
       id: '50513365-f24f-455c-8d47-c507d1c62a96',
       isDeleted: '0',
@@ -310,10 +320,10 @@ describe('tests/cache/models/samples/createSampHsetCommand.js >', () => {
       timeout: '30s',
       valueLabel: 's',
       valueType: 'NUMERIC',
-      criticalRange: [ 0, 1 ],
-      warningRange: [ 2, 3 ],
-      infoRange: [ 4, 5 ],
-      okRange: [ 6, 7 ],
+      criticalRange: [0, 1],
+      warningRange: [2, 3],
+      infoRange: [4, 5],
+      okRange: [6, 7],
       updatedAt: '2018-10-29T22:42:30.918Z',
       createdAt: '2018-10-29T22:42:30.918Z',
       writers: [],

--- a/tests/cache/models/utils.js
+++ b/tests/cache/models/utils.js
@@ -103,4 +103,27 @@ describe('tests/cache/models/utils.js >', () => {
       expect(result[2].name.endsWith(1)).to.be.true;
     });
   });
+
+  describe('cleanQueryBodyObj >', () => {
+    it('obj has some fields in arr', () => {
+      const obj = { a: 'a', b: 'b', c: 'c' };
+      const fieldArr = ['a', 'b', 'd', 'e'];
+      utils.cleanQueryBodyObj(obj, fieldArr);
+      expect(obj).to.deep.equal({ a: 'a', b: 'b' });
+    });
+
+    it('obj has no fields in arr', () => {
+      const obj = { a: 'a', b: 'b', c: 'c' };
+      const fieldArr = ['d', 'e'];
+      utils.cleanQueryBodyObj(obj, fieldArr);
+      expect(obj).to.deep.equal({ });
+    });
+
+    it('obj has all fields in arr', () => {
+      const obj = { a: 'a', b: 'b', c: 'c' };
+      const fieldArr = ['a', 'b', 'c'];
+      utils.cleanQueryBodyObj(obj, fieldArr);
+      expect(obj).to.deep.equal({ a: 'a', b: 'b', c: 'c' });
+    });
+  });
 });

--- a/worker/jobs/bulkUpsertSamples.js
+++ b/worker/jobs/bulkUpsertSamples.js
@@ -56,6 +56,12 @@ module.exports = (job, done) => {
           return Promise.resolve();
         }
 
+        if (!result.hasOwnProperty('name')) {
+          errors.push('Sample record in Redis missing "name" attribute. ' +
+            'Contact your Refocus administrator.');
+          return Promise.resolve();
+        }
+
         successCount++;
         if (featureToggles.isFeatureEnabled('publishSampleInPromiseChain')) {
           // Wait for publish to complete before resolving the promise.

--- a/worker/jobs/bulkUpsertSamples.js
+++ b/worker/jobs/bulkUpsertSamples.js
@@ -56,11 +56,11 @@ module.exports = (job, done) => {
           return Promise.resolve();
         }
 
-        if (!result.hasOwnProperty('name')) {
-          errors.push('Sample record in Redis missing "name" attribute. ' +
-            'Contact your Refocus administrator.');
-          return Promise.resolve();
-        }
+        // if (!result.hasOwnProperty('name')) {
+        //   errors.push('Sample record in Redis missing "name" attribute. ' +
+        //     'Contact your Refocus administrator.');
+        //   return Promise.resolve();
+        // }
 
         successCount++;
         if (featureToggles.isFeatureEnabled('publishSampleInPromiseChain')) {


### PR DESCRIPTION
- Always include expected fields like status, previous status, status changed at. This resolves the issue where we were calling hmset for a sample with an object which did not have a "previousStatus" attribute.

Also:
- if bulkUpsertByName returns an object without a name, treat it as an upsert error instead of proceeding to the "publish" phase.

Also:
- add tests for createSampHsetCommand fn
- add tests for cleanQueryBodyObj fn (which is called by createSampHsetCommand)