### PR TITLE
disable GET /name for generatorTemplates

### DIFF
--- a/api/v1/apiErrors.js
+++ b/api/v1/apiErrors.js
@@ -153,6 +153,17 @@ errors.create({
   'in your Sample Generator\'s context',
 });
 
+errors.create({
+  scope: exports,
+  code: 11112,
+  status: 400,
+  name: 'InvalidKey',
+  parent: this.ValidationError,
+  fields: [],
+  defaultMessage: 'You cannot GET this resource by name, try using id as ' +
+    'key or name as query parameter, e.g. ?name=<name>',
+});
+
 // ----------------------------------------------------------------------------
 // Not Found
 // ----------------------------------------------------------------------------

--- a/api/v1/apiErrors.js
+++ b/api/v1/apiErrors.js
@@ -160,8 +160,8 @@ errors.create({
   name: 'InvalidKey',
   parent: this.ValidationError,
   fields: [],
-  defaultMessage: 'You cannot GET this resource by name, try using id as ' +
-    'key or name as query parameter, e.g. ?name=<name>',
+  defaultMessage: 'This resource has a multipart key. Try using name as a ' +
+  'query parameter to return a list of all records with this name, e.g. ?name=',
 });
 
 // ----------------------------------------------------------------------------

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -37,7 +37,7 @@ module.exports = {
     user: 'user',
   },
 
-  nonUniqueName: true,
+  hasMultipartKey: true,
 
 }; // exports
 

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -37,7 +37,7 @@ module.exports = {
     user: 'user',
   },
 
