### PR TITLE
patch collector group

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -11300,53 +11300,6 @@ paths:
           $ref: "#/responses/404"
         default:
           $ref: "#/responses/genericError"
-
-  /collectorGroups/{key}/collectors:
-    x-swagger-router-controller: collectorGroups
-    post:
-      security:
-        - jwt: []
-      summary: Add a collector to the group
-      tags: [ collectorGroups ]
-      description: >-
-        Add a collector to the group if any collector named in the array isn't already in the list or isn't already
-        assigned to a different group.
-      operationId: addCollectorsToGroup
-      parameters:
-        - name: key
-          in: path
-          description: >-
-            The name of the collector group.
-          required: true
-          type: string
-        - name: queryBody
-          description: Request body.
-          in: body
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-            minItems: 1
-            uniqueItems: true
-            description: >-
-              List of collector names
-      responses:
-        200:
-          description: >-
-            One or more collectors were added to the group.
-          schema:
-            $ref: "#/definitions/CollectorGroupsResponse"
-        400:
-          $ref: "#/responses/400"
-        401:
-          $ref: "#/responses/401"
-        403:
-          $ref: "#/responses/403"
-        404:
-          $ref: "#/responses/404"
-        default:
-          $ref: "#/responses/genericError"
     patch:
       security:
         - jwt: []
@@ -11355,7 +11308,7 @@ paths:
       description: >-
         Update the specified fields. If patching the list of collectors, it will replace the current list.
         It will update if all collectors named in the array aren't already assigned to a different group.
-      operationId: patchCollectorGroups
+      operationId: patchCollectorGroup
       parameters:
         - name: key
           in: path
@@ -11409,7 +11362,7 @@ paths:
       description: >-
         Update all fields, replacing any existing values, and if a field is not provided, it resets to default
         (e.g. empty array of collectors, empty description).
-      operationId: putCollectorGroups
+      operationId: putCollectorGroup
       parameters:
         - name: key
           in: path
@@ -11451,6 +11404,53 @@ paths:
           $ref: "#/responses/401"
         403:
           $ref: "#/responses/404"
+        404:
+          $ref: "#/responses/404"
+        default:
+          $ref: "#/responses/genericError"
+
+  /collectorGroups/{key}/collectors:
+    x-swagger-router-controller: collectorGroups
+    post:
+      security:
+        - jwt: []
+      summary: Add a collector to the group
+      tags: [ collectorGroups ]
+      description: >-
+        Add a collector to the group if any collector named in the array isn't already in the list or isn't already
+        assigned to a different group.
+      operationId: addCollectorsToGroup
+      parameters:
+        - name: key
+          in: path
+          description: >-
+            The name of the collector group.
+          required: true
+          type: string
+        - name: queryBody
+          description: Request body.
+          in: body
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+            minItems: 1
+            uniqueItems: true
+            description: >-
+              List of collector names
+      responses:
+        200:
+          description: >-
+            One or more collectors were added to the group.
+          schema:
+            $ref: "#/definitions/CollectorGroupsResponse"
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
         404:
           $ref: "#/responses/404"
         default:

--- a/db/model/collectorgroup.js
+++ b/db/model/collectorgroup.js
@@ -179,6 +179,21 @@ module.exports = function collectorgroup(seq, dataTypes) {
   }; // addCollectorsToGroup
 
   /**
+   * Set the named collectors to this collector group. Reject if any of the
+   * named collectors is already assigned to this group, or to a different
+   * group.
+   *
+   * @param {Array<String>} arr - array of collector names
+   * @returns {Promise<any | never>}
+   */
+  CollectorGroup.prototype.patchCollectors = function (arr) {
+    return collectorUtils.validate(seq, arr)
+      .then(collectorUtils.alreadyAssigned)
+      .then((collectors) => this.setCollectors(collectors))
+      .then(() => this.reload());
+  }; // patchCollectors
+
+  /**
    * Delete the named collectors from this collector group. Reject if any of
    * the named collectors are not already assigned to this group, or if the
    * array is empty.

--- a/tests/api/v1/collectorGroups/patch.js
+++ b/tests/api/v1/collectorGroups/patch.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/collectorGroups/update.js
+ */
+'use strict'; // eslint-disable-line strict
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const httpStatus = require('../../../../api/v1/constants').httpStatus;
+const tu = require('../../../testUtils');
+const u = require('./utils');
+const Collector = tu.db.Collector;
+const CollectorGroup = tu.db.CollectorGroup;
+const expect = require('chai').expect;
+
+describe('tests/api/v1/collectorGroups/patch.js >', () => {
+  let user;
+  let token;
+  let token2;
+  let collector1;
+  let collector2;
+  let collector3;
+  let cg = { name: '' };
+
+  before((done) => {
+    tu.createUserAndToken()
+      .then((ut) => {
+        user = ut.user;
+        token = ut.token;
+        return tu.createSecondUser();
+      })
+      .then((user2) => tu.createTokenFromUserName(user2.get('name')))
+      .then((t) => (token2 = t))
+      .then(() => done())
+      .catch(done);
+  });
+
+  beforeEach(() => {
+    collector1 = u.getCollectorToCreate();
+    collector1.name += '1';
+    Collector.create(collector1);
+    collector2 = u.getCollectorToCreate();
+    collector2.name += '2';
+    Collector.create(collector2);
+    collector3 = u.getCollectorToCreate();
+    collector3.name += '3';
+    Collector.create(collector3);
+  });
+
+  beforeEach((done) => {
+    CollectorGroup.createCollectorGroup({
+      name: `${tu.namePrefix}cg`,
+      description: 'desc',
+      createdBy: user.id,
+    })
+      .then((created) => {
+        cg = created;
+        done();
+      })
+      .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  after(tu.forceDeleteUser);
+
+  it('patch with empty collector list', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ description: 'new desc', collectors: [] })
+      .expect(httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('description', 'new desc');
+        expect(res.body.collectors).to.be.empty;
+        return done();
+      });
+  });
+
+  it('patch with valid collectors', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({
+        description: 'hi',
+        collectors: [collector1.name, collector2.name],
+      })
+      .expect(httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('name', cg.name);
+        expect(res.body).to.have.property('description', 'hi');
+        expect(res.body.collectors).to.have.lengthOf(2);
+        return done();
+      });
+  });
+
+  it('patch fail if double-assign', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ collectors: [collector1.name] })
+      .expect(httpStatus.OK)
+      .end((err) => {
+        if (err) {
+          return done(err);
+        }
+
+        return api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({ collectors: [collector1.name, collector2.name] })
+          .expect(httpStatus.BAD_REQUEST)
+          .end((_err, _res) => {
+            if (_err) {
+              return done(_err);
+            }
+
+            expect(_res.body.errors).to.have.lengthOf(1);
+            expect(_res.body.errors[0]).to.have.property('message', 'Cannot ' +
+              'double-assign collector(s) [___Coll1] to collector groups');
+            return done();
+          });
+      });
+  });
+
+  it('reject if no write perm', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token2)
+      .send({ description: 'foo', collectors: [collector1.name] })
+      .expect(httpStatus.FORBIDDEN)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors).to.have.lengthOf(1);
+        expect(res.body.errors[0]).to.have.property('type', 'ForbiddenError');
+        done();
+      });
+  });
+});

--- a/tests/db/model/collectorGroup/update.js
+++ b/tests/db/model/collectorGroup/update.js
@@ -183,4 +183,23 @@ describe('tests/db/model/collectorGroup/update.js >', () => {
         done();
       });
   });
+
+  it('patchCollectors replace with empty array', (done) => {
+    collectorGroupDb.patchCollectors([])
+      .then((cg) => {
+        expect(cg.collectors).to.be.empty;
+        return done();
+      })
+      .catch(done);
+  });
+
+  it('patchCollectors replace with non-empty array', (done) => {
+    collectorGroupDb.patchCollectors([collector3.name])
+      .then((cg) => {
+        expect(cg.collectors.length).to.equal(1);
+        expect(cg.collectors[0]).to.have.property('name', collector3.name);
+        return done();
+      })
+      .catch(done);
+  });
 });


### PR DESCRIPTION
for other objects, patch will add items from array attribute to existing but here the value of the array attribute *replaces* existing so we don't use the "standard" doPatch with the array field flagged in the helper