### PR TITLE
Aspect status range validations

### DIFF
--- a/db/dbErrors.js
+++ b/db/dbErrors.js
@@ -139,6 +139,14 @@ errors.create({
   name: 'ReferencedByGenerator',
   parent: this.ValidationError,
 });
+errors.create({
+  scope: exports,
+  code: 10122,
+  status: 400,
+  name: 'InvalidAspectStatusRange',
+  parent: this.ValidationError,
+  defaultMessage: 'Invalid aspect status range.',
+});
 
 // ----------------------------------------------------------------------------
 // Not Found

--- a/db/helpers/aspectUtils.js
+++ b/db/helpers/aspectUtils.js
@@ -19,6 +19,12 @@ const InvalidRangeSizeError = require('../dbErrors').InvalidRangeSizeError;
 const redisOps = require('../../cache/redisOps');
 const publishSample = require('../../realtime/redisPublisher').publishSample;
 const aspSubMapType = redisOps.aspSubMapType;
+const dbErrors = require('../dbErrors');
+const aspValueTypes = {
+  boolean: 'BOOLEAN',
+  numeric: 'NUMERIC',
+  percent: 'PERCENT',
+};
 
 /**
  * Confirms that the array is non-null and has two elements.
@@ -157,7 +163,89 @@ function removeAspectRelatedSamples(aspect, seq) {
   });
 } // removeAspectRelatedSamples
 
+/**
+ * Validate status range based on aspect value type
+ * @param  {Array} statusRange  - Status Range
+ * @param  {boolean|numeric|percent} aspValueType - aspect value type
+ * @throws {object} Error InvalidAspectStatusRange if invalid range
+ */
+function validateRange(statusRange, aspValueType) {
+  if (!statusRange) {
+    return; // undefined status range is allowed
+  }
+
+  const statusRangeFirst = statusRange[0];
+  const statusRangeSecond = statusRange[1];
+
+  /*
+  BOOLEAN value type ranges: [0, 0] or [1, 1]
+  NUMERIC value type ranges: Number.MIN_SAFE_INTEGER to Number.MAX_SAFE_INTEGER
+  PERCENT value type ranges: 0 to 100
+   */
+  if (aspValueType === aspValueTypes.boolean) {
+    if (!((statusRangeFirst === 0 && statusRangeSecond === 0) ||
+     (statusRangeFirst === 1 && statusRangeSecond === 1))) {
+      throw new dbErrors.InvalidAspectStatusRange({
+        message: `Value type: ${aspValueTypes.boolean} can only have ` +
+        'ranges: [0,0] or [1,1]',
+      });
+    }
+  } else if (aspValueType === aspValueTypes.numeric) {
+    if (statusRangeFirst < Number.MIN_SAFE_INTEGER ||
+      statusRangeSecond > Number.MAX_SAFE_INTEGER) {
+      throw new dbErrors.InvalidAspectStatusRange({
+        message: `Value type: ${aspValueTypes.numeric} can only have ranges ` +
+        'with min value: -9007199254740991, max value: 9007199254740991',
+      });
+    }
+  } else if (aspValueType === aspValueTypes.percent) {
+    if (statusRangeFirst < 0 || statusRangeSecond > 100) {
+      throw new dbErrors.InvalidAspectStatusRange({
+        message: `Value type: ${aspValueTypes.percent} can only have ranges ` +
+        'with min value: 0, max value: 100',
+      });
+    }
+  }
+}
+
+/**
+ * Validate all the status ranges of an aspect.
+ * @param  {Object} inst - Aspect seq object
+ * @throws {object} Error InvalidAspectStatusRange if any invalid range
+ */
+function validateAspectStatusRanges(inst) {
+  const aspStatusRanges = [
+    inst.criticalRange, inst.warningRange, inst.infoRange, inst.okRange,
+  ];
+
+  // Boolean value type allows only 2 different status ranges: [0,0] or [1,1]
+  if (inst.valueType === aspValueTypes.boolean) {
+    const definedBoolRanges = aspStatusRanges.filter((ar) => ar);
+    if (definedBoolRanges.length > 2) {
+      throw new dbErrors.InvalidAspectStatusRange({
+        message: 'More than 2 status ranges cannot be assigned for value ' +
+        'type: BOOLEAN',
+      });
+    }
+
+    if (definedBoolRanges.length === 2 &&
+      definedBoolRanges[0][0] === definedBoolRanges[1][0] &&
+      definedBoolRanges[0][1] === definedBoolRanges[1][1]) {
+      throw new dbErrors.InvalidAspectStatusRange({
+        message: 'Same value range to multiple statuses is not allowed for ' +
+        'value type: BOOLEAN',
+      });
+    }
+  }
+
+  aspStatusRanges.forEach((aspRange) => {
+    validateRange(aspRange, inst.valueType);
+  });
+}
+
 module.exports = {
   validateStatusRange,
   removeAspectRelatedSamples,
+  aspValueTypes,
+  validateAspectStatusRanges,
 }; // exports

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -111,8 +111,12 @@ module.exports = function aspect(seq, dataTypes) {
       type: dataTypes.STRING(valueLabelLength),
     },
     valueType: {
-      type: dataTypes.ENUM('BOOLEAN', 'NUMERIC', 'PERCENT'),
-      defaultValue: 'BOOLEAN',
+      type: dataTypes.ENUM(
+        u.aspValueTypes.boolean,
+        u.aspValueTypes.numeric,
+        u.aspValueTypes.percent
+      ),
+      defaultValue: u.aspValueTypes.boolean,
     },
     relatedLinks: {
       type: dataTypes.ARRAY(dataTypes.JSON),
@@ -131,7 +135,9 @@ module.exports = function aspect(seq, dataTypes) {
     },
   }, {
     hooks: {
-
+      beforeCreate(inst /* , opts */) {
+        u.validateAspectStatusRanges(inst);
+      }, // hooks.afterCreate
       /**
        * TODO:
        * 1. Have a look at the sampleStore logic and confirm that it is
@@ -189,6 +195,7 @@ module.exports = function aspect(seq, dataTypes) {
        * @returns {Promise}
        */
       beforeUpdate(inst /* , opts */) {
+        u.validateAspectStatusRanges(inst);
         const promiseArr = [];
         const unpublished = inst.previous('isPublished') && !inst.isPublished;
         const renamed = inst.previous('name') !== inst.name;

--- a/tests/api/v1/admin/rebuildSampleStore.js
+++ b/tests/api/v1/admin/rebuildSampleStore.js
@@ -134,7 +134,7 @@ describe('tests/api/v1/admin/rebuildSampleStore.js >', () => {
             isPublished: true,
             name: `${tu.namePrefix}Aspect2`,
             timeout: '10m',
-            valueType: 'BOOLEAN',
+            valueType: 'NUMERIC',
             okRange: [10, 100],
           }))
           .then((created) => (a2 = created))
@@ -142,7 +142,7 @@ describe('tests/api/v1/admin/rebuildSampleStore.js >', () => {
             isPublished: true,
             name: `${tu.namePrefix}Aspect3`,
             timeout: '10m',
-            valueType: 'BOOLEAN',
+            valueType: 'NUMERIC',
             okRange: [10, 100],
           }))
           .then((created) => (a3 = created))

--- a/tests/api/v1/aspects/patch.js
+++ b/tests/api/v1/aspects/patch.js
@@ -730,4 +730,148 @@ describe('tests/api/v1/aspects/patch.js >', () => {
       .end(done);
     });
   });
