### PR TITLE
Reassign generators among running collectors to distribute load

### DIFF
--- a/config/toggles.js
+++ b/config/toggles.js
@@ -183,6 +183,10 @@ const shortTermToggles = {
   // adds isBot to token and returns token on patches not just posts
   addIsBotToToken: environmentVariableTrue(
     pe, 'ADD_ISBOT_TO_TOKEN'),
+
+  // reassign generators among running collectors to distribute load
+  distributeGenerators: environmentVariableTrue(
+    pe, 'DISTRIBUTE_GENERATORS'),
 }; // shortTermToggles
 
 featureToggles.load(Object.assign({}, longTermToggles, shortTermToggles));

--- a/db/helpers/collectorUtils.js
+++ b/db/helpers/collectorUtils.js
@@ -93,10 +93,8 @@ function assignUnassignedGenerators() {
   // which is an association and can't be looked up with a normal where clause
   return utils.seq.models.Generator.findAll(
     { where: { isActive: true, collectorId: null } }
-  ).map((g) => {
-    g.assignToCollector();
-    return g.save();
-  });
+  ).map((g) => g.assignToCollector()
+    .then(() => g.save()));
 }
 
 module.exports = {

--- a/db/helpers/collectorUtils.js
+++ b/db/helpers/collectorUtils.js
@@ -18,6 +18,7 @@ const Joi = require('joi');
 const ValidationError = require('../dbErrors').ValidationError;
 const semverRegex = require('semver-regex');
 const utils = require('../utils.js');
+const featureToggles = require('feature-toggles');
 
 const osInfoSchema = Joi.object().keys({
   arch: Joi.string(),
@@ -91,10 +92,20 @@ function assignUnassignedGenerators() {
   // finds all unassigned generators (those with no currentCollector).
   // Use collectorId because it's a field on the db model, vs currentCollector
   // which is an association and can't be looked up with a normal where clause
+
+  if (featureToggles.isFeatureEnabled('distributeGenerators')) {
+    return utils.seq.models.Generator.findAll(
+      { where: { isActive: true, collectorId: null } }
+    ).map((g) => g.assignToCollector()
+      .then(() => g.save()));
+  }
+
   return utils.seq.models.Generator.findAll(
     { where: { isActive: true, collectorId: null } }
-  ).map((g) => g.assignToCollector()
-    .then(() => g.save()));
+  ).map((g) => {
+    g.assignToCollector();
+    return g.save();
+  });
 }
 
 module.exports = {

--- a/db/model/collector.js
+++ b/db/model/collector.js
@@ -328,10 +328,8 @@ module.exports = function collector(seq, dataTypes) {
    */
   Collector.prototype.reassignGenerators = function () {
     return this.getCurrentGenerators()
-    .map((g) => {
-      g.assignToCollector();
-      return g.save();
-    });
+    .map((g) => g.assignToCollector()
+      .then(() => g.save()));
   };
 
   Collector.prototype.isWritableBy = function (who) {

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -479,7 +479,6 @@ module.exports = function generator(seq, dataTypes) {
     .then(() => g);
   }; // updateForHeartbeat
 
-
   /**
    * Out of all the possible collectors that are running and alive, find the
    * one with the fewest number of currently assigned generators. Break ties

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -589,6 +589,8 @@ module.exports = function generator(seq, dataTypes) {
         });
       }
 
+      // inactive generator or no possibleCollectors
+      logAssignment(this.name, this.currentCollector, null);
       this.collectorId = null;
       this.currentCollector = null;
       return Promise.resolve();

--- a/tests/db/model/generator/methods.js
+++ b/tests/db/model/generator/methods.js
@@ -394,5 +394,18 @@ describe('tests/db/model/generator/methods.js >', () => {
         expect(generator3.currentCollector.id).to.equal(collector2.id);
       })
     );
+
+    it('No available collector', () =>
+
+      generator1.updateWithCollectors({ // gen1 -> coll1
+        isActive: true,
+        possibleCollectors: [coll1.name],
+      })
+      .then(() => collector1.update({ status: collectorStatuses.Stopped }))
+      .then(() => generator1.reload())
+      .then(() => {
+        expect(generator1.currentCollector).to.equal(null);
+      })
+    );
   });
 });

--- a/tests/db/model/generator/methods.js
+++ b/tests/db/model/generator/methods.js
@@ -131,7 +131,9 @@ describe('tests/db/model/generator/methods.js >', () => {
       .then(() => {
         expect(generator1.currentCollector.name).to.equal(collector3.name);
         expect(generator1.currentCollector.id).to.equal(collector3.id);
-        generator1.assignToCollector();
+        return generator1.assignToCollector();
+      })
+      .then(() => {
         expect(generator1.currentCollector).to.equal(null);
       })
     );
@@ -149,7 +151,9 @@ describe('tests/db/model/generator/methods.js >', () => {
       .then(() => {
         expect(generator1.currentCollector.name).to.equal(collector3.name);
         expect(generator1.currentCollector.id).to.equal(collector3.id);
-        generator1.assignToCollector();
+        return generator1.assignToCollector();
+      })
+      .then(() => {
         expect(generator1.currentCollector).to.equal(null);
       })
     );
@@ -161,15 +165,21 @@ describe('tests/db/model/generator/methods.js >', () => {
       })
       .then(() => {
         expect(generator1.currentCollector).to.equal(null);
-        generator1.assignToCollector();
+        return generator1.assignToCollector();
+      })
+      .then(() => {
         expect(generator1.currentCollector).to.equal(null);
       })
     );
 
-    it('collectors not specified (not assigned)', () => {
+    it('collectors not specified (not assigned)', (done) => {
       expect(generator1.currentCollector).to.equal(null);
-      generator1.assignToCollector();
-      expect(generator1.currentCollector).to.equal(null);
+      generator1.assignToCollector()
+      .then(() => {
+        expect(generator1.currentCollector).to.equal(null);
+        done();
+      })
+      .catch(done);
     });
 
     it('collectors not specified (unassigned)', () =>
@@ -178,8 +188,210 @@ describe('tests/db/model/generator/methods.js >', () => {
       .then(() => {
         expect(generator1.currentCollector.name).to.equal(collector3.name);
         expect(generator1.currentCollector.id).to.equal(collector3.id);
-        generator1.assignToCollector();
+        return generator1.assignToCollector();
+      })
+      .then(() => {
         expect(generator1.currentCollector).to.equal(null);
+      })
+    );
+  });
+
+  describe('getMostAvailableCollector >', () => {
+    const coll4 = {
+      name: 'collector4',
+      version: '1.0.0',
+      status: collectorStatuses.Stopped, // unavailable collector
+      lastHeartbeat: now,
+    };
+
+    let generator2;
+    let generator3;
+    let generator4;
+
+    const gen2 = u.getGenerator();
+    gen2.name += '-2';
+    const gen3 = u.getGenerator();
+    gen3.name += '-3';
+    const gen4 = u.getGenerator();
+    gen4.name += '-4';
+
+    beforeEach(() => Promise.join(
+        Generator.create(gen2),
+        Generator.create(gen3),
+        Generator.create(gen4),
+        Collector.create(coll4)
+      )
+      .spread((_g2, _g3, _g4, _c4) => {
+        generator2 = _g2;
+        generator3 = _g3;
+        generator4 = _g4;
+      })
+    );
+
+    it('Two possible collectors (out of three available) unassigned,' +
+      ' generator assigned to first choice', () =>
+
+      generator1.updateWithCollectors({ // gen1 -> coll1
+        isActive: true,
+        possibleCollectors: [coll1.name],
+      })
+
+      // all 4 collectors assigned as possible collectors of generator2.
+      .then(() => generator2.updateWithCollectors({
+        isActive: true,
+        possibleCollectors: [coll1.name, coll2.name, coll3.name, coll4.name],
+      }))
+      .then(() => {
+        expect(generator1.currentCollector.name).to.equal(collector1.name);
+
+        // generator2 assigned to collector2
+        expect(generator2.currentCollector.name).to.equal(collector2.name);
+        expect(generator2.currentCollector.id).to.equal(collector2.id);
+      })
+    );
+
+    it('One possible collector (out of three available) unassigned, generator' +
+      ' assigned to the only choice', () =>
+      Promise.all([
+        generator1.updateWithCollectors({ // gen1 -> coll1
+          isActive: true,
+          possibleCollectors: [coll1.name],
+        }),
+        generator2.updateWithCollectors({ // gen2 -> coll2
+          isActive: true,
+          possibleCollectors: [coll2.name],
+        }),
+      ])
+
+      // all 4 collectors assigned as possible collectors of generator3.
+      .then(() => generator3.updateWithCollectors({
+        isActive: true,
+        possibleCollectors: [coll1.name, coll2.name, coll3.name, coll4.name],
+      }))
+      .then(() => {
+        expect(generator1.currentCollector.name).to.equal(collector1.name);
+        expect(generator2.currentCollector.name).to.equal(collector2.name);
+
+        // generator3 assigned to collector3
+        expect(generator3.currentCollector.name).to.equal(collector3.name);
+        expect(generator3.currentCollector.id).to.equal(collector3.id);
+      })
+    );
+
+    it('All possible collectors assigned (except the stopped one), generator' +
+      ' assigned to first choice', () =>
+      Promise.all([
+        generator1.updateWithCollectors({ // gen1 -> coll1
+          isActive: true,
+          possibleCollectors: [coll1.name],
+        }),
+        generator2.updateWithCollectors({ // gen2 -> coll2
+          isActive: true,
+          possibleCollectors: [coll2.name],
+        }),
+        generator3.updateWithCollectors({ // gen3 -> coll3
+          isActive: true,
+          possibleCollectors: [coll3.name],
+        }),
+      ])
+
+      // all 4 collectors assigned as possible collectors of generator4
+      .then(() => generator4.updateWithCollectors({
+        isActive: true,
+        possibleCollectors: [coll1.name, coll2.name, coll3.name, coll4.name],
+      }))
+      .then(() => {
+        expect(generator1.currentCollector.name).to.equal(collector1.name);
+        expect(generator2.currentCollector.name).to.equal(collector2.name);
+        expect(generator3.currentCollector.name).to.equal(collector3.name);
+
+        // generator4 is assigned to collector1
+        expect(generator4.currentCollector.name).to.equal(collector1.name);
+        expect(generator4.currentCollector.id).to.equal(collector1.id);
+      })
+    );
+
+    it('Collector with assigned generator stops, generator reassigned to' +
+      ' collector with least number of current generators', () =>
+      Promise.all([
+        generator1.updateWithCollectors({ // gen1 -> coll1
+          isActive: true,
+          possibleCollectors: [coll1.name],
+        }),
+        generator2.updateWithCollectors({ // gen2 -> coll2
+          isActive: true,
+          possibleCollectors: [coll2.name],
+        }),
+        generator3.updateWithCollectors({ // gen3 -> coll3
+          isActive: true,
+          possibleCollectors: [coll3.name],
+        }),
+        generator4.updateWithCollectors({ // gen4 -> coll1
+          isActive: true,
+          possibleCollectors: [coll1.name],
+        }),
+      ])
+
+      // gen2 can be assigned to any collector
+      .then(() => generator2.updateWithCollectors({
+        possibleCollectors: [coll1.name, coll2.name, coll3.name, coll4.name],
+      }))
+      .then(() => {
+        // gen2 still assigned to coll2
+        expect(generator2.currentCollector.name).to.equal(collector2.name);
+
+        /* stop collector2 -> this should reassign gen2 to coll3 because
+        coll1 has 2 generators assigned and coll3 has one generator assigned
+        coll4 is Stopped. */
+        return collector2.update({ status: collectorStatuses.Stopped });
+      })
+      .then(() => generator2.reload())
+      .then(() => {
+        expect(generator1.currentCollector.name).to.equal(collector1.name);
+        expect(generator3.currentCollector.name).to.equal(collector3.name);
+        expect(generator4.currentCollector.name).to.equal(collector1.name);
+
+        // gen2 assigned to coll3
+        expect(generator2.currentCollector.name).to.equal(collector3.name);
+        expect(generator2.currentCollector.id).to.equal(collector3.id);
+      })
+    );
+
+    it('Generator assignment breaks number of currents generators ties using' +
+    ' number of possible generators', () =>
+      Promise.all([
+        generator1.updateWithCollectors({ // gen1 -> coll1
+          isActive: true,
+          possibleCollectors: [coll1.name],
+        }),
+        generator2.updateWithCollectors({ // gen2 -> coll2
+          isActive: true,
+          possibleCollectors: [coll2.name],
+        }),
+      ])
+
+      // gen2 can be assigned to any of 4 collectors
+      .then(() => generator2.updateWithCollectors({
+        possibleCollectors: [coll2.name, coll3.name, coll1.name, coll4.name],
+      }))
+
+      /* generator3 possible collectors set to these 3:
+      coll1 (Status=Running) -> currGenerator (1), possible generators(2)
+      coll2 (Status=Running) -> currGenerator (1), possible generators(1)
+      coll4 (Status=Stopped) -> currGenerator (0), possible generators(1)
+      generator3 should be assigned to coll2 (breaking ties with coll1)
+      */
+      .then(() => generator3.updateWithCollectors({
+        isActive: true,
+        possibleCollectors: [coll1.name, coll2.name, coll4.name],
+      }))
+      .then(() => {
+        expect(generator1.currentCollector.name).to.equal(collector1.name);
+        expect(generator2.currentCollector.name).to.equal(collector2.name);
+
+        // gen3 assigned to coll2
+        expect(generator3.currentCollector.name).to.equal(collector2.name);
+        expect(generator3.currentCollector.id).to.equal(collector2.id);
       })
     );
   });


### PR DESCRIPTION
Implement this by changing the assignment logic in Generator.assignToCollector:
Out of all the possible collectors that are running and alive, find the one with the fewest number of currently assigned generators. Break ties based on the number of possible generators each collector has.
@jgraff2 I did not go through raw sql query route because its not always that we are going to db to get info, we go to db only when we do not have currentGenerators or possibleGenerators on collector object.