-  nameFinderWithoutLimit: true,
+  nonUniqueName: true,
 
 }; // exports
 

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -298,11 +298,11 @@ function toSequelizeOrder(sortOrder) {
  */
 function applyLimitIfUniqueField(opts, props) {
   /*
-   * Attribute nonUniqueName is a temp workaround until we define
+   * Attribute hasMultipartKey is a temp workaround until we define
    * the best way to NOT change/restrict limit when unique field is the default
    * (name) for some nouns.
    */
-  if (props.nonUniqueName) return;
+  if (props.hasMultipartKey) return;
 
   const uniqueFieldName = props.nameFinder || 'name';
   if (opts.where && opts.where[uniqueFieldName]) {

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -298,11 +298,11 @@ function toSequelizeOrder(sortOrder) {
  */
 function applyLimitIfUniqueField(opts, props) {
   /*
-   * Attribute nameFinderWithoutLimit is a temp workaround until we define
+   * Attribute nonUniqueName is a temp workaround until we define
    * the best way to NOT change/restrict limit when unique field is the default
    * (name) for some nouns.
    */
-  if (props.nameFinderWithoutLimit) return;
+  if (props.nonUniqueName) return;
 
   const uniqueFieldName = props.nameFinder || 'name';
   if (opts.where && opts.where[uniqueFieldName]) {

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -442,16 +442,27 @@ function findByName(model, key, opts) {
  * @param {String} key - The id or name to search for
  * @param {Object} opts - The Sequelize options to send with the find
  *  operation
+ * @param {Object} props - The helpers/nouns module for the given DB model
  * @returns {Promise} which resolves to the record found, or rejects with
  *  ResourceNotFoundError if record not found
  */
-function findByIdThenName(model, key, opts) {
+function findByIdThenName(model, key, opts, props) {
   return new Promise((resolve, reject) => {
     const wh = opts.where;
     delete opts.where;
     model.findById(key, opts)
     .then((found) => found)
     .catch(() => {
+
+      /* The resource has non-unique name and hence GET /{resource}/$name is
+      not allowed */
+      if (props && props.nonUniqueName) {
+        const err = new apiErrors.InvalidKey();
+        err.resource = model.name;
+        err.key = key;
+        throw err;
+      }
+
       opts.where = wh;
       return findByName(model, key, opts);
     })
@@ -700,12 +711,21 @@ function findByKey(props, params, extraAttributes) {
   // If the models key auto-increments then the key will be an
   // integer and still should find records by ID.
   if (common.looksLikeId(key)) {
-    return findByIdThenName(scopedModel, key, opts);
+    return findByIdThenName(scopedModel, key, opts, props);
   } else if ((typeof key === 'number') && (key % 1 === 0)) {
-    return findByIdThenName(scopedModel, key, opts);
+    return findByIdThenName(scopedModel, key, opts, props);
   }
 
-  return findByName(scopedModel, key, opts);
+  /* The resource has non-unique name and hence GET /{resource}/$name is
+  not allowed */
+  if (props && props.nonUniqueName) {
+    const err = new apiErrors.InvalidKey();
+    err.resource = scopedModel.name;
+    err.key = key;
+    throw err;
+  }
+
+  return findByName(scopedModel, key, opts, props);
 } // findByKey
 
 /**

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -456,7 +456,7 @@ function findByIdThenName(model, key, opts, props) {
 
       /* The resource has non-unique name and hence GET /{resource}/$name is
       not allowed */
-      if (props && props.nonUniqueName) {
+      if (props && props.hasMultipartKey) {
         const err = new apiErrors.InvalidKey();
         err.resource = model.name;
         err.key = key;
@@ -718,7 +718,7 @@ function findByKey(props, params, extraAttributes) {
 
   /* The resource has non-unique name and hence GET /{resource}/$name is
   not allowed */
-  if (props && props.nonUniqueName) {
+  if (props && props.hasMultipartKey) {
     const err = new apiErrors.InvalidKey();
     err.resource = scopedModel.name;
     err.key = key;

--- a/tests/api/v1/common/testAssociations.js
+++ b/tests/api/v1/common/testAssociations.js
@@ -58,6 +58,11 @@ function testAssociations(path, associations, joiSchema, conf) {
   });
 
   it('get by key includes associations', (done) => {
+    // GET /v1/generatorTemplates/name is invalid
+    if (path === '/v1/generatorTemplates') {
+      return done();
+    }
+
     api.get(`${path}/${recordId}`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -71,6 +76,11 @@ function testAssociations(path, associations, joiSchema, conf) {
   });
 
   it('get by key with field param does not include associations', (done) => {
+    // GET /v1/generatorTemplates/name is invalid
+    if (path === '/v1/generatorTemplates') {
+      return done();
+    }
+
     api.get(`${path}/${recordId}?fields=name`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -101,6 +111,11 @@ function testAssociations(path, associations, joiSchema, conf) {
 
   associations.forEach((assoc) => {
     it(`get by key: an association can be specified as a field param (${assoc})`, (done) => {
+      // GET /v1/generatorTemplates/name is invalid
+      if (path === '/v1/generatorTemplates') {
+        return done();
+      }
+
       api.get(`${path}/${recordId}?fields=name,${assoc}`)
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)

--- a/tests/api/v1/generatorTemplates/get.js
+++ b/tests/api/v1/generatorTemplates/get.js
@@ -146,17 +146,6 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
     });
   });
 
-  it('Simple GET with name', (done) => {
-    api.get(`${path}/${template1.name}`)
-    .set('Authorization', token)
-    .expect(constants.httpStatus.OK)
-    .end((err) => {
-      if (err) return done(err);
-
-      done();
-    });
-  });
-
   it('Must GET a single GT when valid name and version', (done) => {
     api.get(`${path}/${template1.name}/${template1.version}`)
       .set('Authorization', token)
@@ -200,13 +189,41 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       });
   });
 
-  it('Simple GET with name in lowercase', (done) => {
+  it('error, Simple GET with name, 400', (done) => {
+    api.get(`${path}/${template1.name}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) return done(err);
+      expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
+      expect(res.body.errors[0].message).to
+        .include('cannot GET this resource by name');
+      done();
+    });
+  });
+
+  it('error, Simple GET with name in lowercase, 400', (done) => {
     api.get(`${path}/${template1.name.toLowerCase()}`)
     .set('Authorization', token)
-    .expect(constants.httpStatus.OK)
-    .end((err) => {
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
       if (err) return done(err);
+      expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
+      expect(res.body.errors[0].message).to
+        .include('cannot GET this resource by name');
+      done();
+    });
+  });
 
+  it('error, Simple GET with name which does not exist, 400', (done) => {
+    api.get(`${path}/notExist`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) return done(err);
+      expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
+      expect(res.body.errors[0].message).to
+        .include('cannot GET this resource by name');
       done();
     });
   });

--- a/tests/api/v1/generatorTemplates/get.js
+++ b/tests/api/v1/generatorTemplates/get.js
@@ -197,7 +197,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       if (err) return done(err);
       expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
       expect(res.body.errors[0].message).to
-        .include('cannot GET this resource by name');
+        .include('This resource has a multipart key');
       done();
     });
   });
@@ -210,7 +210,7 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       if (err) return done(err);
       expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
       expect(res.body.errors[0].message).to
-        .include('cannot GET this resource by name');
+        .include('This resource has a multipart key');
       done();
     });
   });
@@ -223,7 +223,20 @@ describe('tests/api/v1/generatorTemplates/get.js > ', () => {
       if (err) return done(err);
       expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
       expect(res.body.errors[0].message).to
-        .include('cannot GET this resource by name');
+        .include('This resource has a multipart key');
+      done();
+    });
+  });
+
+  it('error, Simple GET with name which looks like id, 400', (done) => {
+    api.get(`${path}/1234567890`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.BAD_REQUEST)
+    .end((err, res) => {
+      if (err) return done(err);
+      expect(res.body.errors[0].source).to.be.equal('GeneratorTemplate');
+      expect(res.body.errors[0].message).to
+        .include('This resource has a multipart key');
       done();
     });
   });

--- a/tests/api/v1/generatorTemplates/getWriters.js
+++ b/tests/api/v1/generatorTemplates/getWriters.js
@@ -73,7 +73,7 @@ describe('tests/api/v1/generatorTemplates/getWriters.js > ', () => {
   });
 
   it('find Writers and make sure the passwords are not returned', (done) => {
-    api.get(getWritersPath.replace('{key}', generatorTemplate.name))
+    api.get(getWritersPath.replace('{key}', generatorTemplate.id))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
     .expect((res) => {
@@ -89,7 +89,7 @@ describe('tests/api/v1/generatorTemplates/getWriters.js > ', () => {
   });
 
   it('find Writer by username', (done) => {
-    api.get(getWriterPath.replace('{key}', generatorTemplate.name)
+    api.get(getWriterPath.replace('{key}', generatorTemplate.id)
     .replace('{userNameOrId}', user.name))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -100,7 +100,7 @@ describe('tests/api/v1/generatorTemplates/getWriters.js > ', () => {
   });
 
   it('find Writer by userId', (done) => {
-    api.get(getWriterPath.replace('{key}', generatorTemplate.name)
+    api.get(getWriterPath.replace('{key}', generatorTemplate.id)
     .replace('{userNameOrId}', user.id))
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -114,12 +114,12 @@ describe('tests/api/v1/generatorTemplates/getWriters.js > ', () => {
     api.get(getWriterPath.replace('{key}', 'invalidresource')
     .replace('{userNameOrId}', user.id))
     .set('Authorization', token)
-    .expect(constants.httpStatus.NOT_FOUND)
+    .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
 
   it('Writer not found for invalid username', (done) => {
-    api.get(getWriterPath.replace('{key}', generatorTemplate.name)
+    api.get(getWriterPath.replace('{key}', generatorTemplate.id)
     .replace('{userNameOrId}', 'invalidUser'))
     .set('Authorization', token)
     .expect(constants.httpStatus.NOT_FOUND)

--- a/tests/api/v1/helpers/findUtils.js
+++ b/tests/api/v1/helpers/findUtils.js
@@ -207,7 +207,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
 
     it('Must not change limit when single unique field is default and ' +
       'does NOT require limit', () => {
-      const noun = { nonUniqueName: true };
+      const noun = { hasMultipartKey: true };
       const opts = {
         limit: 100,
         where: {
@@ -316,7 +316,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
       ' value and does not require limit', () => {
       const props = {
         nameFinder: 'absolutePath',
-        nonUniqueName: true,
+        hasMultipartKey: true,
       };
       const opts = {
         limit: 100,
@@ -345,7 +345,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
 
     it('Must not change limit when unique field is default, has multiple ' +
       'value and does not require limit', () => {
-      const props = { nonUniqueName: true };
+      const props = { hasMultipartKey: true };
       const opts = {
         limit: 10,
         where: {

--- a/tests/api/v1/helpers/findUtils.js
+++ b/tests/api/v1/helpers/findUtils.js
@@ -207,7 +207,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
 
     it('Must not change limit when single unique field is default and ' +
       'does NOT require limit', () => {
-      const noun = { nameFinderWithoutLimit: true };
+      const noun = { nonUniqueName: true };
       const opts = {
         limit: 100,
         where: {
@@ -316,7 +316,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
       ' value and does not require limit', () => {
       const props = {
         nameFinder: 'absolutePath',
-        nameFinderWithoutLimit: true,
+        nonUniqueName: true,
       };
       const opts = {
         limit: 100,
@@ -345,7 +345,7 @@ describe('tests/api/v1/helpers/findUtils.js', () => {
 
     it('Must not change limit when unique field is default, has multiple ' +
       'value and does not require limit', () => {
-      const props = { nameFinderWithoutLimit: true };
+      const props = { nonUniqueName: true };
       const opts = {
         limit: 10,
         where: {


### PR DESCRIPTION
The user must NOT be able to GET Generators Template by name /v1/generatorTemplates/$name, however, must be able to GET by /generatorTemplates/$ID.

- Return return 400 (invalid) error when the query is by name.
- Updated/Added tests.