+
+  describe(`PATCH ${path} status ranges >`, () => {
+    let token;
+    let createdAspectId;
+
+    before((done) => {
+      Aspect.create({
+        name: `${tu.namePrefix}Weight`,
+        timeout: '110s',
+        helpUrl: 'http://abc.com',
+        helpEmail: 'abc@xyz.com',
+      })
+      .then((asp) => {
+        createdAspectId = asp.id;
+        return tu.createToken();
+      })
+      .then((returnedToken) => {
+        token = returnedToken;
+        done();
+      })
+      .catch(done);
+    });
+
+    after(u.forceDelete);
+    after(tu.forceDeleteUser);
+
+    it('OK, valueType=boolean, ranges valid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({ okRange: [1, 1], criticalRange: [0, 0] })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.okRange).to.be.eql([1, 1]);
+        expect(res.body.criticalRange).to.be.eql([0, 0]);
+        return done();
+      });
+    });
+
+    it('not OK, valueType=boolean, ranges invalid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({ okRange: [0, 1], criticalRange: [0, 0] })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: BOOLEAN can only have ranges: [0,0] or [1,1]'
+        );
+        done();
+      });
+    });
+
+    it('OK, valueType=numeric, ranges valid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({
+        okRange: [-50, 1],
+        criticalRange: [30, 90],
+        valueType: 'NUMERIC',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.okRange).to.be.eql([-50, 1]);
+        expect(res.body.criticalRange).to.be.eql([30, 90]);
+        return done();
+      });
+    });
+
+    it('not OK, valueType=numeric, ranges invalid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({
+        okRange: [Number.MIN_SAFE_INTEGER - 50, 1],
+        valueType: 'NUMERIC',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: NUMERIC can only have ranges with min value: ' +
+          '-9007199254740991, max value: 9007199254740991'
+        );
+        done();
+      });
+    });
+
+    it('OK, valueType=percent, ranges valid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({
+        okRange: [1, 50],
+        criticalRange: [50, 90],
+        valueType: 'PERCENT',
+      })
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.okRange).to.be.eql([1, 50]);
+        expect(res.body.criticalRange).to.be.eql([50, 90]);
+        return done();
+      });
+    });
+
+    it('not OK, valueType=percent, ranges invalid', (done) => {
+      api.patch(`${path}/${createdAspectId}`)
+      .set('Authorization', token)
+      .send({
+        okRange: [-20, 1],
+        valueType: 'PERCENT',
+      })
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: PERCENT can only have ranges with min value: ' +
+          '0, max value: 100'
+        );
+        done();
+      });
+    });
+  });
 });

