### PR TITLE
Generator template API

### DIFF
--- a/api/v1/controllers/generatorTemplates.js
+++ b/api/v1/controllers/generatorTemplates.js
@@ -50,6 +50,20 @@ module.exports = {
   },
 
   /**
+   * GET /generatorTemplates/{name}/{version}
+   *
+   * Retrieves the generatorTemplate by name and version and sends it back
+   * in the response.
+   *
+   * @param {IncomingMessage} req - The request object
+   * @param {ServerResponse} res - The response object
+   * @param {Function} next - The next middleware function in the stack
+   */
+  getGeneratorTemplateByNameAndVersion(req, res, next) {
+    doFind(req, res, next, helper);
+  },
+
+  /**
    * PATCH /generatorTemplates/{key}
    *
    * Modifies the generatorTemplate and sends it back in the response.

--- a/api/v1/controllers/generatorTemplates.js
+++ b/api/v1/controllers/generatorTemplates.js
@@ -14,6 +14,7 @@
 const helper = require('../helpers/nouns/generatorTemplates');
 const doDeleteOneAssoc = require('../helpers/verbs/doDeleteOneBToMAssoc');
 const doFind = require('../helpers/verbs/doFind');
+const doFindOne = require('../helpers/verbs/doFindOne');
 const doGet = require('../helpers/verbs/doGet');
 const doPatch = require('../helpers/verbs/doPatch');
 const doPost = require('../helpers/verbs/doPost');
@@ -60,7 +61,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   getGeneratorTemplateByNameAndVersion(req, res, next) {
-    doFind(req, res, next, helper);
+    doFindOne(req, res, next, helper);
   },
 
   /**

--- a/api/v1/controllers/samples.js
+++ b/api/v1/controllers/samples.js
@@ -366,9 +366,7 @@ module.exports = {
         const dataValues = samp.dataValues ? samp.dataValues : samp;
 
         // loop through remove values to delete property
-        if (helper.fieldsToExclude) {
-          u.removeFieldsFromResponse(helper.fieldsToExclude, dataValues);
-        }
+        u.removeFieldsFromResponse(helper.fieldsToExclude, dataValues);
 
         /*
          * Send the upserted sample to the client by publishing it to the redis
@@ -485,9 +483,7 @@ module.exports = {
       const retval = u.responsify(o, helper, req.method);
 
       // loop through remove values to delete property
-      if (helper.fieldsToExclude) {
-        u.removeFieldsFromResponse(helper.fieldsToExclude, retval);
-      }
+      u.removeFieldsFromResponse(helper.fieldsToExclude, retval);
 
       /* send the updated sample to the client by publishing it to the redis
       channel */

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -36,5 +36,7 @@ module.exports = {
   fieldScopeMap: {
     user: 'user',
   },
+  uniqueFieldWithoutLimit: 'name',
+
 }; // exports
 

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -36,7 +36,8 @@ module.exports = {
   fieldScopeMap: {
     user: 'user',
   },
-  uniqueFieldWithoutLimit: 'name',
+
+  nameFinderWithoutLimit: true,
 
 }; // exports
 

--- a/api/v1/helpers/verbs/doFind.js
+++ b/api/v1/helpers/verbs/doFind.js
@@ -15,7 +15,6 @@ const fu = require('./findUtils');
 const COUNT_HEADER_NAME = require('../../constants').COUNT_HEADER_NAME;
 const httpStatus = require('../../constants').httpStatus;
 const redisCache = require('../../../../cache/redisCache').client.cache;
