### PR TITLE
Configure landing page url

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,11 +237,13 @@ function start(clusterProcessId = 0) { // eslint-disable-line max-statements
     app.use(helmet.noSniff());
 
     /*
-     * Redirect '/' to the application landing page, which right now is the
-     * default perspective (or the first perspective in alphabetical order if
-     * no perspective is defined as the default).
+     * Redirect '/' to the application landing page, which is the environment
+     * variable `LANDING_PAGE_URL` if it is defined. If it is not defined then
+     * use the default perspective (or the first perspective in alphabetical
+     * order if no perspective is defined as the default).
      */
-    app.get('/', (req, res) => res.redirect('/perspectives'));
+    app.get('/', (req, res) =>
+      res.redirect(process.env.LANDING_PAGE_URL || '/perspectives'));
 
     // Set the JSON payload limit.
     app.use(bodyParser.json({ limit: conf.payloadLimit }));

--- a/tests/api/v1/index/v1index.js
+++ b/tests/api/v1/index/v1index.js
@@ -78,10 +78,22 @@ describe('tests/api/v1/index/v1index.js >', () => {
   });
 
   describe('/ >', () => {
+    afterEach(() => {
+      delete process.env.LANDING_PAGE_URL;
+    });
+
     it('/ should redirect to /perspectives', (done) => {
       api.get('/')
       .expect((res) => expect(res.redirect).to.be.true)
       .expect((res) => expect(res.header.location).to.contain('/perspectives'))
+      .end(done);
+    });
+
+    it('/ should redirect to /rooms if LANDING_PAGE_URL is set', (done) => {
+      process.env.LANDING_PAGE_URL = '/rooms';
+      api.get('/')
+      .expect((res) => expect(res.redirect).to.be.true)
+      .expect((res) => expect(res.header.location).to.contain('/rooms'))
       .end(done);
     });
   });


### PR DESCRIPTION
- If process.env.LANDING_PAGE_URL is defined then redirect to that endpoint, otherwise use default /perspectives