### PR TITLE
Removing skip on bot API test

### DIFF
--- a/tests/api/v1/bots/delete.js
+++ b/tests/api/v1/bots/delete.js
@@ -21,18 +21,20 @@ const tu = require('../../../testUtils');
 describe('tests/api/v1/bots/delete.js >', () => {
   let testBot;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   before((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newBot) => {
       testBot = newBot;
       done();

--- a/tests/api/v1/bots/deleteWithoutPerms.js
+++ b/tests/api/v1/bots/deleteWithoutPerms.js
@@ -45,7 +45,7 @@ describe('tests/api/v1/bots/patchWithoutPerms.js >', () => {
     User.findOne({ where: { name: pfx + 'myUniqueValidUser' } })
     .then((usr) => {
       user = usr;
-      return u.createStandard();
+      return u.createStandard(user.id);
     })
     .then((newBot) => {
       testBot = newBot;

--- a/tests/api/v1/bots/get.js
+++ b/tests/api/v1/bots/get.js
@@ -27,18 +27,20 @@ const uiBlob = fs.readFileSync(paths.join(__dirname, './uiBlob'));
 describe('tests/api/v1/bots/get.js >', () => {
   let testBot;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   beforeEach((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newBot) => {
       testBot = newBot;
       done();
@@ -130,7 +132,7 @@ describe('tests/api/v1/bots/get.js >', () => {
   });
 
   /* TODO IMC please fix this test */
-  it.skip('Pass, get by id', (done) => {
+  it('Pass, get by id', (done) => {
     api.get(`${path}/${testBot.id}`)
     .set('Authorization', token)
     .expect(constants.httpStatus.OK)
@@ -144,6 +146,7 @@ describe('tests/api/v1/bots/get.js >', () => {
       expect(res.body.helpUrl).to.equal(u.standard.helpUrl);
       expect(res.body.ownerUrl).to.equal(u.standard.ownerUrl);
       expect(res.body.ui.data.length).to.equal(uiBlob.length);
+      expect(res.body.installedBy).to.equal(userId);
       return done();
     });
   });

--- a/tests/api/v1/bots/get.js
+++ b/tests/api/v1/bots/get.js
@@ -131,7 +131,6 @@ describe('tests/api/v1/bots/get.js >', () => {
     .catch(done);
   });
 
-  /* TODO IMC please fix this test */
   it('Pass, get by id', (done) => {
     api.get(`${path}/${testBot.id}`)
     .set('Authorization', token)

--- a/tests/api/v1/bots/get.js
+++ b/tests/api/v1/bots/get.js
@@ -45,7 +45,7 @@ describe('tests/api/v1/bots/get.js >', () => {
       testBot = newBot;
       done();
     })
-    .catch(done);
+    .catch((err) => console.log('aaaaaaaaaaaabbbbbbbb' + err));
   });
 
   afterEach(u.forceDelete);

--- a/tests/api/v1/bots/heartbeat.js
+++ b/tests/api/v1/bots/heartbeat.js
@@ -22,23 +22,25 @@ const tu = require('../../../testUtils');
 describe('tests/api/v1/bots/heartbeat.js >', () => {
   let testBot;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   beforeEach((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newBot) => {
       testBot = newBot;
       done();
     })
-    .catch(done);
+    .catch((err) => console.log("qqqqzzzzz" + err));
   });
 
   afterEach(u.forceDelete);

--- a/tests/api/v1/bots/heartbeat.js
+++ b/tests/api/v1/bots/heartbeat.js
@@ -40,7 +40,7 @@ describe('tests/api/v1/bots/heartbeat.js >', () => {
       testBot = newBot;
       done();
     })
-    .catch((err) => console.log("qqqqzzzzz" + err));
+    .catch(done);
   });
 
   afterEach(u.forceDelete);

--- a/tests/api/v1/bots/patch.js
+++ b/tests/api/v1/bots/patch.js
@@ -22,18 +22,20 @@ const tu = require('../../../testUtils');
 describe('tests/api/v1/bots/patch.js >', () => {
   let testBot;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   beforeEach((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newBot) => {
       testBot = newBot;
       done();

--- a/tests/api/v1/bots/patchWithoutPerms.js
+++ b/tests/api/v1/bots/patchWithoutPerms.js
@@ -45,7 +45,7 @@ describe('tests/api/v1/bots/patchWithoutPerms.js >', () => {
     User.findOne({ where: { name: pfx + 'myUniqueValidUser' } })
     .then((usr) => {
       user = usr;
-      return u.createStandard();
+      return u.createStandard(user.id);
     })
     .then((newBot) => {
       testBot = newBot;

--- a/tests/api/v1/bots/post.js
+++ b/tests/api/v1/bots/post.js
@@ -22,11 +22,13 @@ const jwtUtil = require('../../../../utils/jwtUtil');
 
 describe('tests/api/v1/bots/post.js >', () => {
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
@@ -69,7 +71,7 @@ describe('tests/api/v1/bots/post.js >', () => {
   });
 
   it('Fail, duplicate bot', (done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then(() => {
       api.post(`${path}`)
       .set('Authorization', token)

--- a/tests/api/v1/bots/put.js
+++ b/tests/api/v1/bots/put.js
@@ -25,18 +25,20 @@ const uiBlob2 = fs.readFileSync(paths.join(__dirname, './uiBlob2'));
 describe('tests/api/v1/bots/put.js >', () => {
   let testBot;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   beforeEach((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newBot) => {
       testBot = newBot;
       done();

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -138,8 +138,10 @@ module.exports = {
     return tu.db.Bot.create(nonActive);
   },
 
-  createStandard() {
-    return tu.db.Bot.create(standard);
+  createStandard(userId) {
+    const standardBot = standard;
+    if (userId) standardBot.installedBy = userId;
+    return tu.db.Bot.create(standardBot);
   },
 
   forceDelete(done) {

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -140,9 +140,7 @@ module.exports = {
 
   createStandard(userId) {
     const standardBot = standard;
-    if (userId) {
-      standardBot.installedBy = userId;
-    }
+    standardBot.installedBy = userId;
     return tu.db.Bot.create(standardBot);
   },
 

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -141,18 +141,14 @@ module.exports = {
   createStandard(userId) {
     const standardBot = standard;
     if (userId) {
-      console.log("QQQWWWEEE")
-      console.log(userId)
       standardBot.installedBy = userId;
     }
-
-    console.log(standard)
-    return tu.db.Bot.create(standard);
+    return tu.db.Bot.create(standardBot);
   },
 
   forceDelete(done) {
     tu.forceDelete(tu.db.Bot, testStartTime)
     .then(() => done())
-    .catch((err) => console.log("ddddeeeee" + err));
+    .catch(done);
   },
 };

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -140,13 +140,19 @@ module.exports = {
 
   createStandard(userId) {
     const standardBot = standard;
-    if (userId) standardBot.installedBy = userId;
-    return tu.db.Bot.create(standardBot);
+    if (userId) {
+      console.log("QQQWWWEEE")
+      console.log(userId)
+      standardBot.installedBy = userId;
+    }
+
+    console.log(standard)
+    return tu.db.Bot.create(standard);
   },
 
   forceDelete(done) {
     tu.forceDelete(tu.db.Bot, testStartTime)
     .then(() => done())
-    .catch(done);
+    .catch((err) => console.log("ddddeeeee" + err));
   },
 };

--- a/tests/api/v1/roomTypes/patch.js
+++ b/tests/api/v1/roomTypes/patch.js
@@ -23,18 +23,20 @@ const bu = require('../bots/utils');
 describe('tests/api/v1/roomTypes/patch.js >', () => {
   let testRoomType;
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
       done();
     })
     .catch(done);
   });
 
   beforeEach((done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then((newRoomType) => {
       testRoomType = newRoomType;
       done();
@@ -63,7 +65,7 @@ describe('tests/api/v1/roomTypes/patch.js >', () => {
   });
 
   it('Pass, patch roomType bots', (done) => {
-    bu.createStandard();
+    bu.createStandard(userId);
     api.patch(`${path}/${testRoomType.name}`)
     .set('Authorization', token)
     .send({ bots: [bu.name] })

--- a/tests/api/v1/roomTypes/post.js
+++ b/tests/api/v1/roomTypes/post.js
@@ -22,14 +22,16 @@ const bu = require('../bots/utils');
 
 describe(`tests/api/v1/roomTypes/post.js >`, () => {
   let token;
+  let userId;
 
   before((done) => {
-    tu.createToken()
-    .then((returnedToken) => {
-      token = returnedToken;
+    tu.createUserAndToken()
+    .then((obj) => {
+      userId = obj.user.id;
+      token = obj.token;
     })
     .then(() => {
-      bu.createStandard();
+      bu.createStandard(userId);
       done();
     })
     .catch(done);
@@ -77,7 +79,7 @@ describe(`tests/api/v1/roomTypes/post.js >`, () => {
   });
 
   it('Fail, duplicate roomType', (done) => {
-    u.createStandard()
+    u.createStandard(userId)
     .then(() => {
       api.post(`${path}`)
       .set('Authorization', token)


### PR DESCRIPTION
- This test was failing because we were directly creating a bot in the DB. Because we were directly creating it in the db, there was no installedBy field being inserted (installedBy is usually added to the object at the API layer).

- During the test, the response validation was failing because it was expecting installedBy to be present in the response object.

- Fix was to add this installedBy field when creating it in the DB (this is the same way that the lens tests already do it).