-const config = require('../../../../config');
 
 /**
  * Finds all matching records but only returns a subset of the results for
@@ -33,19 +32,20 @@ const config = require('../../../../config');
  *  find command
  */
 function doFindAndCountAll(reqResNext, props, opts, resultObj) {
-  return u.getScopedModel(props, opts.attributes).findAndCountAll(opts)
-  .then((o) => {
-    resultObj.dbTime = new Date() - resultObj.reqStartTime;
-    reqResNext.res.set(COUNT_HEADER_NAME, o.count);
-    return o.rows.map((row) => {
-      if (props.modelName === 'Lens') {
-        delete row.dataValues.library;
-      }
+  return u.getScopedModel(props, opts.attributes)
+    .findAndCountAll(opts)
+    .then((o) => {
+      resultObj.dbTime = new Date() - resultObj.reqStartTime;
+      reqResNext.res.set(COUNT_HEADER_NAME, o.count);
+      return o.rows.map((row) => {
+        if (props.modelName === 'Lens') {
+          delete row.dataValues.library;
+        }
 
-      return u.responsify(row, props, reqResNext.req.method);
-    });
-  })
-  .catch((err) => u.handleError(reqResNext.next, err, props.modelName));
+        return u.responsify(row, props, reqResNext.req.method);
+      });
+    })
+    .catch((err) => u.handleError(reqResNext.next, err, props.modelName));
 } // doFindAndCountAll
 
 /**
@@ -68,26 +68,26 @@ function doFindResponse(reqResNext, props, opts, resultObj) {
   }
 
   return doFindAndCountAll(reqResNext, props, opts, resultObj)
-  .then((retval) => {
-    u.sortArrayObjectsByField(props, retval);
+    .then((retVal) => {
+      u.sortArrayObjectsByField(props, retVal);
 
-    // loop through remove values to delete property
-    if (props.fieldsToExclude) {
-      for (let i = retval.length - 1; i >= 0; i--) {
-        u.removeFieldsFromResponse(props.fieldsToExclude, retval[i]);
+      // loop through remove values to delete property
+      if (props.fieldsToExclude) {
+        for (let i = retVal.length - 1; i >= 0; i--) {
+          u.removeFieldsFromResponse(props.fieldsToExclude, retVal[i]);
+        }
       }
-    }
 
-    if (props.cacheKey) {
-      // cache the object by cacheKey.
-      const strObj = JSON.stringify(retval);
-      redisCache.setex(props.cacheKey, props.cacheExpiry, strObj);
-    }
+      if (props.cacheKey) {
+        // cache the object by cacheKey.
+        const strObj = JSON.stringify(retVal);
+        redisCache.setex(props.cacheKey, props.cacheExpiry, strObj);
+      }
 
-    u.logAPI(reqResNext.req, resultObj, retval);
-    reqResNext.res.status(httpStatus.OK).json(retval);
-  })
-  .catch((err) => u.handleError(reqResNext.next, err, props.modelName));
+      u.logAPI(reqResNext.req, resultObj, retVal);
+      reqResNext.res.status(httpStatus.OK).json(retVal);
+    })
+    .catch((err) => u.handleError(reqResNext.next, err, props.modelName));
 }
 
 /**
@@ -109,13 +109,13 @@ module.exports = function doFind(req, res, next, props) {
       if (cacheErr || !reply) {
         // if err or no reply, get resuls from db and set redis cache
         return doFindResponse({ req, res, next }, props, opts, resultObj);
-      } else {
-        // get from cache
-        const dbObj = JSON.parse(reply);
-        resultObj.dbTime = new Date() - resultObj.reqStartTime;
-        u.logAPI(req, resultObj, dbObj);
-        res.status(httpStatus.OK).json(dbObj);
       }
+
+      // get from cache
+      const dbObj = JSON.parse(reply);
+      resultObj.dbTime = new Date() - resultObj.reqStartTime;
+      u.logAPI(req, resultObj, dbObj);
+      res.status(httpStatus.OK).json(dbObj);
     });
   } else {
     return doFindResponse({ req, res, next }, props, opts, resultObj);

--- a/api/v1/helpers/verbs/doFindOne.js
+++ b/api/v1/helpers/verbs/doFindOne.js
@@ -12,8 +12,8 @@
 'use strict'; // eslint-disable-line strict
 const verbUtils = require('./utils');
 const findUtils = require('./findUtils');
-const httpStatus = require('../../constants').httpStatus;
 const apiErrors = require('../../apiErrors');
+const OK = require('../../constants').httpStatus.OK;
 
 function doFindOne_(reqResNextWrapper, props, opts, dbTimeObject) {
   return props.model
@@ -54,7 +54,7 @@ function handleResponse(props, responseObject, reqResNextWrapper,
   verbUtils.logAPI(reqResNextWrapper.req, dbTimeObject, responseObject, null);
   reqResNextWrapper
     .res
-    .status(httpStatus.OK)
+    .status(OK)
     .json(responseObject);
 } // handleResponse
 

--- a/api/v1/helpers/verbs/doFindOne.js
+++ b/api/v1/helpers/verbs/doFindOne.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * api/v1/helpers/verbs/doFind.js
+ * api/v1/helpers/verbs/doFindOne.js
  */
 'use strict'; // eslint-disable-line strict
 const verbUtils = require('./utils');

