### PR TITLE
increased the length of related link name from 25 to 60 chars

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -11460,7 +11460,7 @@ definitions:
     properties:
       name:
         type: string
-        maxLength: 25
+        maxLength: 60
         readOnly: true
         description: >
           Name of the related link.
@@ -11481,8 +11481,8 @@ definitions:
       name:
         type: string
         minLength: 1
-        maxLength: 25
-        pattern: ^[0-9A-Za-z_\\ -]{1,25}$
+        maxLength: 60
+        pattern: ^[0-9A-Za-z_\\ -]{1,60}$
         description: >
           Name of the related link.
       url:

--- a/tests/api/v1/subjects/postRelatedLinks.js
+++ b/tests/api/v1/subjects/postRelatedLinks.js
@@ -38,7 +38,7 @@ describe(`tests/api/v1/subjects/postRelatedLinks.js, POST ${path} >`, () => {
   it('post subject with relatedLinks', (done) => {
     const subjectToPost = { name: `${tu.namePrefix}NorthAmerica` };
     const relatedLinks = [
-      { name: 'link1', url: 'https://samples.com' },
+      { name: 'refocuslinknametotestcharacterlength', url: 'https://samples.com' },
       { name: 'link2', url: 'https://samples.com' },
     ];
     subjectToPost.relatedLinks = relatedLinks;


### PR DESCRIPTION
@iamigo Can you please review and merge this change.
