### PR TITLE
add travis_retry for npm scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,15 +41,15 @@ services:
   - redis-server
 
 script:
-  - npm run jscs-enforce
-  - npm run checkdb
-  - npm run test-travis
+  - travis_retry npm run jscs-enforce
+  - travis_retry npm run checkdb
+  - travis_retry npm run test-travis
 
 before_install:
-  - npm install -g npm@^5.7.0
+  - travis_retry npm install -g npm@^5.7.0
 
 install:
-  - npm ci
+  - travis_retry npm ci
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ services:
   - redis-server
 
 script:
-  - travis_retry npm run jscs-enforce
-  - travis_retry npm run checkdb
+  - npm run jscs-enforce
+  - npm run checkdb
   - travis_retry npm run test-travis
 
 before_install:


### PR DESCRIPTION
This may be the "band-aid" approach for dealing with flappers in travis - [travis_retry](https://docs.travis-ci.com/user/common-build-problems/#travis_retry) will retry the command up to three times if the return code is non-zero.