--- a/api/v1/helpers/verbs/doFindOne.js
+++ b/api/v1/helpers/verbs/doFindOne.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * api/v1/helpers/verbs/doFind.js
+ */
+'use strict'; // eslint-disable-line strict
+const u = require('./utils');
+const fu = require('./findUtils');
+const httpStatus = require('../../constants').httpStatus;
+const redisCache = require('../../../../cache/redisCache').client.cache;
+const apiErrors = require('../../apiErrors');
+
+function doFindOne_(reqResNextWrapper, props, opts, dbTimeObject) {
+  return props.model
+    .findOne(opts)
+    .then((object) => {
+      dbTimeObject.dbTime = new Date() - dbTimeObject.reqStartTime;
+      if (!object) {
+        throw new apiErrors.ResourceNotFoundError({
+          explanation: `${props.model} not found`,
+        });
+      }
+
+      if (props.modelName === 'Lens') {
+        delete object.dataValues.library;
+      }
+
+      return u.responsify(object, props, reqResNextWrapper.req.method);
+    })
+    .catch((err) => u.handleError(reqResNextWrapper.next, err,
+      props.modelName));
+} // doFind
+
+function handleResponse(props, responseObject, reqResNextWrapper,
+                        dbTimeObject) {
+  u.sortArrayObjectsByField(props, responseObject);
+
+  if (props.fieldsToExclude) {
+    u.removeFieldsFromResponse(props.fieldsToExclude, responseObject);
+  }
+
+  u.logAPI(reqResNextWrapper.req, dbTimeObject, responseObject, null);
+  reqResNextWrapper
+    .res.status(httpStatus.OK).json(responseObject);
+}
+
+function handleResponseWithCache(props, responseObject, reqResNextWrapper,
+                                 resultObj) {
+  // cache the object by cacheKey.
+  if (props.cacheKey) {
+    redisCache.setex(
+      props.cacheKey,
+      props.cacheExpiry,
+      JSON.stringify(responseObject));
+  }
+
+  handleResponse(props, responseObject, reqResNextWrapper, resultObj);
+}
+
+/**
+ * Finds a single matching record. Get result from cache if present, else, get
+ * results from db and store in cache, if caching is enabled.
+ *
+ * @param {IncomingMessage} req - The request object
+ * @param {ServerResponse} res - The response object
+ * @param {Function} next - The next middleware function in the stack
+ * @param {Object} props - The helpers/nouns module for the given DB model
+ */
+module.exports = function doFindOne(req, res, next, props) {
+  const dbTimeObject = { reqStartTime: req.timestamp };
+
+  const opts = fu.options(req.swagger.params, props);
+  const reqResNextWrapper = { req, res, next };
+
+  if (props.cacheEnabled) {
+    redisCache.get(props.cacheKey, (cacheErr, reply) => {
+      if (cacheErr || !reply) {
+        // No cache, get results from db and set cache
+        return doFindOne_(reqResNextWrapper, props, opts, dbTimeObject)
+          .then((responseObject) => handleResponseWithCache(props,
+            responseObject, reqResNextWrapper, dbTimeObject))
+          .catch((err) => u.handleError(next, err, props.modelName));
+      }
+
+      // From cache
+      dbTimeObject.dbTime = new Date() - dbTimeObject.reqStartTime;
+      const responseObject = JSON.parse(reply);
+      u.logAPI(req, dbTimeObject, responseObject, null);
+
+      res.status(httpStatus.OK)
+        .json(responseObject);
+    });
+  } else {
+    return doFindOne_(reqResNextWrapper, props, opts, dbTimeObject)
+      .then((responseObject) => handleResponse(props, responseObject,
+        reqResNextWrapper, dbTimeObject))
+      .catch((err) => u.handleError(next, err, props.modelName));
+  }
+}; // exports

--- a/api/v1/helpers/verbs/doFindOne.js
+++ b/api/v1/helpers/verbs/doFindOne.js
@@ -10,10 +10,9 @@
  * api/v1/helpers/verbs/doFind.js
  */
 'use strict'; // eslint-disable-line strict
-const u = require('./utils');
-const fu = require('./findUtils');
+const verbUtils = require('./utils');
+const findUtils = require('./findUtils');
 const httpStatus = require('../../constants').httpStatus;
