### PR TITLE
Update adm-zip to V0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,9 +286,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.10.tgz",
+      "integrity": "sha512-075E4f1zFxHbsnn6C4OI4jVzUT1zV+M68QdBxcVxmO/Yqk35CFnFFYLaepvth68gzlIlyQ/hkaI2JY99Nh3C5Q=="
     },
     "after": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,9 +286,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.10.tgz",
-      "integrity": "sha512-075E4f1zFxHbsnn6C4OI4jVzUT1zV+M68QdBxcVxmO/Yqk35CFnFFYLaepvth68gzlIlyQ/hkaI2JY99Nh3C5Q=="
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.11.tgz",
+      "integrity": "sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA=="
     },
     "after": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -286,9 +286,9 @@
       }
     },
     "adm-zip": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
-      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E="
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
     "after": {
       "version": "0.8.2",
@@ -13422,6 +13422,11 @@
           }
         }
       }
+    },
+    "original-fs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/original-fs/-/original-fs-1.0.0.tgz",
+      "integrity": "sha512-X/sHggGgmoyG3plMSAZcyehbBNnADefp2uN+ahSP2OV+HjCCS4p997yDL0kC5YSHPIp9eTEfezWulEQgvx1TIQ=="
     },
     "os-browserify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@salesforce/refocus-collector": "^1.0.1",
-    "adm-zip": "^0.4.11",
+    "adm-zip": "0.4.11",
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.26.3",
     "babel-eslint": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@salesforce/refocus-collector": "^1.0.1",
-    "adm-zip": "^0.4.13",
+    "adm-zip": "^0.4.10",
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.26.3",
     "babel-eslint": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@salesforce/refocus-collector": "^1.0.1",
-    "adm-zip": "0.4.7",
+    "adm-zip": "^0.4.13",
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.26.3",
     "babel-eslint": "^6.0.4",
@@ -133,6 +133,7 @@
     "nock": "^3.6.0",
     "npm": "^3.10.9",
     "npm-watch": "^0.1.6",
+    "original-fs": "^1.0.0",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "passport-saml": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@salesforce/refocus-collector": "^1.0.1",
-    "adm-zip": "^0.4.10",
+    "adm-zip": "^0.4.11",
     "autoprefixer": "^6.0.3",
     "babel-core": "^6.26.3",
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
- original-fs module is required to update adm-zip
- adm-zip needs to be updated past 0.4.11 (security vulnerability)
  - https://github.com/OpenLiberty/sample-acmegifts/issues/14
- this npm original-fs acts as a monkey dependency to fs