--- a/tests/api/v1/aspects/put.js
+++ b/tests/api/v1/aspects/put.js
@@ -781,4 +781,155 @@ describe('tests/api/v1/aspects/put.js >', () => {
       .end(done);
     });
   });
+
+  describe('status ranges >', () => {
+    let createdAspId;
+
+    before((done) => {
+      tu.createToken()
+      .then((returnedToken) => {
+        token = returnedToken;
+        done();
+      })
+      .catch(done);
+    });
+
+    const aspObj = {
+      name: `${tu.namePrefix}Weight`,
+      timeout: '110s',
+      helpUrl: 'http://abc.com',
+      helpEmail: 'abc@xyz.com',
+    };
+
+    beforeEach((done) => {
+      Aspect.create(aspObj)
+      .then((asp) => {
+        createdAspId = asp.id;
+        done();
+      })
+      .catch(done);
+    });
+
+    it('OK, valueType=boolean, ranges valid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [1, 1];
+      aspectObj.criticalRange = [0, 0];
+      aspectObj.valueType = 'BOOLEAN';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.okRange).to.be.eql([1, 1]);
+        expect(res.body.criticalRange).to.be.eql([0, 0]);
+      })
+      .end(done);
+    });
+
+    it('not OK, valueType=boolean, ranges invalid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [1, 1];
+      aspectObj.criticalRange = [0, 1];
+      aspectObj.valueType = 'BOOLEAN';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: BOOLEAN can only have ranges: [0,0] or [1,1]'
+        );
+        done();
+      });
+    });
+
+    it('OK, valueType=numeric, ranges valid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [-11, 100];
+      aspectObj.criticalRange = [105, 50000];
+      aspectObj.valueType = 'NUMERIC';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.okRange).to.be.eql([-11, 100]);
+        expect(res.body.criticalRange).to.be.eql([105, 50000]);
+      })
+      .end(done);
+    });
+
+    it('not OK, valueType=numeric, ranges invalid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [Number.MIN_SAFE_INTEGER - 50, 100];
+      aspectObj.criticalRange = [105, 50000];
+      aspectObj.valueType = 'NUMERIC';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: NUMERIC can only have ranges with min value: ' +
+          '-9007199254740991, max value: 9007199254740991'
+        );
+        done();
+      });
+    });
+
+    it('OK, valueType=percent, ranges valid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [0, 70];
+      aspectObj.criticalRange = [75, 100];
+      aspectObj.valueType = 'PERCENT';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.okRange).to.be.eql([0, 70]);
+        expect(res.body.criticalRange).to.be.eql([75, 100]);
+      })
+      .end(done);
+    });
+
+    it('not OK, valueType=percent, ranges invalid', (done) => {
+      const aspectObj = JSON.parse(JSON.stringify(aspObj));
+      aspectObj.okRange = [-70, 70];
+      aspectObj.criticalRange = [75, 100];
+      aspectObj.valueType = 'PERCENT';
+
+      api.put(`${path}/${createdAspId}`)
+      .set('Authorization', token)
+      .send(aspectObj)
+      .expect(constants.httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors[0].type).to.equal('InvalidAspectStatusRange');
+        expect(res.body.errors[0].message).to.equal(
+          'Value type: PERCENT can only have ranges with min value: ' +
+          '0, max value: 100'
+        );
+        done();
+      });
+    });
+  });
 });