-const redisCache = require('../../../../cache/redisCache').client.cache;
 const apiErrors = require('../../apiErrors');
 
 function doFindOne_(reqResNextWrapper, props, opts, dbTimeObject) {
@@ -31,41 +30,36 @@ function doFindOne_(reqResNextWrapper, props, opts, dbTimeObject) {
         delete object.dataValues.library;
       }
 
-      return u.responsify(object, props, reqResNextWrapper.req.method);
+      return verbUtils.responsify(object, props, reqResNextWrapper.req.method);
     })
-    .catch((err) => u.handleError(reqResNextWrapper.next, err,
+    .catch((err) => verbUtils.handleError(reqResNextWrapper.next, err,
       props.modelName));
-} // doFind
-
-function handleResponse(props, responseObject, reqResNextWrapper,
-                        dbTimeObject) {
-  u.sortArrayObjectsByField(props, responseObject);
-
-  if (props.fieldsToExclude) {
-    u.removeFieldsFromResponse(props.fieldsToExclude, responseObject);
-  }
-
-  u.logAPI(reqResNextWrapper.req, dbTimeObject, responseObject, null);
-  reqResNextWrapper
-    .res.status(httpStatus.OK).json(responseObject);
-}
-
-function handleResponseWithCache(props, responseObject, reqResNextWrapper,
-                                 resultObj) {
-  // cache the object by cacheKey.
-  if (props.cacheKey) {
-    redisCache.setex(
-      props.cacheKey,
-      props.cacheExpiry,
-      JSON.stringify(responseObject));
-  }
-
-  handleResponse(props, responseObject, reqResNextWrapper, resultObj);
-}
+} // doFindOne_
 
 /**
- * Finds a single matching record. Get result from cache if present, else, get
- * results from db and store in cache, if caching is enabled.
+ * Convenient method to sort response by field, remove fields and Log API time
+ * before sending back the response object to the client.
+ *
+ * @param props
+ * @param responseObject
+ * @param reqResNextWrapper
+ * @param dbTimeObject
+ */
+function handleResponse(props, responseObject, reqResNextWrapper,
+                        dbTimeObject) {
+  verbUtils.sortArrayObjectsByField(props, responseObject);
+
+  verbUtils.removeFieldsFromResponse(props.fieldsToExclude, responseObject);
+
+  verbUtils.logAPI(reqResNextWrapper.req, dbTimeObject, responseObject, null);
+  reqResNextWrapper
+    .res
+    .status(httpStatus.OK)
+    .json(responseObject);
+} // handleResponse
+
+/**
+ * Helper method to find a single matching record.
  *
  * @param {IncomingMessage} req - The request object
  * @param {ServerResponse} res - The response object
@@ -73,33 +67,12 @@ function handleResponseWithCache(props, responseObject, reqResNextWrapper,
  * @param {Object} props - The helpers/nouns module for the given DB model
  */
 module.exports = function doFindOne(req, res, next, props) {
-  const dbTimeObject = { reqStartTime: req.timestamp };
+  const opts = findUtils.options(req.swagger.params, props);
 
-  const opts = fu.options(req.swagger.params, props);
   const reqResNextWrapper = { req, res, next };
-
-  if (props.cacheEnabled) {
-    redisCache.get(props.cacheKey, (cacheErr, reply) => {
-      if (cacheErr || !reply) {
-        // No cache, get results from db and set cache
-        return doFindOne_(reqResNextWrapper, props, opts, dbTimeObject)
-          .then((responseObject) => handleResponseWithCache(props,
-            responseObject, reqResNextWrapper, dbTimeObject))
-          .catch((err) => u.handleError(next, err, props.modelName));
-      }
-
-      // From cache
-      dbTimeObject.dbTime = new Date() - dbTimeObject.reqStartTime;
-      const responseObject = JSON.parse(reply);
-      u.logAPI(req, dbTimeObject, responseObject, null);
-
-      res.status(httpStatus.OK)
-        .json(responseObject);
-    });
-  } else {
-    return doFindOne_(reqResNextWrapper, props, opts, dbTimeObject)
-      .then((responseObject) => handleResponse(props, responseObject,
-        reqResNextWrapper, dbTimeObject))
-      .catch((err) => u.handleError(next, err, props.modelName));
-  }
+  const dbTimeObject = { reqStartTime: req.timestamp };
+  return doFindOne_(reqResNextWrapper, props, opts, dbTimeObject)
+    .then((responseObject) => handleResponse(props, responseObject,
+      reqResNextWrapper, dbTimeObject))
+    .catch((err) => verbUtils.handleError(next, err, props.modelName));
 }; // exports

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -254,47 +254,57 @@ function toSequelizeOrder(sortOrder) {
 } // toSequelizeOrder
 
 /**
- * Check for unique field in opts. If unique field is present, there are
- * following cases:
- * 1) Limit unchanged if unique field is present and doesn't requires limit.
- *    doesn't requires limit: It's not specified into the noun,
- *    uniqueFieldWithoutLimit attribute.
- * 2) Unique field have single value and requires limit - set limit to 1
- *    Eg: opts = { where: { [Op.iLike]: { uniqField: 'someValue' } } };
- * 3) Unique field can have multiple values (Op.or) and requires limit - set
- *    limit to the number of values
- *  Eg: opts = {
- *       where: {
- *        uniqField: {
- *         [Op.or]: [{ [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' }]
- *        },
- *       },
- *      };
- * 4) Unique field requires limit but have single wildcard value - limit
- *    unchanged.
- *    Eg: opts = { where: { [Op.iLike]: { uniqField: '%someValue%' } } };
- * 5) Unique field requires limit and have multiple values one of which is
- *    wildcard value - limit unchanged
+ * Check for unique field in opts.
+ *
+ * Unique field is 'name' by default and can be overwrite via
+ * adding attribute nameFinder into the respective noun. see /noun/subject.
+ *
+ * If unique field is present and the noun does require SQL limit, there are
+ * the following cases:
+ *
+ * 1) Unique field has single value without wildcard: set limit to 1.
+ *    Eg: opts = { where: { [Op.iLike]: { UniqueFieldName: 'someValue' } } };
+ *    Limit: 1
+ *
+ * 2) Unique field can have multiple values - set limit to the number of values
  *    Eg: opts = {
- *         where: {
- *           uniqField: {
- *             [Op.or]:[{ [Op.iLike]: 'someName1' },{[Op.iLike]: '%someName%'}],
- *           },
- *         },
- *        };
+ *      where:
+ *      {
+ *        UniqueFieldName: {
+ *          [Op.or]: [
+ *            { [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' },
+ *          ],
+ *        },
+ *      }
+ *    };
+ *    limit = 2.
+ *
+ * 3) Unique field has single value with wildcard: limit unchanged.
+ *    Eg: opts = { where: { [Op.iLike]: { UniqueFieldName: '%someValue%' } } };
+ *
+ * 4) Unique field has multiple values of which has wildcard: limit unchanged
+ *    Eg: opts = {
+ *        where: {
+ *          UniqueFieldName: {
+ *            [Op.or]: [
+ *              { [Op.iLike]: 'someName1' }, { [Op.iLike]: '%someName%' },
+ *            ] },
+ *        }
+ *      };
+ *
  * It is assumed that each field value will have $iLike operator applied.
  * @param  {Object} opts - Query options object
  * @param  {Object} props - The helpers/nouns module for the given DB model
  */
 function applyLimitIfUniqueField(opts, props) {
+  /*
+   * Attribute nameFinderWithoutLimit is a temp workaround until we define
+   * the best way to NOT change/restrict limit when unique field is the default
+   * (name) for some nouns.
+   */
+  if (props.nameFinderWithoutLimit) return;
+
   const uniqueFieldName = props.nameFinder || 'name';
-
-  const uniqueFieldWithoutLimit = props.uniqueFieldWithoutLimit &&
-    opts.where[props.uniqueFieldWithoutLimit];
-  if (uniqueFieldWithoutLimit) {
-    return;
-  }
-
   if (opts.where && opts.where[uniqueFieldName]) {
     const optsWhereOR = opts.where[uniqueFieldName][Op.or];
     if (optsWhereOR && Array.isArray(optsWhereOR)) { // multiple values
@@ -320,7 +330,7 @@ function applyLimitIfUniqueField(opts, props) {
 }
 
 /**
- * Builds the "options" object to pass intto the Sequelize find command.
+ * Builds the "options" object to pass into the Sequelize find command.
  *
  * @param {Object} params - The request params
  * @param {Object} props - The helpers/nouns module for the given DB model
@@ -362,14 +372,12 @@ function options(params, props) {
     }
   }
 
-  if (filter) {
-    opts.where = toSequelizeWhere(filter, props);
-    if (props.modifyWhereClause) {
-      props.modifyWhereClause(params, opts);
-    }
-
-    applyLimitIfUniqueField(opts, props);
+  opts.where = toSequelizeWhere(filter, props);
+  if (props.modifyWhereClause) {
+    props.modifyWhereClause(params, opts);
   }
+
+  applyLimitIfUniqueField(opts, props);
 
   return opts;
 } // options

--- a/api/v1/helpers/verbs/index.js
+++ b/api/v1/helpers/verbs/index.js
@@ -15,6 +15,7 @@
 
 const doDelete = require('./doDelete');
 const doFind = require('./doFind');
+const doFindOne = require('./doFindOne');
 const doGet = require('./doGet');
 const doPatch = require('./doPatch');
 const doPost = require('./doPost');
@@ -23,6 +24,7 @@ const doPut = require('./doPut');
 module.exports = {
   doDelete,
   doFind,
+  doFindOne,
   doGet,
   doPatch,
   doPost,

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -122,8 +122,10 @@ function handleUpdatePromise(resultObj, req, retVal, props, res) {
  * @param {Object} The input object without the keys in fieldsArr
  */
 function removeFieldsFromResponse(fieldsToExclude, responseObj) {
-  for (let i = fieldsToExclude.length - 1; i >= 0; i--) {
-    delete responseObj[fieldsToExclude[i]];
+  if (fieldsToExclude) {
+    for (let i = fieldsToExclude.length - 1; i >= 0; i--) {
+      delete responseObj[fieldsToExclude[i]];
+    }
   }
 } // removeFieldsFromResponse
 

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -684,7 +684,8 @@ function findByKey(props, params, extraAttributes) {
   opts.where[props.nameFinder || 'name'] = keyClause;
 
   let attrArr = opts.attributes;
-  if (extraAttributes && Array.isArray(extraAttributes) && extraAttributes.length) {
+  if (extraAttributes && Array.isArray(extraAttributes) &&
+    extraAttributes.length) {
     if (attrArr) {
       attrArr.push(...extraAttributes);
     } else {

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -4790,7 +4790,7 @@ paths:
       summary: Get generatorTemplate
       tags: [ generatorTemplates ]
       description: >-
-        Retrieve the specified generatoTemplate.
+        Retrieve the specified generatorTemplate.
       operationId: getGeneratorTemplate
       parameters:
         -
@@ -4819,7 +4819,7 @@ paths:
       tags: [ generatorTemplates ]
       description: >-
         Update the specified generatorTemplate. Requires user to have write
-        permision. If a field is not included in the query body, that field
+        permission. If a field is not included in the query body, that field
         will not be updated.
       operationId: patchGeneratorTemplate
       parameters:
@@ -5023,6 +5023,45 @@ paths:
           $ref: "#/responses/403"
         404:
           $ref: "#/responses/404"
+        default:
+          $ref: "#/responses/genericError"
+
+  # ---------------------------------------------------------------------------
+  /generatorTemplates/{name}/{version}:
+    x-swagger-router-controller: generatorTemplates
+    get:
+      security:
+      - jwt: []
+      summary: Get generatorTemplate
+      tags: [ generatorTemplates ]
+      description: >-
+        Retrieve the specified generatorTemplate by name and version.
+      operationId: getGeneratorTemplateByNameAndVersion
+      parameters:
+      -
+        name: name
+        in: path
+        description: >-
+          The name of the generatorTemplate to be retrieved.
+        required: true
+        type: string
+      -
+        name: version
+        in: path
+        description: >-
+          The version of the generatorTemplate to be retrieved.
+        required: true
+        type: string
+      responses:
+        200:
+          description: >-
+            Success, returns a generatorTemplate
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/GeneratorTemplateResponse"
+        400:
+          $ref: "#/responses/400"
         default:
           $ref: "#/responses/genericError"
 

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -5055,9 +5055,9 @@ paths:
       responses:
         200:
           description: >-
-            Success, returns a generatorTemplate
+            Success, returns a single generatorTemplate
           schema:
-            type: array
+            type: object
             items:
               $ref: "#/definitions/GeneratorTemplateResponse"
         400:

--- a/tests/api/v1/generatorTemplates/get.js
+++ b/tests/api/v1/generatorTemplates/get.js
@@ -139,9 +139,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+      if (err) return done(err);
 
       expect(res.body.name).to.equal(template1.name);
       done();
@@ -152,10 +150,8 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     api.get(`${path}/${template1.name}`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
-    .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+    .end((err) => {
+      if (err) return done(err);
 
       done();
     });
@@ -166,9 +162,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)
       .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         expect(res.body.name).to.equal(template1.name);
         expect(res.body.version).to.equal(template1.version);
@@ -210,10 +204,8 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     api.get(`${path}/${template1.name.toLowerCase()}`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
-    .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+    .end((err) => {
+      if (err) return done(err);
 
       done();
     });
@@ -224,9 +216,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+      if (err) return done(err);
 
       expect(res.body).to.have.length(THREE);
       done();
@@ -238,9 +228,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+      if (err) return done(err);
 
       expect(res.body).to.have.length(ONE);
       expect(res.body[ZERO]).to.have.property('name', template2.name);
@@ -253,9 +241,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
+      if (err) return done(err);
 
       expect(res.body).to.have.length(ZERO);
       done();
@@ -271,9 +257,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)
       .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         if (res.body.errors) {
           return done(res.body.errors[0]);
@@ -302,9 +286,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)
       .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
+        if (err) return done(err);
 
         fields.forEach((field) => {
           expect(res.body[field]).to.deep.equal(template1[field]);

--- a/tests/api/v1/generatorTemplates/get.js
+++ b/tests/api/v1/generatorTemplates/get.js
@@ -34,8 +34,8 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
   template1.name = 'template1';
   template1.version = '1.0.0';
   const template2 = u.getGeneratorTemplate();
-  template2.name = 'template2';
-  template2.version = '1.0.0';
+  template2.name = 'template1';
+  template2.version = '1.0.2';
   template2.tags.push('tag2');
   const template3 = u.getGeneratorTemplate();
   template3.name = 'template3';
@@ -157,12 +157,11 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
         return done(err);
       }
 
-      expect(res.body.name).to.equal(template1.name);
       done();
     });
   });
 
-  it('Must retrieve when valid name and version', (done) => {
+  it('Must GET a single GT when valid name and version', (done) => {
     api.get(`${path}/${template1.name}/${template1.version}`)
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)
@@ -171,51 +170,38 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
           return done(err);
         }
 
-        expect(res.body.length).to.equal(ONE);
-        expect(res.body[0].name).to.equal(template1.name);
-        expect(res.body[0].version).to.equal(template1.version);
+        expect(res.body.name).to.equal(template1.name);
+        expect(res.body.version).to.equal(template1.version);
         done();
       });
   });
 
-  it('Must not retrieve by incorrect version', (done) => {
-    api.get(`${path}/${template1.name}/1.0.2`)
+  it('Must not GET when incorrect version', (done) => {
+    api.get(`${path}/${template1.name}/1.0.3`)
       .set('Authorization', token)
-      .expect(constants.httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
-        expect(res.body.length).to.equal(ZERO);
+      .expect(constants.httpStatus.NOT_FOUND)
+      .end((err) => {
+        if (err) return done(err);
         done();
       });
   });
 
-  it('Must not retrieve by incorrect name', (done) => {
+  it('Must not GET by incorrect name', (done) => {
     api.get(`${path}/foo/${template1.version}`)
       .set('Authorization', token)
-      .expect(constants.httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
-        expect(res.body.length).to.equal(ZERO);
+      .expect(constants.httpStatus.NOT_FOUND)
+      .end((err) => {
+        if (err) return done(err);
         done();
       });
   });
 
-  it('Must not retrieve by incorrect name and version', (done) => {
+  it('Must not GET by incorrect name and version', (done) => {
     api.get(`${path}/foo/aa`)
       .set('Authorization', token)
-      .expect(constants.httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
-        expect(res.body.length).to.equal(ZERO);
+      .expect(constants.httpStatus.NOT_FOUND)
+      .end((err) => {
+        if (err) return done(err);
         done();
       });
   });
@@ -229,7 +215,6 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
         return done(err);
       }
 
-      expect(res.body.name).to.equal(template1.name);
       done();
     });
   });
@@ -412,7 +397,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     });
 
     it('find by name', (done) => {
-      findByField(done, 'name', 'template2', 1);
+      findByField(done, 'name', 'template1', 2);
     });
 
     it('find by name wildcard', (done) => {

--- a/tests/api/v1/generatorTemplates/get.js
+++ b/tests/api/v1/generatorTemplates/get.js
@@ -32,8 +32,10 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
   let o4;
   const template1 = u.getGeneratorTemplate();
   template1.name = 'template1';
+  template1.version = '1.0.0';
   const template2 = u.getGeneratorTemplate();
   template2.name = 'template2';
+  template2.version = '1.0.0';
   template2.tags.push('tag2');
   const template3 = u.getGeneratorTemplate();
   template3.name = 'template3';
@@ -158,6 +160,64 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       expect(res.body.name).to.equal(template1.name);
       done();
     });
+  });
+
+  it('Must retrieve when valid name and version', (done) => {
+    api.get(`${path}/${template1.name}/${template1.version}`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(ONE);
+        expect(res.body[0].name).to.equal(template1.name);
+        expect(res.body[0].version).to.equal(template1.version);
+        done();
+      });
+  });
+
+  it('Must not retrieve by incorrect version', (done) => {
+    api.get(`${path}/${template1.name}/1.0.2`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(ZERO);
+        done();
+      });
+  });
+
+  it('Must not retrieve by incorrect name', (done) => {
+    api.get(`${path}/foo/${template1.version}`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(ZERO);
+        done();
+      });
+  });
+
+  it('Must not retrieve by incorrect name and version', (done) => {
+    api.get(`${path}/foo/aa`)
+      .set('Authorization', token)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.length).to.equal(ZERO);
+        done();
+      });
   });
 
   it('Simple GET with name in lowercase', (done) => {

--- a/tests/api/v1/helpers/findUtils.js
+++ b/tests/api/v1/helpers/findUtils.js
@@ -177,7 +177,24 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
       });
     });
 
