### PR TITLE
Sample generator api : collectorGroup attribute

### DIFF
--- a/api/v1/controllers/generators.js
+++ b/api/v1/controllers/generators.js
@@ -225,6 +225,8 @@ module.exports = {
       instance.possibleCollectors = _collectors;
       return instance.setPossibleCollectors(_collectors);
     })
+    .then(() => helper.model.validateCollectorGroup(toPut.collectorGroup))
+    .then((_collGroup) => instance.setCollectorGroup(_collGroup))
     .then(() => u.updateInstance(instance, puttableFields, toPut))
     .then(() => instance.reload())
     .then((retVal) =>

--- a/api/v1/helpers/nouns/generators.js
+++ b/api/v1/helpers/nouns/generators.js
@@ -64,6 +64,7 @@ module.exports = {
     user: 'user',
     possibleCollectors: 'possibleCollectors',
     currentCollector: 'currentCollector',
+    collectorGroup: 'collectorGroup',
   },
 
   /*

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -4083,6 +4083,9 @@ paths:
                  type: array
                  items:
                    type: string
+              collectorGroup:
+                 description: Name of set of collectors this Sample Generator should try to use.
+                 type: string
               aspects:
                 description: List of one or more Aspects you want to collect Samples for.
                 type: array
@@ -4255,6 +4258,9 @@ paths:
                 type: array
                 items:
                   type: string
+              collectorGroup:
+                 description: Name of set of collectors this Sample Generator should try to use.
+                 type: string
               isActive:
                 type: boolean
                 description: >-
@@ -4377,6 +4383,9 @@ paths:
                 type: array
                 items:
                   type: string
+              collectorGroup:
+                 description: Name of set of collectors this Sample Generator should try to use.
+                 type: string
               isActive:
                 type: boolean
                 description: >-
@@ -13229,6 +13238,9 @@ definitions:
         type: array
         items:
           type: object
+      collectorGroup:
+         description: Specifies et of collectors this Sample Generator should try to use.
+         type: object
       aspects:
         description: Names of the aspects.
         type: array
@@ -13310,6 +13322,9 @@ definitions:
         type: array
         items:
           type: object
+      collectorGroup:
+         description: Specifies set of collectors this Sample Generator should try to use.
+         type: object
       aspects:
         description: Array of aspects.
         type: array
@@ -13678,6 +13693,7 @@ parameters:
         - currentCollector
         - user
         - possibleCollectors
+        - collectorGroup
 
   GeneratorTemplateFieldsParam:
     name: fields

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -13239,7 +13239,7 @@ definitions:
         items:
           type: object
       collectorGroup:
-         description: Specifies et of collectors this Sample Generator should try to use.
+         description: Specifies set of collectors this Sample Generator should try to use.
          type: object
       aspects:
         description: Names of the aspects.

--- a/db/helpers/generatorUtil.js
+++ b/db/helpers/generatorUtil.js
@@ -173,6 +173,37 @@ function validateCollectors(seq, collectorNames) {
 }
 
 /**
+ * Used by db model.
+ * Validate the collectorGroup name field: if succeed, return a promise with
+ * the collectorGroup.
+ * If fail, reject Promise with the appropriate error
+ *
+ * @param {Object} seq the Sequelize object
+ * @param {String} collectorGroup name
+ * @returns {Promise} with collectorGroup if validation pass,
+ * rejected promise with the appropriate error otherwise.
+ */
+function validateCollectorGroup(seq, collectorGroupName) {
+  if (!collectorGroupName) {
+    return Promise.resolve(null);
+  }
+
+  return new seq.Promise((resolve, reject) =>
+    seq.models.CollectorGroup.findOne({ where: { name: collectorGroupName } })
+    .then((_cg) => {
+      if (_cg) {
+        resolve(_cg);
+      }
+
+      const err = new dbErrors.ResourceNotFoundError();
+      err.resourceType = 'CollectorGroup';
+      err.resourceKey = collectorGroupName;
+      reject(err);
+    })
+  );
+}
+
+/**
  * Returns a where clause object that uses the "IN" operator
  * @param  {Array} arr - An array that needs to be assigned to the "IN" operator
  * @returns {Object} - An where clause object
@@ -190,4 +221,5 @@ module.exports = {
   validateCollectors,
   validateGeneratorCtx,
   validateSubjectQuery,
+  validateCollectorGroup,
 };

--- a/db/model/collectorgroup.js
+++ b/db/model/collectorgroup.js
@@ -87,6 +87,12 @@ module.exports = function collectorgroup(seq, dataTypes) {
     });
 
     CollectorGroup.addScope('defaultScope', {
+      include: [
+        {
+          model: models.Collector.scope('embed'),
+          as: 'collectors',
+        },
+      ],
       order: ['name'],
     }, { override: true });
   };

--- a/tests/api/v1/generators/patchWithCollector.js
+++ b/tests/api/v1/generators/patchWithCollector.js
@@ -133,6 +133,32 @@ describe('tests/api/v1/generators/patchWithCollector.js >', () => {
     });
   });
 
+  it('ok: PATCH collectorGroup', (done) => {
+    const cgObj = { name: `${tu.namePrefix}-cg1`, description: 'test' };
+    tu.db.CollectorGroup.create(cgObj)
+    .then((cg) => cg.addCollector(collector1))
+    .then(() => {
+      api.patch(`${path}/${generatorId}`)
+      .set('Authorization', token)
+      .send({ collectorGroup: cgObj.name })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        const { collectorGroup } = res.body;
+        expect(collectorGroup.name).to.equal(cgObj.name);
+        expect(collectorGroup.description).to.equal(cgObj.description);
+        expect(collectorGroup.collectors.length).to.equal(ONE);
+        expect(collectorGroup.collectors[0].name).to.equal(collector1.name);
+        expect(collectorGroup.collectors[0].status).to.equal(collector1.status);
+        done();
+      });
+    })
+    .catch(done);
+  });
+
   it('400 error with duplicate collectors in request body', (done) => {
     const _collectors = [collector1.name, collector1.name];
     api.patch(`${path}/${generatorId}`)

--- a/tests/api/v1/generators/utils.js
+++ b/tests/api/v1/generators/utils.js
@@ -72,6 +72,7 @@ module.exports = {
   forceDelete(done) {
     tu.forceDelete(tu.db.Generator, testStartTime)
     .then(() => tu.forceDelete(tu.db.Collector, testStartTime))
+    .then(() => tu.forceDelete(tu.db.CollectorGroup, testStartTime))
     .then(() => tu.forceDelete(tu.db.User, testStartTime))
     .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
     .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))


### PR DESCRIPTION
Basic Sample Generator api functionality working with collectorGroup attribute.
- Swagger changes
- Updated collectorGroup default scope to return collectors as well
- Updated generator default scope to include collectorGroup
- post/pu/patch accepts collectorGroup attribute
- GET generator returns collectorGroup object (containing collectors info just like possibleCollectors)
- Corresponding tests
- **Does not include detailed collector assignment functionality (see comment on story for details)**