--- a/tests/api/v1/samples/upsertBulk.js
+++ b/tests/api/v1/samples/upsertBulk.js
@@ -54,7 +54,7 @@ describe(`tests/api/v1/samples/upsertBulk.js, POST ${path} >`, () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect2`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       });
     })

--- a/tests/api/v1/subjects/getHierarchyStatusAndCombinedFilters.js
+++ b/tests/api/v1/subjects/getHierarchyStatusAndCombinedFilters.js
@@ -53,6 +53,7 @@ describe('tests/api/v1/subjects/getHierarchyStatusAndCombinedFilters.js, ' +
   };
   const aspectTemp = {
     criticalRange: [3, 5],
+    valueType: 'NUMERIC',
     name: 'temperature',
     timeout: '60s',
     isPublished: true,

--- a/tests/cache/jobQueue/bulkUpsert.js
+++ b/tests/cache/jobQueue/bulkUpsert.js
@@ -60,7 +60,7 @@ describe('tests/cache/jobQueue/bulkUpsert.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Subject.create({

--- a/tests/cache/jobQueue/getBulkUpsertStatus.js
+++ b/tests/cache/jobQueue/getBulkUpsertStatus.js
@@ -55,7 +55,7 @@ describe('tests/cache/jobQueue/getBulkUpsertStatus.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Subject.create({

--- a/tests/cache/models/aspects/aspectCRUD.js
+++ b/tests/cache/models/aspects/aspectCRUD.js
@@ -471,7 +471,7 @@ describe('tests/cache/models/aspects/aspectCRUD.js, ' +
     }) // temperature aspect deleted
     .then((a) => {
       aspectName = a.name;
-      return a.update({ okRange: [0, 10] });
+      return a.update({ okRange: [0, 0] });
     })
     .then(() => rcli.smembersAsync(sampleIndexName))
     .then((members) => {

--- a/tests/cache/models/redisTestUtil.js
+++ b/tests/cache/models/redisTestUtil.js
@@ -45,7 +45,7 @@ module.exports = {
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((created) => (a2 = created))

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -74,7 +74,7 @@ describe('tests/cache/models/samples/get.js, ' +
         isPublished: true,
         name: `${tu.namePrefix}Aspect2`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a2 = created))

--- a/tests/cache/models/samples/upsertBulk.js
+++ b/tests/cache/models/samples/upsertBulk.js
@@ -54,7 +54,7 @@ describe('tests/cache/models/samples/upsertBulk.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((aspectTwo) => Subject.create({

--- a/tests/cache/models/samples/upsertBulkConcurrent.js
+++ b/tests/cache/models/samples/upsertBulkConcurrent.js
@@ -47,21 +47,21 @@ describe('tests/cache/models/samples/upsertBulkConcurrent.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Aspect.create({
       isPublished: true,
       name: `${tu.namePrefix}Aspect3`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Aspect.create({
       isPublished: true,
       name: `${tu.namePrefix}Aspect4`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Subject.create({

--- a/tests/cache/models/samples/upsertBulkWithprovider.js
+++ b/tests/cache/models/samples/upsertBulkWithprovider.js
@@ -56,7 +56,7 @@ describe('tests/cache/models/samples/upsertBulkWithprovider.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((aspectTwo) => Subject.create({

--- a/tests/cache/models/samples/utils.js
+++ b/tests/cache/models/samples/utils.js
@@ -20,6 +20,7 @@ const aspectToCreate = {
   isPublished: true,
   name: aspectName,
   timeout: '30s',
+  valueType: 'NUMERIC',
   criticalRange: [0, 1],
   warningRange: [2, 3],
   infoRange: [4, 5],

--- a/tests/cache/persist.js
+++ b/tests/cache/persist.js
@@ -50,7 +50,7 @@ describe('tests/cache/persist.js, persist sample store back to db >', () => {
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((created) => (a2 = created))
@@ -58,7 +58,7 @@ describe('tests/cache/persist.js, persist sample store back to db >', () => {
       isPublished: true,
       name: `${tu.namePrefix}Aspect3`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((created) => (a3 = created))

--- a/tests/cache/redisOps.js
+++ b/tests/cache/redisOps.js
@@ -49,7 +49,7 @@ describe('tests/cache/redisOps >', () => {
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((created) => (a2 = created))
@@ -57,7 +57,7 @@ describe('tests/cache/redisOps >', () => {
       isPublished: true,
       name: `${tu.namePrefix}Aspect3`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then((created) => (a3 = created))

--- a/tests/cache/sampleStore.js
+++ b/tests/cache/sampleStore.js
@@ -75,7 +75,7 @@ describe('tests/cache/sampleStore.js >', () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect2`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a2 = created))
@@ -83,7 +83,7 @@ describe('tests/cache/sampleStore.js >', () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect3`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a3 = created))
@@ -91,7 +91,7 @@ describe('tests/cache/sampleStore.js >', () => {
         isPublished: false, // unpublished aspect should still be found
         name: `${tu.namePrefix}Aspect4`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a4 = created))

--- a/tests/cache/sampleStoreFlagFlipFlop.js
+++ b/tests/cache/sampleStoreFlagFlipFlop.js
@@ -65,7 +65,7 @@ describe('tests/cache/sampleStoreFlagFlipFlop.js >', () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect2`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a2 = created))
@@ -73,7 +73,7 @@ describe('tests/cache/sampleStoreFlagFlipFlop.js >', () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect3`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a3 = created))
@@ -81,7 +81,7 @@ describe('tests/cache/sampleStoreFlagFlipFlop.js >', () => {
         isPublished: false,
         name: `${tu.namePrefix}Aspect4`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then((created) => (a4 = created))

--- a/tests/db/helpers/aspectUtils.js
+++ b/tests/db/helpers/aspectUtils.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/db/helpers/aspectUtils.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const tu = require('../../testUtils');
+const u = require('../model/aspect/utils');
+const aspectUtils = require('../../../db/helpers/aspectUtils');
+const Aspect = tu.db.Aspect;
+
+/**
+ * aspect json object
+ * @return {Object} aspect json object
+ */
+function getAspectJson() {
+  return JSON.parse(JSON.stringify({
+    name: `${tu.namePrefix}TestAspect`,
+    description: 'This is an awesome aspect I\'m testing here',
+    helpEmail: 'jolson@dailyplanet.com',
+    helpUrl: 'http://www.dailyplanet.com',
+    isPublished: true,
+    timeout: '10m',
+    valueLabel: 'ms',
+    valueType: aspectUtils.aspValueTypes.boolean,
+  }));
+}
+
+describe('tests/db/model/aspect/aspectUtils.js >', () => {
+  afterEach(u.forceDelete);
+
+  describe('validateAspectStatusRanges >', () => {
+    it('ok, aspect valueType=boolean, valid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [0, 0];
+      aspToCreate.okRange = [1, 1];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.boolean;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('not ok, aspect valueType=boolean, duplicate status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [0, 0];
+      aspToCreate.okRange = [0, 0];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.boolean;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done('Expecting error');
+      } catch (err) {
+        const msg = 'Same value range to multiple statuses is not allowed for ' +
+        'value type: BOOLEAN';
+        expect(err.name).to.be.equal('InvalidAspectStatusRange');
+        expect(err.message).to.be.equal(msg);
+        done();
+      }
+    });
+
+    it('not ok, aspect valueType=boolean, >2 status set', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [1, 1];
+      aspToCreate.okRange = [0, 0];
+      aspToCreate.infoRange = [1, 1];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.boolean;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done('Expecting error');
+      } catch (err) {
+        const msg = 'More than 2 status ranges cannot be assigned for value ' +
+        'type: BOOLEAN';
+        expect(err.name).to.be.equal('InvalidAspectStatusRange');
+        expect(err.message).to.be.equal(msg);
+        done();
+      }
+    });
+
+    it('not ok, aspect valueType=boolean, invalid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [1, 0];
+      aspToCreate.okRange = [0, 0];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.boolean;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done('Expecting error');
+      } catch (err) {
+        const msg = 'Value type: BOOLEAN can only have ranges: [0,0] or [1,1]';
+        expect(err.name).to.be.equal('InvalidAspectStatusRange');
+        expect(err.message).to.be.equal(msg);
+        done();
+      }
+    });
+
+    it('ok, aspect valueType=numeric, valid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [-1234, -123];
+      aspToCreate.warningRange = [-122, 0];
+      aspToCreate.infoRange = [0, 5678];
+      aspToCreate.okRange = [5679, 56789];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.numeric;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('ok, aspect valueType=numeric, some statuses undefined', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [-1234, -123];
+      aspToCreate.warningRange = [-122, 0];
+      delete aspToCreate.infoRange;
+      delete aspToCreate.okRange;
+      aspToCreate.valueType = aspectUtils.aspValueTypes.numeric;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('ok, aspect valueType=numeric, same/overlapping statuses', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [-1234, -123];
+      aspToCreate.warningRange = [-1234, -123];
+      aspToCreate.infoRange = [0, 5678];
+      aspToCreate.okRange = [5678, 56789];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.numeric;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('not ok, aspect valueType=numeric, invalid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [Number.MIN_SAFE_INTEGER - 5, -123];
+      aspToCreate.warningRange = [-122, 0];
+      aspToCreate.infoRange = [0, 5678];
+      aspToCreate.okRange = [5678, Number.MAX_SAFE_INTEGER + 10];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.numeric;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done('Expecting error');
+      } catch (err) {
+        const msg = 'Value type: NUMERIC can only have ranges with ' +
+        'min value: -9007199254740991, max value: 9007199254740991';
+        expect(err.name).to.be.equal('InvalidAspectStatusRange');
+        expect(err.message).to.be.equal(msg);
+        done();
+      }
+    });
+
+    it('ok, aspect valueType=percent, valid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [0, 20];
+      aspToCreate.warningRange = [21, 40];
+      aspToCreate.infoRange = [41, 50];
+      aspToCreate.okRange = [51, 100];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.percent;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('ok, aspect valueType=percent, some statuses undefined', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [0, 10];
+      aspToCreate.warningRange = [20, 50];
+      delete aspToCreate.infoRange;
+      delete aspToCreate.okRange;
+      aspToCreate.valueType = aspectUtils.aspValueTypes.percent;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('ok, aspect valueType=percent, same/overlapping statuses', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [0, 60];
+      aspToCreate.okRange = [50, 80];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.percent;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    it('not ok, aspect valueType=percent, invalid status ranges', (done) => {
+      const aspToCreate = getAspectJson();
+      aspToCreate.criticalRange = [-1, 1];
+      aspToCreate.okRange = [0, 110];
+      aspToCreate.valueType = aspectUtils.aspValueTypes.percent;
+
+      const aspInst = Aspect.build(aspToCreate);
+      try {
+        aspectUtils.validateAspectStatusRanges(aspInst);
+        done('Expecting error');
+      } catch (err) {
+        const msg = 'Value type: PERCENT can only have ranges with ' +
+        'min value: 0, max value: 100';
+        expect(err.name).to.be.equal('InvalidAspectStatusRange');
+        expect(err.message).to.be.equal(msg);
+        done();
+      }
+    });
+  });
+});

--- a/tests/db/model/aspect/create.js
+++ b/tests/db/model/aspect/create.js
@@ -1219,6 +1219,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two ascending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.criticalRange = [100, 1000];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.criticalRange, 2) &&
@@ -1235,6 +1236,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two equal numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.criticalRange = [3.1415927, 3.1415927];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.criticalRange, 2) &&
@@ -1251,6 +1253,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two descending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.criticalRange = [99, 98];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then(() => done(tu.valError))
         .catch((err) => {
@@ -1455,6 +1458,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two ascending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.warningRange = [100, 1000];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.warningRange, 2) &&
@@ -1471,6 +1475,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two equal numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.warningRange = [3.1415927, 3.1415927];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.warningRange, 2) &&
@@ -1487,6 +1492,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two descending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.warningRange = [99, 98];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then(() => done(tu.valError))
         .catch((err) => {
@@ -1687,6 +1693,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two ascending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.infoRange = [100, 1000];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.infoRange, 2) &&
@@ -1703,6 +1710,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two equal numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.infoRange = [3.1415927, 3.1415927];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.infoRange, 2) &&
@@ -1719,6 +1727,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two descending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.infoRange = [99, 98];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then(() => done(tu.valError))
         .catch((err) => {
@@ -1911,6 +1920,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two ascending numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.okRange = [100, 1000];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.okRange, 2) &&
@@ -1927,6 +1937,7 @@ describe('tests/db/model/aspect/create.js >', () => {
       it('provide an array with two equal numeric elements', (done) => {
         const toCreate = u.getSmall();
         toCreate.okRange = [3.1415927, 3.1415927];
+        toCreate.valueType = 'NUMERIC';
         Aspect.create(toCreate)
         .then((o) => {
           if (tu.gotArrayWithExpectedLength(o.okRange, 2) &&

--- a/tests/db/model/aspect/utils.js
+++ b/tests/db/model/aspect/utils.js
@@ -34,7 +34,7 @@ const medium = {
   okRange: [3, 4],
   timeout: '10m',
   valueLabel: 'ms',
-  valueType: 'BOOLEAN',
+  valueType: 'NUMERIC',
 };
 
 module.exports = {

--- a/tests/db/model/sample/statusCalculation.js
+++ b/tests/db/model/sample/statusCalculation.js
@@ -536,9 +536,9 @@ describe('tests/db/model/sample/statusCalculation.js >', () => {
     describe('infinite ranges >', () => {
       before((done) => {
         setupRanges({
-          criticalRange: [-Infinity, -1],
+          criticalRange: [Number.MIN_SAFE_INTEGER, -1],
           warningRange: [0, 0],
-          infoRange: [1, Infinity],
+          infoRange: [1, Number.MAX_SAFE_INTEGER],
           okRange: null,
         })
         .then(() => done())

--- a/tests/db/model/sample/upsertBulk.js
+++ b/tests/db/model/sample/upsertBulk.js
@@ -37,7 +37,7 @@ describe('tests/db/model/sample/upsertBulk.js >', () => {
         isPublished: true,
         name: `${tu.namePrefix}Aspect2`,
         timeout: '10m',
-        valueType: 'BOOLEAN',
+        valueType: 'NUMERIC',
         okRange: [10, 100],
       }))
       .then(() => Subject.create({

--- a/tests/jobQueue/v1/bulkUpsert.js
+++ b/tests/jobQueue/v1/bulkUpsert.js
@@ -58,7 +58,7 @@ describe('tests/jobQueue/v1/bulkUpsert.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Subject.create({

--- a/tests/jobQueue/v1/getBulkUpsertStatus.js
+++ b/tests/jobQueue/v1/getBulkUpsertStatus.js
@@ -54,7 +54,7 @@ describe('tests/jobQueue/v1/getBulkUpsertStatus.js, ' +
       isPublished: true,
       name: `${tu.namePrefix}Aspect2`,
       timeout: '10m',
-      valueType: 'BOOLEAN',
+      valueType: 'NUMERIC',
       okRange: [10, 100],
     }))
     .then(() => Subject.create({

--- a/tests/realtime/realtimeUtils.js
+++ b/tests/realtime/realtimeUtils.js
@@ -48,6 +48,7 @@ describe('tests/realtime/realtimeUtils.js, realtime utils Tests >', () => {
     name: tu.namePrefix + 'temperature',
     timeout: '30s',
     okRange: [1, 5],
+    valueType: 'NUMERIC',
     isPublished: true,
     tags: ['temp'],
   };


### PR DESCRIPTION
If valueType is *BOOLEAN*: - the only valid range values are [0,0] or [1,1], e.g. reject this as invalid { "criticalRange": [0,1] } - you cannot specify the same range of values to more than one status, e.g. reject this as invalid { "criticalRange": [0,0], "warningRange": [0,0] } The combination of the two rules above also means you can *only* specify status assignment for zero to two ranges.

 If valueType is *PERCENT*: - the min/max values allowed to be specified for any of the ranges are 0.00 to 100.00 (inclusive). e.g. reject this as invalid { "infoRange": [-1,1] }, reject this as invalid { "criticalRange": [0, 110] } 

If valueType is *NUMERIC*: - the min value allowed is javascript Number.MIN_SAFE_INTEGER (-(253 - 1)), i.e. -9007199254740991 - the max value allowed is javascript Number.MAX_SAFE_INTEGER (253 - 1), i.e. 9007199254740991

Provided meaningful error messages for validation failures (esp. when the validation error comes from the relationship between two or more attributes).

Added tests