-    it('opts with name field, one value, limit set to 1', () => {
+    it('Must not set limit when unique field does not require limit', () => {
+      // given a noun where name is the key but doesnt require
+      // limit like generatorTemplate
+      const noun = { uniqueFieldWithoutLimit: 'name' };
+      const opts = {
+        limit: 10,
+        where: { name: { [Op.iLike]: 'someName' } },
+      };
+
+      fu.applyLimitIfUniqueField(opts, noun);
+
+      expect(opts).to.deep.equal({
+        limit: 10,
+        where: { name: { [Op.iLike]: 'someName' } },
+      });
+    });
+
+    it('Must set limit = 1 when unique field requires limit', () => {
       const props = {};
       const opts = {
         limit: 15000,
@@ -191,21 +208,59 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
       });
     });
 
-    it('opts with name field, multiple value, limit set to number of ' +
-      'values', () => {
+    it('Must set limit when unique field, multiple value and requires ' +
+      'limit', () => {
       const props = {};
       const opts = {
         limit: 40,
-        where: { name:
-          { [Op.or]: [{ [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' }] },
+        where: {
+          name: {
+            [Op.or]: [
+              { [Op.iLike]: 'someName1' },
+              { [Op.iLike]: 'someName2' },
+            ],
+          },
         },
       };
 
       fu.applyLimitIfUniqueField(opts, props);
+
       expect(opts).to.deep.equal({
         limit: 2,
-        where: { name:
-          { [Op.or]: [{ [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' }] },
+        where: {
+          name: {
+            [Op.or]: [
+              { [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' },
+            ],
+          },
+        },
+      });
+    });
+
+    it('Must not set limit when unique field, multiple value and not ' +
+      'requires limit', () => {
+      const props = { uniqueFieldWithoutLimit: 'name' };
+      const opts = {
+        limit: 10,
+        where: {
+          name: {
+            [Op.or]: [
+              { [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' },
+            ],
+          },
+        },
+      };
+
+      fu.applyLimitIfUniqueField(opts, props);
+
+      expect(opts).to.deep.equal({
+        limit: 10,
+        where: {
+          name: {
+            [Op.or]: [
+              { [Op.iLike]: 'someName1' }, { [Op.iLike]: 'someName2' },
+            ],
+          },
         },
       });
     });


### PR DESCRIPTION
**Task: API returning Generator Templates.**

* Added API to return a single Generator Template by /$name/$version
* Fixed generatorTemplates?name=$name returning a list of Generator
  * Added the attribute **nameFinderWithoutLimit** to the noun which will skip the limit verification when unique field is used (overwritten or default).

I have added a new **findOne** module returning a single object because the query is not by the key (via doGet) and it must returns a single object (original doFind returns an Array).

_Item to remove API querying by name will be handled in a separate story._
