### PR TITLE
Add owner attribute to models

### DIFF
--- a/api/v1/controllers/bots.js
+++ b/api/v1/controllers/bots.js
@@ -144,7 +144,9 @@ module.exports = {
 
       const user = req.user;
       seqObj.installedBy = user.id;
-      helper.model.create(seqObj)
+      u.setOwner(seqObj, req)
+        .then(() => helper.model.create(seqObj))
+        .then((o) => o.reload())
         .then((o) => {
           o.dataValues.ui = uiObj;
           if (featureToggles.isFeatureEnabled('addIsBotToToken')) {
@@ -178,23 +180,26 @@ module.exports = {
     const resultObj = { reqStartTime: req.timestamp };
     const reqObj = req.swagger.params;
     const uiObj = {};
+    const seqObj = {};
     u.findByKey(helper, req.swagger.params)
     .then((o) => u.isWritable(req, o))
     .then((o) => {
       for (const param in reqObj) {
         if (reqObj[param].value) {
           if (param === 'ui') {
-            o.set(param, reqObj[param].value.buffer);
+            seqObj[param] = reqObj[param].value.buffer;
             uiObj.name = reqObj[param].value.originalname;
             uiObj.size = reqObj[param].value.size;
           } else {
-            o.set(param, reqObj[param].value);
+            seqObj[param] = reqObj[param].value;
           }
         }
       }
 
-      return o.save();
+      return u.setOwner(seqObj, req, o);
     })
+    .then((o) => o.update(seqObj))
+    .then((o) => o.reload())
     .then((o) => {
       o.dataValues.ui = uiObj;
       if (featureToggles.isFeatureEnabled('addIsBotToToken')) {
@@ -207,7 +212,7 @@ module.exports = {
 
       resultObj.dbTime = new Date() - resultObj.reqStartTime;
       u.logAPI(req, resultObj, o.dataValues);
-      res.status(httpStatus.CREATED).json(u.responsify(o, helper, req.method));
+      res.status(httpStatus.OK).json(u.responsify(o, helper, req.method));
     })
     .catch((err) => u.handleError(next, err, helper.modelName));
   },

--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -387,7 +387,9 @@ function startCollector(req, res, next) {
   })
 
   /* Update or create. Generators will be assigned in db hooks */
+  .then((coll) => u.setOwner(body, req, coll))
   .then((coll) => coll ? coll.update(body) : helper.model.create(body))
+  .then((coll) => coll.reload())
 
   /* Format assigned generators to send back to collector */
   .then((coll) => {

--- a/api/v1/controllers/generatorTemplates.js
+++ b/api/v1/controllers/generatorTemplates.js
@@ -74,7 +74,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchGeneratorTemplate(req, res, next) {
-    const allowedToPatch = ['isPublished'];
+    const allowedToPatch = ['isPublished', 'owner'];
     const illegal = Object.keys(req.body)
     .filter((f) => !allowedToPatch.includes(f));
     if (illegal.length) {

--- a/api/v1/controllers/generators.js
+++ b/api/v1/controllers/generators.js
@@ -149,6 +149,7 @@ module.exports = {
     const requestBody = req.swagger.params.queryBody.value;
     validateGeneratorAspectsPermissions(requestBody.aspects, req)
     .then(() => u.findByKey(helper, req.swagger.params))
+    .then((o) => u.setOwner(requestBody, req, o))
     .then((o) => u.isWritable(req, o))
     .then((o) => {
       u.patchArrayFields(o, requestBody, helper);
@@ -174,7 +175,8 @@ module.exports = {
     u.mergeDuplicateArrayElements(params.queryBody.value, helper);
     const toPost = params.queryBody.value;
     toPost.createdBy = req.user.id;
-    validateGeneratorAspectsPermissions(toPost.aspects, req)
+    u.setOwner(toPost, req)
+    .then(() => validateGeneratorAspectsPermissions(toPost.aspects, req))
     .then(() =>
       helper.model.createWithCollectors(toPost))
     .then((o) => {
@@ -211,6 +213,7 @@ module.exports = {
      */
     validateGeneratorAspectsPermissions(toPut.aspects, req)
     .then(() => u.findByKey(helper, req.swagger.params))
+    .then((o) => u.setOwner(toPut, req, o))
     .then((o) => u.isWritable(req, o))
     .then((o) => {
       instance = o;

--- a/api/v1/controllers/rooms.js
+++ b/api/v1/controllers/rooms.js
@@ -38,6 +38,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   deleteRooms(req, res, next) {
+    convertKeyToNumber(req);
     doDelete(req, res, next, helper);
   },
 
@@ -80,6 +81,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   getRoom(req, res, next) {
+    convertKeyToNumber(req);
     doGet(req, res, next, helper);
   },
 
@@ -93,6 +95,7 @@ module.exports = {
    * @param {Function} next - The next middleware function in the stack
    */
   patchRoom(req, res, next) {
+    convertKeyToNumber(req);
     doPatch(req, res, next, helper);
   },
 
@@ -178,3 +181,10 @@ module.exports = {
   }, // deleteRoomWriter
 
 }; // exports
+
+function convertKeyToNumber(req) {
+  let key = req.swagger.params.key.value;
+  if (Number(key)) {
+    req.swagger.params.key.value = Number(key);
+  }
+}

--- a/api/v1/helpers/nouns/aspects.js
+++ b/api/v1/helpers/nouns/aspects.js
@@ -38,6 +38,7 @@ module.exports = {
   fieldsWithEnum,
   fieldScopeMap: {
     user: 'user',
+    owner: 'owner',
   },
   tagFilterName: 'tags',
   readOnlyFields: ['id', 'isDeleted'],

--- a/api/v1/helpers/nouns/collectors.js
+++ b/api/v1/helpers/nouns/collectors.js
@@ -32,6 +32,8 @@ module.exports = {
   readOnlyFields: ['id', 'isDeleted'],
   fieldsWritableByCollectorOnly: ['osInfo', 'processInfo', 'version'],
   fieldScopeMap: {
+    user: 'user',
+    owner: 'owner',
     status: 'status',
     possibleGenerators: 'possibleGenerators',
     currentGenerators: 'currentGenerators',

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -35,6 +35,7 @@ module.exports = {
   tagFilterName: 'tags',
   fieldScopeMap: {
     user: 'user',
+    owner: 'owner',
   },
 
   hasMultipartKey: true,

--- a/api/v1/helpers/nouns/generators.js
+++ b/api/v1/helpers/nouns/generators.js
@@ -62,6 +62,7 @@ module.exports = {
   tagFilterName: 'tags',
   fieldScopeMap: {
     user: 'user',
+    owner: 'owner',
     possibleCollectors: 'possibleCollectors',
     currentCollector: 'currentCollector',
     collectorGroup: 'collectorGroup',

--- a/api/v1/helpers/nouns/lenses.js
+++ b/api/v1/helpers/nouns/lenses.js
@@ -25,6 +25,7 @@ module.exports = {
   fieldScopeMap: {
     lensLibrary: 'lensLibrary',
     user: 'user',
+    owner: 'owner',
   },
   baseUrl: '/v1/lenses',
   model: Lens,

--- a/api/v1/helpers/nouns/perspectives.js
+++ b/api/v1/helpers/nouns/perspectives.js
@@ -61,6 +61,7 @@ module.exports = {
   baseUrl: '/v1/perspectives',
   fieldScopeMap: {
     user: 'user',
+    owner: 'owner',
     lens: 'lens',
   },
   model: Perspective,

--- a/api/v1/helpers/nouns/subjects.js
+++ b/api/v1/helpers/nouns/subjects.js
@@ -53,6 +53,7 @@ module.exports = {
   fieldScopeMap: {
     hierarchy: 'hierarchy',
     user: 'user',
+    owner: 'owner',
   },
   model: Subject,
   modelName: 'Subject',

--- a/api/v1/helpers/verbs/doPatch.js
+++ b/api/v1/helpers/verbs/doPatch.js
@@ -33,7 +33,9 @@ const validateAtLeastOneFieldPresent =
 function doPatch(req, res, next, props) {
   const resultObj = { reqStartTime: req.timestamp };
   const requestBody = req.swagger.params.queryBody.value;
-  const patchPromise = u.findByKey(props, req.swagger.params)
+
+  u.findByKey(props, req.swagger.params)
+  .then((o) => u.setOwner(requestBody, req, o))
   .then((o) => u.isWritable(req, o))
   .then((o) => {
     /*
@@ -71,10 +73,9 @@ function doPatch(req, res, next, props) {
     u.patchJsonArrayFields(o, requestBody, props);
     u.patchArrayFields(o, requestBody, props);
 
-    return o.update(requestBody);
-  });
+    return o.update(requestBody).then((o) => o.reload());
+  })
 
-  patchPromise
   .then((retVal) => u.handleUpdatePromise(resultObj, req, retVal, props, res))
   .catch((err) => u.handleError(next, err, props.modelName));
 }

--- a/api/v1/helpers/verbs/doPost.js
+++ b/api/v1/helpers/verbs/doPost.js
@@ -28,7 +28,9 @@ function doPost(req, res, next, props) {
   const resultObj = { reqStartTime: req.timestamp };
   const params = req.swagger.params;
   u.mergeDuplicateArrayElements(params.queryBody.value, props);
-  pu.makePostPromise(params, props, req)
+  const toPost = params.queryBody.value;
+  u.setOwner(toPost, req)
+  .then(() => pu.makePostPromise(toPost, props, req))
   .then((o) => pu.handlePostResult(o, resultObj, props, res, req))
   .catch((err) => u.handleError(next, err, props.modelName));
 }

--- a/api/v1/helpers/verbs/doPut.js
+++ b/api/v1/helpers/verbs/doPut.js
@@ -34,6 +34,7 @@ function doPut(req, res, next, props) {
 
   // find the instance, then update it
   u.findByKey(props, req.swagger.params)
+  .then((o) => u.setOwner(toPut, req, o))
   .then((o) => u.isWritable(req, o))
   .then((o) => u.updateInstance(o, puttableFields, toPut))
   .then((retVal) => u.handleUpdatePromise(resultObj, req, retVal, props, res))

--- a/api/v1/helpers/verbs/postUtils.js
+++ b/api/v1/helpers/verbs/postUtils.js
@@ -15,13 +15,12 @@ const logAPI = require('../../../../utils/apiLog').logAPI;
 const u = require('./utils');
 
 /**
- * @param {Object} params From swagger
+ * @param {Object} toPost Request body to post
  * @param {Object} props The helpers/nouns module for the given DB model
  * @param {Object} req From express
  * @returns {Promise} - which resolves to a created instance of the model
  */
-function makePostPromise(params, props, req) {
-  const toPost = params.queryBody.value;
+function makePostPromise(toPost, props, req) {
   toPost.createdBy = req.user ? req.user.id : undefined;
   return props.model.create(toPost, req.user);
 }

--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -19,6 +19,7 @@ const logAPI = require('../../../../utils/apiLog').logAPI;
 const publisher = require('../../../../realtime/redisPublisher');
 const realtimeEvents = require('../../../../realtime/constants').events;
 const redisCache = require('../../../../cache/redisCache').client.cache;
+const userProps = require('../nouns/users');
 const Op = require('sequelize').Op;
 const md5 = require('md5');
 const ADMIN_OVERRIDE_KEYWORD = 'admin';
@@ -32,13 +33,15 @@ const ADMIN_OVERRIDE_KEYWORD = 'admin';
 function updateInstance(o, puttableFields, toPut) {
   const keys = Object.keys(puttableFields);
   for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    if (toPut[key] === undefined) {
+    let key = keys[i];
+    const fieldDef = puttableFields[key];
+    if (key === 'owner') key = 'ownerId';
+    if (toPut[key] === undefined && key !== 'ownerId') {
       let nullish = null;
-      if (puttableFields[key].type === 'boolean') {
+      if (fieldDef.type === 'boolean') {
         nullish = false;
-      } else if (puttableFields[key].enum) {
-        nullish = puttableFields[key].default;
+      } else if (fieldDef.enum) {
+        nullish = fieldDef.default;
       }
 
       o.set(key, nullish);
@@ -53,7 +56,7 @@ function updateInstance(o, puttableFields, toPut) {
     }
   }
 
-  return o.save();
+  return o.save().then((o) => o.reload());
 }
 
 /**
@@ -458,7 +461,7 @@ function findByIdThenName(model, key, opts, props) {
     delete opts.where;
     model.findById(key, opts)
     .then((found) => found)
-    .catch(() => {
+    .catch((err) => {
 
       /* The resource has non-unique name and hence GET /{resource}/$name is
       not allowed */
@@ -874,6 +877,58 @@ function getHash(resource, url) {
   return (resource + md5(url));
 } // getHash
 
+/**
+ * Set the owner id. Default to createdBy, also allow specifying a user name in
+ * the request body.
+ *
+ * @param {Object} requestBody - the request body
+ * @param {Object} req - the request object
+ * @param {Object} existing - the existing sequelize instance, if any
+ *
+ * @returns {Promise<Object>} - resolves to the existing instance
+ */
+function setOwner(requestBody, req, existing) {
+  const ownerKey = requestBody.owner;
+  delete requestBody.owner;
+
+  // check permissions to change existing owner
+  if (existing && ownerKey) {
+    const userName = req.user && req.user.name;
+    const ownerName = existing.owner && existing.owner.name;
+    const isAdmin = req.headers && req.headers.IsAdmin && req.query
+      && req.query.override === ADMIN_OVERRIDE_KEYWORD;
+    if (userName !== ownerName && !isAdmin) {
+      throw new apiErrors.ForbiddenError(
+        'Only the existing owner or an admin user can change the owner'
+      );
+    }
+  }
+
+  if (ownerKey) { // explicitly set owner
+    const params = { key: { value: ownerKey } };
+    return findByKey(userProps, params)
+    .then((user) => {
+      requestBody.ownerId = user.id;
+      return existing;
+    })
+    .catch((err) => {
+      if (err instanceof apiErrors.ResourceNotFoundError) {
+        throw new apiErrors.ValidationError(
+          'Attempted to set the owner to a nonexistent user.'
+        );
+      } else {
+        throw err;
+      }
+    });
+  } else {
+    if (!existing) { // default owner to createdBy on new record
+      requestBody.ownerId = req.user ? req.user.id : undefined;
+    }
+
+    return Promise.resolve(existing);
+  }
+} // setOwner
+
 // ----------------------------------------------------------------------------
 
 module.exports = {
@@ -941,5 +996,7 @@ module.exports = {
   removeFieldsFromResponse,
 
   checkDuplicateRLinks,
+
+  setOwner,
 
 }; // exports

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -406,6 +406,10 @@ paths:
                   Provide guidance for how a lens should display aspects--ascending order by
                   rank (numeric, nulls last) then within rank in ascending order by name
                   (alphanumeric).
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - timeout
@@ -643,6 +647,10 @@ paths:
                   Provide guidance for how a lens should display aspects--ascending order by
                   rank (numeric, nulls last) then within rank in ascending order by name
                   (alphanumeric).
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: Success, returns the updated aspect.
@@ -811,6 +819,10 @@ paths:
                   Provide guidance for how a lens should display aspects--ascending order by
                   rank (numeric, nulls last) then within rank in ascending order by name
                   (alphanumeric).
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -1537,6 +1549,10 @@ paths:
               userId:
                 type: string
                 description: The user of which this action is in reference with
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - roomId
@@ -1677,6 +1693,10 @@ paths:
               userId:
                 type: string
                 description: The user of which this action is in reference with
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -1970,6 +1990,10 @@ paths:
                 type: integer
                 maxLength: 254
                 description: Number for the corresponding room
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - value
@@ -2223,6 +2247,10 @@ paths:
                 type: integer
                 maxLength: 254
                 description: Number for the corresponding room
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - value
@@ -2326,6 +2354,10 @@ paths:
                 type: integer
                 maxLength: 254
                 description: Number for the coresponding room
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -2492,6 +2524,12 @@ paths:
           items:
             type: string
           default: []
+        -
+          name: owner
+          in: formData
+          description: >
+            The name of the user to assign as the owner. Defaults to the user that created it
+          type: string
       responses:
         201:
           description: >-
@@ -2643,6 +2681,10 @@ paths:
                 description: Array of objects that contain the name of data on a bot
                 items:
                   type: object
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -2735,10 +2777,15 @@ paths:
           items:
             type: string
           default: []
+        -
+          name: owner
+          in: formData
+          description: >
+            The name of the user to assign as the owner. Defaults to the user that created it
+          type: string
       responses:
-        201:
-          description: >-
-            Created bot
+        200:
+          description: Success, returns the updated bot.
           schema:
             $ref: "#/definitions/BotResponse"
         400:
@@ -3149,6 +3196,10 @@ paths:
               version:
                 type: string
                 description: Access restricted to Refocus Collector only.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - version
@@ -3257,6 +3308,10 @@ paths:
               version:
                 type: string
                 description: Access restricted to Refocus Collector only.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         403:
           $ref: "#/responses/403"
@@ -3853,6 +3908,10 @@ paths:
               userId:
                 type: string
                 description: User that this event relates to.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - log
       responses:
@@ -3916,6 +3975,10 @@ paths:
                 userId:
                   type: string
                   description: User that this event relates to.
+                owner:
+                  type: string
+                  description: >
+                    The name of the user to assign as the owner. Defaults to the user that created it
               required:
                 - log
       responses:
@@ -4232,6 +4295,10 @@ paths:
                       left-most non-zero major, minor or patch number.
                       See https://github.com/npm/node-semver for more details
                       on semver matching.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - aspects
@@ -4390,6 +4457,10 @@ paths:
                       left-most non-zero major, minor or patch number.
                       See https://github.com/npm/node-semver for more details
                       on semver matching.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: Success, returns the updated generator.
@@ -4515,6 +4586,10 @@ paths:
                       left-most non-zero major, minor or patch number.
                       See https://github.com/npm/node-semver for more details
                       on semver matching.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - aspects
@@ -4875,6 +4950,10 @@ paths:
                   Default false. When set to true, the generatorTemplate is
                   available to all users.
                 default: false
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - version
@@ -4957,6 +5036,10 @@ paths:
                   Default false. When set to true, the generatorTemplate is
                   available to all users.
                 default: false
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: Success, returns the updated generatorTemplate.
@@ -5553,6 +5636,12 @@ paths:
             A version for the lens. Leave empty if you want to use the
             version provided by the lens publisher (i.e. sourceVersion).
           type: string
+        -
+          name: owner
+          in: formData
+          description: >-
+            The name of the user to assign as the owner. Defaults to the user that created it
+          type: string
       responses:
         201:
           description: Returns created lens
@@ -5684,6 +5773,10 @@ paths:
                   A version for the lens. Leave empty if you want to use the
                   version provided by the lens publisher (i.e. sourceVersion).
                 type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -5756,6 +5849,12 @@ paths:
           description: >-
             A version for the lens. Leave empty if you want to use the
             version provided by the lens publisher (i.e. sourceVersion).
+          type: string
+        -
+          name: owner
+          in: formData
+          description: >-
+            The name of the user to assign as the owner. Defaults to the user that created it
           type: string
       responses:
         200:
@@ -6203,6 +6302,10 @@ paths:
                 type: string
                 description: >
                   The id of Lens.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - lensId
@@ -6394,6 +6497,10 @@ paths:
                 type: string
                 description: >
                   The id of Lens.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -6519,6 +6626,10 @@ paths:
                 enum:
                   - INCLUDE
                   - EXCLUDE
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - lensId
@@ -7460,6 +7571,10 @@ paths:
                 type: string
                 maxLength: 254
                 description: Name of the room
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
               - type
@@ -7494,9 +7609,9 @@ paths:
           name: key
           in: path
           description: >-
-            The id the room to retrieve
+            The id or name of the room to retrieve
           required: true
-          type: integer
+          type: string
       responses:
         200:
           description: >-
@@ -7523,9 +7638,9 @@ paths:
           name: key
           in: path
           description: >-
-            The id the room to retrieve
+            The id or name of the room to retrieve
           required: true
-          type: integer
+          type: string
         -
           name: active
           description: Get rooms depending on its active tag
@@ -7563,9 +7678,9 @@ paths:
           name: key
           in: path
           description: >-
-            The id the room to retrieve
+            The id or name of the room to retrieve
           required: true
-          type: integer
+          type: string
         -
           name: queryBody
           in: body
@@ -7586,6 +7701,10 @@ paths:
                 type: string
                 maxLength: 254
                 description: Id of roomType
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -7965,6 +8084,10 @@ paths:
                 description: Default bots for roomType
                 items:
                   type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -8099,6 +8222,10 @@ paths:
                 description: Default bots for roomType
                 items:
                   type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -8465,6 +8592,10 @@ paths:
                 type: string
                 description: >
                   TODO
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - aspectId
               - subjectId
@@ -8600,6 +8731,10 @@ paths:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >
                   RelatedLinks associated with this model.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -8669,6 +8804,10 @@ paths:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >
                   RelatedLinks associated with this model.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: >-
@@ -8738,6 +8877,10 @@ paths:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >
                   RelatedLinks associated with this model.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -8807,6 +8950,10 @@ paths:
                     Stored as a string but will be treated as whatever the aspect’s
                     valueType was specified as, i.e. [BOOLEAN|NUMERIC|PERCENT]. If timeout
                     occurs, value is set to null.
+                owner:
+                  type: string
+                  description: >
+                    The name of the user to assign as the owner. Defaults to the user that created it
               required:
               - name
       responses:
@@ -9369,6 +9516,10 @@ paths:
                   type: number
                 description: >
                   If the subject has a physical location, specify its longitude and latitude in this two-element array, e.g. [-122.431297, 37.773972]. The first element in the array represents longitude; the second element represents latitude.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -9558,6 +9709,10 @@ paths:
                   type: number
                 description: >
                   If the subject has a physical location, specify its longitude and latitude in this two-element array, e.g. [-122.431297, 37.773972]. The first element in the array represents longitude; the second element represents latitude.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
 
       responses:
         200:
@@ -9681,6 +9836,10 @@ paths:
                   type: number
                 description: >
                   If the subject has a physical location, specify its longitude and latitude in this two-element array, e.g. [-122.431297, 37.773972]. The first element in the array represents longitude; the second element represents latitude.
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -11264,6 +11423,10 @@ paths:
                 type: array
                 items:
                   type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
       responses:
@@ -11435,6 +11598,10 @@ paths:
                 type: array
                 items:
                   type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
       responses:
         200:
           description: Success, returns the updated collector group.
@@ -11489,6 +11656,10 @@ paths:
                 type: array
                 items:
                   type: string
+              owner:
+                type: string
+                description: >
+                  The name of the user to assign as the owner. Defaults to the user that created it
             required:
               - name
 
@@ -13839,6 +14010,8 @@ parameters:
         - osInfo
         - processInfo
         - version
+        - user
+        - owner
 
   limitParam:
     name: limit
@@ -13888,6 +14061,7 @@ parameters:
         - valueType
         - warningRange
         - user
+        - owner
 
   AuditEventsFieldsParam:
     name: fields
@@ -13932,6 +14106,7 @@ parameters:
         - updatedAt
         - currentCollector
         - user
+        - owner
         - possibleCollectors
         - collectorGroup
 
@@ -13960,6 +14135,7 @@ parameters:
         - transform
         - isPublished
         - user
+        - owner
 
   LensesFieldsParam:
     name: fields
@@ -13988,6 +14164,7 @@ parameters:
         - updatedAt
         - version
         - user
+        - owner
 
   PerspectivesFieldsParam:
     name: fields
@@ -14016,6 +14193,7 @@ parameters:
         - subjectTagFilterType
         - updatedAt
         - user
+        - owner
         - lens
 
   ProfilesFieldsParam:
@@ -14102,6 +14280,7 @@ parameters:
         - relatedLinks
         - updatedAt
         - user
+        - owner
 
   TokensFieldsParam:
     name: fields

--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -48,6 +48,8 @@ const sampFields = {
   UPD_AT: 'updatedAt',
   ASP_ID: 'aspectId',
   SUBJ_ID: 'subjectId',
+  OWNER: 'owner',
+  OWNER_ID: 'ownerId',
 };
 const sampleFieldsArr = Object.keys(sampFields).map((key) => sampFields[key]);
 

--- a/cache/sampleStore.js
+++ b/cache/sampleStore.js
@@ -33,6 +33,7 @@ const constants = {
       'okRange',
       'writers',
       'user', // an object
+      'owner',
     ],
     sample: ['relatedLinks', 'user'],
     subject: [
@@ -42,6 +43,7 @@ const constants = {
       'relatedLinks',
       'tags',
       'user',
+      'owner',
     ],
   },
   indexKey: {

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -414,6 +414,10 @@ module.exports = function aspect(seq, dataTypes) {
   };
 
   Aspect.postImport = function (models) {
+    assoc.owner = Aspect.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Aspect.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -439,10 +443,23 @@ module.exports = function aspect(seq, dataTypes) {
           association: assoc.user,
           attributes: ['name', 'email', 'fullName'],
         },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
       ],
       order: ['name'],
     }, {
       override: true,
+    });
+
+    Aspect.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
     });
 
     Aspect.addScope('user', {

--- a/db/model/bot.js
+++ b/db/model/bot.js
@@ -147,6 +147,10 @@ module.exports = function bot(seq, dataTypes) {
   };
 
   Bot.postImport = function (models) {
+    assoc.owner = Bot.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Bot.belongsTo(models.User, {
       foreignKey: 'installedBy',
       as: 'user',
@@ -162,6 +166,16 @@ module.exports = function bot(seq, dataTypes) {
     });
 
     Bot.addScope('botUI', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
       attributes: { include: ['ui'] },
     });
 
@@ -169,6 +183,10 @@ module.exports = function bot(seq, dataTypes) {
       include: [
         {
           association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
           attributes: ['name', 'email', 'fullName'],
         },
       ],

--- a/db/model/botAction.js
+++ b/db/model/botAction.js
@@ -180,6 +180,10 @@ module.exports = function botAction(seq, dataTypes) {
         allowNull: false,
       },
     });
+    assoc.owner = BotAction.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = BotAction.belongsTo(models.User, {
       foreignKey: 'userId',
       allowNull: true,
@@ -188,6 +192,21 @@ module.exports = function botAction(seq, dataTypes) {
       as: 'writers',
       through: 'BotActionWriters',
       foreignKey: 'botId',
+    });
+
+    BotAction.addScope('defaultScope', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    }, {
+      override: true,
     });
   };
 

--- a/db/model/botData.js
+++ b/db/model/botData.js
@@ -168,6 +168,11 @@ module.exports = function botData(seq, dataTypes) {
       allowNull: false,
     });
 
+    assoc.owner = BotData.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
     assoc.user = BotData.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -191,6 +196,10 @@ module.exports = function botData(seq, dataTypes) {
       include: [
         {
           association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
           attributes: ['name', 'email', 'fullName'],
         },
       ],

--- a/db/model/collector.js
+++ b/db/model/collector.js
@@ -236,8 +236,14 @@ module.exports = function collector(seq, dataTypes) {
       foreignKey: 'collectorId',
     });
 
-    assoc.createdBy = Collector.belongsTo(models.User, {
+    assoc.owner = Collector.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
+    assoc.user = Collector.belongsTo(models.User, {
       foreignKey: 'createdBy',
+      as: 'user',
     });
 
     assoc.writers = Collector.belongsToMany(models.User, {
@@ -248,6 +254,24 @@ module.exports = function collector(seq, dataTypes) {
 
     Collector.addScope('baseScope', {
       order: ['name'],
+    });
+
+    Collector.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    });
+
+    Collector.addScope('user', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
     });
 
     Collector.addScope('status', {
@@ -281,6 +305,8 @@ module.exports = function collector(seq, dataTypes) {
 
     Collector.addScope('defaultScope',
       dbUtils.combineScopes([
+        'user',
+        'owner',
         'baseScope',
         'currentGenerators',
         'possibleGenerators',

--- a/db/model/collectorgroup.js
+++ b/db/model/collectorgroup.js
@@ -108,12 +108,36 @@ module.exports = function collectorgroup(seq, dataTypes) {
       foreignKey: 'collectorGroupId',
     });
 
-    assoc.createdBy = CollectorGroup.belongsTo(models.User, {
+    assoc.owner = CollectorGroup.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
+    assoc.user = CollectorGroup.belongsTo(models.User, {
       foreignKey: 'createdBy',
+      as: 'user',
     });
 
     CollectorGroup.addScope('baseScope', {
       order: ['name'],
+    });
+
+    CollectorGroup.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    });
+
+    CollectorGroup.addScope('user', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
     });
 
     CollectorGroup.addScope('collectors', {
@@ -128,6 +152,8 @@ module.exports = function collectorgroup(seq, dataTypes) {
 
     CollectorGroup.addScope('defaultScope',
       dbUtils.combineScopes([
+        'user',
+        'owner',
         'baseScope',
         'collectors',
       ], CollectorGroup),

--- a/db/model/event.js
+++ b/db/model/event.js
@@ -115,6 +115,10 @@ module.exports = function event(seq, dataTypes) {
     assoc.botAction = Event.belongsTo(models.BotAction, {
       foreignKey: 'botActionId',
     });
+    assoc.owner = Event.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Event.belongsTo(models.User, {
       foreignKey: 'userId',
     });
@@ -123,6 +127,40 @@ module.exports = function event(seq, dataTypes) {
       through: 'EventWriters',
       foreignKey: 'botId',
     });
+
+    Event.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    });
+
+    Event.addScope('user', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    });
+
+    Event.addScope('defaultScope', {
+      include: [
+        {
+          association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    }, {
+      override: true,
+    });
+
   };
 
   return Event;

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -298,6 +298,11 @@ module.exports = function generator(seq, dataTypes) {
       foreignKey: 'collectorGroupId',
     });
 
+    assoc.owner = Generator.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
     assoc.user = Generator.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -328,6 +333,15 @@ module.exports = function generator(seq, dataTypes) {
       include: [
         {
           association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
+    });
+
+    Generator.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
           attributes: ['name', 'email', 'fullName'],
         },
       ],
@@ -365,6 +379,7 @@ module.exports = function generator(seq, dataTypes) {
       dbUtils.combineScopes([
         'baseScope',
         'user',
+        'owner',
         'currentCollector',
         'possibleCollectors',
         'collectorGroup',

--- a/db/model/generatortemplate.js
+++ b/db/model/generatortemplate.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 const common = require('../helpers/common');
+const dbUtils = require('../utils');
 const constants = require('../constants');
 const ValidationError = require('../dbErrors').ValidationError;
 const semver = require('semver');
@@ -315,6 +316,11 @@ module.exports = function user(seq, dataTypes) {
   };
 
   GeneratorTemplate.postImport = function (models) {
+    assoc.owner = GeneratorTemplate.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
     assoc.user = GeneratorTemplate.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -336,10 +342,23 @@ module.exports = function user(seq, dataTypes) {
           association: assoc.user,
           attributes: ['name', 'email', 'fullName'],
         },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
       ],
       order: ['name'],
     }, {
       override: true,
+    });
+
+    GeneratorTemplate.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
     });
 
     GeneratorTemplate.addScope('user', {

--- a/db/model/lens.js
+++ b/db/model/lens.js
@@ -227,6 +227,10 @@ module.exports = function lens(seq, dataTypes) {
   };
 
   Lens.postImport = function (models) {
+    assoc.owner = Lens.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Lens.belongsTo(models.User, {
       foreignKey: 'installedBy',
       as: 'user',
@@ -260,11 +264,24 @@ module.exports = function lens(seq, dataTypes) {
           association: assoc.user,
           attributes: ['name', 'email'],
         },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
       ],
       attributes: { exclude: ['library'] },
       order: ['name'],
     }, {
       override: true,
+    });
+
+    Lens.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email'],
+        },
+      ],
     });
 
     Lens.addScope('user', {

--- a/db/model/perspective.js
+++ b/db/model/perspective.js
@@ -151,6 +151,10 @@ module.exports = function perspective(seq, dataTypes) {
   };
 
   Perspective.postImport = function (models) {
+    assoc.owner = Perspective.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Perspective.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -179,6 +183,10 @@ module.exports = function perspective(seq, dataTypes) {
           attributes: ['name', 'email'],
         },
         {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
           association: assoc.lens,
           attributes: [
             'helpEmail',
@@ -193,6 +201,15 @@ module.exports = function perspective(seq, dataTypes) {
       order: ['name'],
     }, {
       override: true,
+    });
+
+    Perspective.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email'],
+        },
+      ],
     });
 
     Perspective.addScope('user', {

--- a/db/model/room.js
+++ b/db/model/room.js
@@ -180,6 +180,11 @@ module.exports = function room(seq, dataTypes) {
       onDelete: 'CASCADE',
     });
 
+    assoc.owner = Room.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
     assoc.user = Room.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -202,6 +207,10 @@ module.exports = function room(seq, dataTypes) {
       include: [
         {
           association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
           attributes: ['name', 'email', 'fullName'],
         },
       ],

--- a/db/model/roomType.js
+++ b/db/model/roomType.js
@@ -228,6 +228,11 @@ module.exports = function roomType(seq, dataTypes) {
       through: 'RoomTypeBots',
     });
 
+    assoc.owner = RoomType.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
+
     assoc.user = RoomType.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -243,6 +248,10 @@ module.exports = function roomType(seq, dataTypes) {
       include: [
         {
           association: assoc.user,
+          attributes: ['name', 'email', 'fullName'],
+        },
+        {
+          association: assoc.owner,
           attributes: ['name', 'email', 'fullName'],
         },
       ],

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -556,6 +556,10 @@ module.exports = function subject(seq, dataTypes) {
   };
 
   Subject.postImport = function (models) {
+    assoc.owner = Subject.belongsTo(models.User, {
+      foreignKey: 'ownerId',
+      as: 'owner',
+    });
     assoc.user = Subject.belongsTo(models.User, {
       foreignKey: 'createdBy',
       as: 'user',
@@ -582,10 +586,23 @@ module.exports = function subject(seq, dataTypes) {
           association: assoc.user,
           attributes: ['name', 'email', 'fullName'],
         },
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
       ],
       order: ['absolutePath'],
     }, {
       override: true,
+    });
+
+    Subject.addScope('owner', {
+      include: [
+        {
+          association: assoc.owner,
+          attributes: ['name', 'email', 'fullName'],
+        },
+      ],
     });
 
     Subject.addScope('user', {

--- a/migrations/20190206212652-add-owner.js
+++ b/migrations/20190206212652-add-owner.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+'use strict';
+
+const columnName = 'ownerId';
+const tablesToModify = [
+  'Aspects',
+  'BotActions',
+  'BotData',
+  'Bots',
+  'CollectorGroups',
+  'Collectors',
+  'Events',
+  'Generators',
+  'GeneratorTemplates',
+  'Lenses',
+  'Perspectives',
+  'Rooms',
+  'RoomTypes',
+  'Subjects',
+];
+
+module.exports = {
+  up: (qi, Sequelize) => {
+    const columnDef = {
+      type: Sequelize.UUID,
+      references: {
+        model: 'Users',
+        key: 'id',
+      },
+    };
+
+    return Promise.all(
+      tablesToModify.map((modelName) =>
+        qi.addColumn(modelName, columnName, columnDef)
+      )
+    );
+  },
+
+  down: (qi, Sequelize) => {
+    return Promise.all(
+      tablesToModify.map((modelName) =>
+        qi.removeColumn(modelName, columnName)
+      )
+    );
+  },
+};
+

--- a/migrations/20190206212652-add-owner.js
+++ b/migrations/20190206212652-add-owner.js
@@ -42,12 +42,11 @@ module.exports = {
     );
   },
 
-  down: (qi, Sequelize) => {
-    return Promise.all(
+  down: (qi, Sequelize) =>
+    Promise.all(
       tablesToModify.map((modelName) =>
         qi.removeColumn(modelName, columnName)
       )
-    );
-  },
+    ),
 };
 

--- a/migrations/20190206212704-set-owner.js
+++ b/migrations/20190206212704-set-owner.js
@@ -26,8 +26,8 @@ const modelsToUpdate = [
 ];
 
 module.exports = {
-  up: (qi, Sequelize) => {
-    return db.User.findOne({ where: { name: 'admin@refocus.admin' } })
+  up: (qi, Sequelize) =>
+    db.User.findOne({ where: { name: 'admin@refocus.admin' } })
     .then((adminUser) => {
       if (!adminUser || !adminUser.id) return Promise.reject("couldn't find admin user");
       const defaultOwnerId = adminUser.id;
@@ -45,8 +45,7 @@ module.exports = {
           ));
         })
       );
-    });
-  },
+    }),
 
   down: (qi, Sequelize) =>
     Promise.all(

--- a/migrations/20190206212704-set-owner.js
+++ b/migrations/20190206212704-set-owner.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+'use strict';
+const db = require('../db/index');
+
+const modelsToUpdate = [
+  'Aspect',
+  'BotAction',
+  'BotData',
+  'Bot',
+  'CollectorGroup',
+  'Collector',
+  'Event',
+  'Generator',
+  'GeneratorTemplate',
+  'Lens',
+  'Perspective',
+  'Room',
+  'RoomType',
+  'Subject',
+];
+
+module.exports = {
+  up: (qi, Sequelize) => {
+    return db.User.findOne({ where: { name: 'admin@refocus.admin' } })
+    .then((adminUser) => {
+      if (!adminUser || !adminUser.id) return Promise.reject("couldn't find admin user");
+      const defaultOwnerId = adminUser.id;
+      return Promise.all(
+        modelsToUpdate.map((modelName) => {
+          const model = db[modelName];
+          return model.findAll()
+          .then((records) => Promise.all(
+            records.map((record) => {
+              if (record.ownerId) return Promise.resolve();
+              const ownerId = record.createdBy || record.installedBy
+                || record.userId || defaultOwnerId;
+              return record.update({ ownerId });
+            })
+          ));
+        })
+      );
+    });
+  },
+
+  down: (qi, Sequelize) =>
+    Promise.all(
+      modelsToUpdate.map((modelName) =>
+        db[modelName].findAll()
+        .then((records) => Promise.all(
+          records.map((record) =>
+            record.update({ ownerId: null })
+          )
+        ))
+      )
+    ),
+};
+

--- a/tests/api/v1/aspects/associations.js
+++ b/tests/api/v1/aspects/associations.js
@@ -38,6 +38,7 @@ describe(`tests/api/v1/aspects/associations.js, GET ${path} >`, () => {
     tu.createUser('testUser')
     .then((user) => {
       toCreate.forEach((a) => a.createdBy = user.id);
+      toCreate.forEach((a) => a.ownerId = user.id);
       conf.token = tu.createTokenFromUserName(user.name);
       done();
     })
@@ -55,9 +56,17 @@ describe(`tests/api/v1/aspects/associations.js, GET ${path} >`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user'];
+  const associations = ['user', 'owner'];
   const schema = {
     user: Joi.object().keys({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
       name: Joi.string().required(),
       fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),

--- a/tests/api/v1/aspects/utils.js
+++ b/tests/api/v1/aspects/utils.js
@@ -27,17 +27,29 @@ const subjectToCreate = {
   name: `${tu.namePrefix}TEST_SUBJECT`,
 };
 
+const basic = {
+  name: `${tu.namePrefix}ASPECTNAME`,
+  isPublished: true,
+  timeout: '110s',
+  status0range: [0, 0],
+  status1range: [1, 2],
+  valueType: 'NUMERIC',
+};
+
 module.exports = {
-  toCreate: {
-    name: `${tu.namePrefix}ASPECTNAME`,
-    isPublished: true,
-    timeout: '110s',
-    status0range: [0, 0],
-    status1range: [1, 2],
-    valueType: 'NUMERIC',
-  },
+  toCreate: basic,
 
   subjectToCreate,
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Aspect.create(toCreate);
+  },
 
   forceDelete(done) {
     Promise.join(

--- a/tests/api/v1/botActions/utils.js
+++ b/tests/api/v1/botActions/utils.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 const tu = require('../../../testUtils');
+const roomUtil = require('../rooms/utils');
+const botUtil = require('../bots/utils');
 
 const testStartTime = new Date();
 const Action1 = 'Action1';
@@ -57,6 +59,40 @@ module.exports = {
 
   createResponse() {
     return tu.db.BotData.create(res);
+  },
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(standard));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  doSetup(props={}) {
+    const { userId } = props;
+    return Promise.all([
+      botUtil.createBasic({ installedBy: userId }),
+      roomUtil.createBasic({ createdBy: userId }),
+    ])
+    .then(([bot, room]) => {
+      const createdIds = {
+        botId: bot.id,
+        roomId: room.id,
+      };
+      return createdIds;
+    });
+  },
+
+  createBasic(overrideProps={}) {
+    const { userId } = overrideProps;
+    return this.doSetup({ userId })
+    .then(({ botId, roomId }) => {
+      Object.assign(overrideProps, { botId, roomId });
+      const toCreate = this.getBasic(overrideProps);
+      return tu.db.BotAction.create(toCreate);
+    });
+  },
+
+  getDependencyProps() {
+    return ['botId', 'roomId'];
   },
 
   forceDelete(done) {

--- a/tests/api/v1/botData/utils.js
+++ b/tests/api/v1/botData/utils.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 const tu = require('../../../testUtils');
+const roomUtil = require('../rooms/utils');
+const botUtil = require('../bots/utils');
 
 const testStartTime = new Date();
 const n = `${tu.namePrefix}TestBotData`;
@@ -29,6 +31,40 @@ module.exports = {
 
   createStandard() {
     return tu.db.BotData.create(standard);
+  },
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(standard));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  doSetup(props={}) {
+    const { createdBy } = props;
+    return Promise.all([
+      botUtil.createBasic({ installedBy: createdBy }),
+      roomUtil.createBasic({ createdBy: createdBy }),
+    ])
+    .then(([bot, room]) => {
+      const createdIds = {
+        botId: bot.id,
+        roomId: room.id,
+      };
+      return createdIds;
+    });
+  },
+
+  createBasic(overrideProps={}) {
+    const { createdBy } = overrideProps;
+    return this.doSetup({ createdBy })
+    .then(({ botId, roomId }) => {
+      Object.assign(overrideProps, { botId, roomId });
+      const toCreate = this.getBasic(overrideProps);
+      return tu.db.BotData.create(toCreate);
+    });
+  },
+
+  getDependencyProps() {
+    return ['botId', 'roomId'];
   },
 
   forceDelete(done) {

--- a/tests/api/v1/bots/put.js
+++ b/tests/api/v1/bots/put.js
@@ -54,7 +54,7 @@ describe('tests/api/v1/bots/put.js >', () => {
     .set('Authorization', token)
     .field('name', u.name)
     .attach('ui', 'tests/api/v1/bots/uiBlob2')
-    .expect(constants.httpStatus.CREATED)
+    .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
         return done(err);
@@ -77,7 +77,7 @@ describe('tests/api/v1/bots/put.js >', () => {
     .field('version', '9.9.9')
     .field('url', newUrl)
     .field('helpUrl', newUrl)
-    .expect(constants.httpStatus.CREATED)
+    .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
         return done(err);
@@ -111,7 +111,7 @@ describe('tests/api/v1/bots/put.js >', () => {
     api.put(`${path}/${testBot.id}`)
     .set('Authorization', token)
     .send({ invalid: true })
-    .expect(constants.httpStatus.CREATED)
+    .expect(constants.httpStatus.OK)
     .end((err, res) => {
       if (err) {
         return done(err);

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -144,6 +144,16 @@ module.exports = {
     return tu.db.Bot.create(standardBot);
   },
 
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(standard));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Bot.create(toCreate);
+  },
+
   forceDelete(done) {
     tu.forceDelete(tu.db.Bot, testStartTime)
     .then(() => done())

--- a/tests/api/v1/collectorGroups/utils.js
+++ b/tests/api/v1/collectorGroups/utils.js
@@ -11,15 +11,52 @@
  */
 'use strict';
 const tu = require('../../../testUtils');
+const collectorUtil = require('../collectors/utils');
 const testStartTime = new Date();
 const colltoCreate = {
   name: tu.namePrefix + 'Coll',
   version: '1.0.0',
 };
 
+const basic = {
+  name: 'coll-group1',
+  description: 'description...',
+  collectors: [],
+};
+
 module.exports = {
   getCollectorToCreate() {
     return JSON.parse(JSON.stringify(colltoCreate));
+  },
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  doSetup(props={}) {
+    const { createdBy } = props;
+    return collectorUtil.createBasic({ createdBy })
+    .then((collector) => {
+      const createdIds = {
+        collectorName: collector.name,
+      };
+      return createdIds;
+    });
+  },
+
+  createBasic(overrideProps={}) {
+    const { createdBy } = overrideProps;
+    return this.doSetup({ createdBy })
+    .then(({ collectorName }) => {
+      Object.assign(overrideProps, { collectors: [collectorName] });
+      const toCreate = this.getBasic(overrideProps);
+      return tu.db.CollectorGroup.create(toCreate);
+    });
+  },
+
+  getDependencyProps() {
+    return ['collectorName'];
   },
 
   forceDelete(done) {

--- a/tests/api/v1/collectors/utils.js
+++ b/tests/api/v1/collectors/utils.js
@@ -183,6 +183,16 @@ function getCollectorToCreate() {
 }
 
 module.exports = {
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(collectorToCreate));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Collector.create(toCreate);
+  },
+
   forceDelete(done) {
     tu.forceDelete(tu.db.Collector, testStartTime)
     .then(() => tu.forceDelete(tu.db.GeneratorTemplate, testStartTime))

--- a/tests/api/v1/common/owner.js
+++ b/tests/api/v1/common/owner.js
@@ -1,0 +1,585 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/common/owner.js
+ */
+'use strict';
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const tu = require('../../../testUtils');
+const constants = require('../../../../api/v1/constants');
+const expect = require('chai').expect;
+const Promise = require('bluebird');
+supertest.Test.prototype.end = Promise.promisify(supertest.Test.prototype.end);
+supertest.Test.prototype.then = function (resolve, reject) {
+  return this.end().then(resolve).catch(reject);
+};
+
+const modelsToTest = {
+  aspects: ['post', 'put', 'patch'],
+  botActions: ['post', 'patch'],
+  botData: ['post', 'patch', 'upsert'],
+  bots: ['post', 'put', 'patch'],
+  collectorGroups: ['post', 'put', 'patch'],
+  collectors: ['start', 'patch'],
+  events: ['post', 'post bulk'],
+  generators: ['post', 'put', 'patch'],
+  generatorTemplates: ['post', 'patch'],
+  lenses: ['post', 'put', 'patch'],
+  perspectives: ['post', 'put', 'patch'],
+  rooms: ['post', 'patch'],
+  roomTypes: ['post', 'patch'],
+  subjects: ['post', 'put', 'patch'],
+};
+
+const skipByName = ['events', 'generatorTemplates'];
+
+let adminToken;
+let mainUser;
+let otherUser;
+let nonexistentUser;
+let token1;
+let token2;
+
+describe('tests/api/v1/common/owner >', () => {
+  before(createTokens);
+  after(tu.forceDeleteUser);
+
+  Object.entries(modelsToTest).forEach(runOwnerTestsForModel);
+});
+
+function runOwnerTestsForModel([modelName, methods]) {
+  let obj;
+  let keys;
+  let key;
+  let dependencyProps;
+
+  describe(`${modelName} owner attribute`, () => {
+    const u = getUtilForModel(modelName);
+    afterEach(u.forceDelete);
+
+    describe('GET >', () => {
+      beforeEach(() => createModel(modelName, mainUser));
+
+      runByKeyAndId(modelName, () => {
+        it('basic', () => {
+          const token = token1;
+          return getOwner({ modelName, key, token })
+          .then((res) => {
+            expect(res.body.owner.name).to.equal(mainUser.name);
+          });
+        });
+      });
+    });
+
+    if (methods.includes('post')) {
+      describe('POST >', () => {
+        beforeEach(() => createDependencies(modelName, mainUser));
+
+        runByKeyAndId(modelName, () => {
+          it('owner defaults to createdBy', () => {
+            const owner = undefined;
+            const token = token1;
+            return postOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('set owner explicitly', () => {
+            const owner = otherUser;
+            const token = token1;
+            return postOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('set owner explicitly - nonexistent user (error)', () => {
+            const owner = nonexistentUser;
+            const token = token1;
+            const expectedStatus = constants.httpStatus.BAD_REQUEST;
+            return postOwner({ modelName, owner, token, expectedStatus })
+            .then((res) => {
+              const err = res.body.errors[0];
+              expect(err).to.have.property('type', 'ValidationError');
+              expect(err).to.have.property(
+                'message', 'Attempted to set the owner to a nonexistent user.'
+              );
+            });
+          });
+        });
+      });
+    }
+
+    if (methods.includes('put')) {
+      describe('PUT >', () => {
+        beforeEach(() => createModel(modelName, mainUser));
+
+        runByKeyAndId(modelName, () => {
+          it('owner not changed', () => {
+            const newOwner = undefined;
+            const token = token1;
+            return putOwner({ modelName, key, newOwner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - owner token', () => {
+            const newOwner = otherUser;
+            const token = token1;
+            return putOwner({ modelName, key, newOwner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, override', () => {
+            const newOwner = otherUser;
+            const token = adminToken;
+            const override = true;
+            return putOwner({ modelName, key, newOwner, token, override })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, no override (error)', () => {
+            const newOwner = otherUser;
+            const token = adminToken;
+            const override = false;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return putOwner({ modelName, key, newOwner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token (error)', () => {
+            const newOwner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return putOwner({ modelName, key, newOwner, token, expectedStatus })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token, override (error)', () => {
+            const newOwner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            const override = true;
+            return putOwner({ modelName, key, newOwner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - nonexistent user (error)', () => {
+            const newOwner = nonexistentUser;
+            const token = token1;
+            const expectedStatus = constants.httpStatus.BAD_REQUEST;
+            return putOwner({ modelName, key, newOwner, token, expectedStatus })
+            .then((res) => {
+              const err = res.body.errors[0];
+              expect(err).to.have.property('type', 'ValidationError');
+              expect(err).to.have.property(
+                'message', 'Attempted to set the owner to a nonexistent user.'
+              );
+            });
+          });
+        });
+      });
+    }
+
+    if (methods.includes('patch')) {
+      describe('PATCH >', () => {
+        beforeEach(() => createModel(modelName, mainUser));
+
+        runByKeyAndId(modelName, () => {
+          it('dont change owner', () => {
+            const newOwner = undefined;
+            const token = token1;
+            return patchOwner({ modelName, key, newOwner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - owner token', () => {
+            const newOwner = otherUser;
+            const token = token1;
+            return patchOwner({ modelName, key, newOwner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, override', () => {
+            const newOwner = otherUser;
+            const token = adminToken;
+            const override = true;
+            return patchOwner({ modelName, key, newOwner, token, override })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, no override (error)', () => {
+            const newOwner = otherUser;
+            const token = adminToken;
+            const override = false;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return patchOwner({ modelName, key, newOwner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token (error)', () => {
+            const newOwner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return patchOwner({ modelName, key, newOwner, token, expectedStatus })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token, override (error)', () => {
+            const newOwner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            const override = true;
+            return patchOwner({ modelName, key, newOwner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - nonexistent user (error)', () => {
+            const newOwner = nonexistentUser;
+            const token = token1;
+            const expectedStatus = constants.httpStatus.BAD_REQUEST;
+            return patchOwner({ modelName, key, newOwner, token, expectedStatus })
+            .then((res) => {
+              const err = res.body.errors[0];
+              expect(err).to.have.property('type', 'ValidationError');
+              expect(err).to.have.property(
+                'message', 'Attempted to set the owner to a nonexistent user.'
+              );
+            });
+          });
+        });
+      });
+    }
+
+    if (methods.includes('start')) {
+      describe('START - new >', () => {
+        beforeEach(() => createDependencies(modelName, mainUser));
+
+        runByKeyAndId(modelName, () => {
+          it('owner defaults to createdBy', () => {
+            const owner = undefined;
+            const token = token1;
+            return startOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('set owner explicitly', () => {
+            const owner = otherUser;
+            const token = token1;
+            return startOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('set owner explicitly - nonexistent user (error)', () => {
+            const owner = nonexistentUser;
+            const token = token1;
+            const expectedStatus = constants.httpStatus.BAD_REQUEST;
+            return startOwner({ modelName, owner, token, expectedStatus })
+            .then((res) => {
+              const err = res.body.errors[0];
+              expect(err).to.have.property('type', 'ValidationError');
+              expect(err).to.have.property(
+                'message', 'Attempted to set the owner to a nonexistent user.'
+              );
+            });
+          });
+        });
+      });
+
+      describe('START - existing >', () => {
+        beforeEach(() => createModel(modelName, mainUser));
+
+        runByKeyAndId(modelName, () => {
+          it('owner not changed', () => {
+            const owner = undefined;
+            const token = token1;
+            return startOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - owner token', () => {
+            const owner = otherUser;
+            const token = token1;
+            return startOwner({ modelName, owner, token })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, override', () => {
+            const owner = otherUser;
+            const token = adminToken;
+            const override = true;
+            return startOwner({ modelName, owner, token, override })
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(otherUser.name);
+            });
+          });
+
+          it('change owner - admin token, no override (error)', () => {
+            const owner = otherUser;
+            const token = adminToken;
+            const override = false;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return startOwner({ modelName, owner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token (error)', () => {
+            const owner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            return startOwner({ modelName, owner, token, expectedStatus })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - other token, override (error)', () => {
+            const owner = otherUser;
+            const token = token2;
+            const expectedStatus = constants.httpStatus.FORBIDDEN;
+            const override = true;
+            return startOwner({ modelName, owner, token, expectedStatus, override })
+            .then(() => getOwner({ modelName, key, token }))
+            .then((res) => {
+              expect(res.body.owner.name).to.equal(mainUser.name);
+            });
+          });
+
+          it('change owner - nonexistent user (error)', () => {
+            const owner = nonexistentUser;
+            const token = token1;
+            const expectedStatus = constants.httpStatus.BAD_REQUEST;
+            return startOwner({ modelName, owner, token, expectedStatus })
+            .then((res) => {
+              const err = res.body.errors[0];
+              expect(err).to.have.property('type', 'ValidationError');
+              expect(err).to.have.property(
+                'message', 'Attempted to set the owner to a nonexistent user.'
+              );
+            });
+          });
+        });
+      });
+    }
+  });
+
+  function getOwner({ modelName, key, token }) {
+    const path = `/v1/${modelName}`;
+    return api.get(`${path}/${key}`)
+    .set('Authorization', token)
+    .expect(constants.httpStatus.OK);
+  }
+
+  function postOwner({ modelName, key, owner, token, expectedStatus }) {
+    owner = owner && owner.name;
+    expectedStatus = expectedStatus || constants.httpStatus.CREATED;
+    const u = getUtilForModel(modelName);
+    const toCreate = u.getBasic({ owner });
+    Object.assign(toCreate, dependencyProps);
+    const path = `/v1/${modelName}`;
+    const req = api.post(`${path}`)
+    .set('Authorization', token)
+    .expect(expectedStatus);
+
+    if (modelName === 'lenses') {
+      Object.entries(toCreate).forEach(([key, value]) => {
+        if (key && value) {
+          req.field(key, value);
+        }
+      });
+      return req.attach('library', 'tests/api/v1/apiTestsUtils/lens.zip');
+    } else {
+      return req.send(toCreate);
+    }
+  }
+
+  function patchOwner({ modelName, key, newOwner, token, expectedStatus, override }) {
+    const owner = newOwner && newOwner.name;
+    expectedStatus = expectedStatus || constants.httpStatus.OK;
+    const path = `/v1/${modelName}`;
+    const req = api.patch(`${path}/${key}`)
+    .set('Authorization', token)
+    .send({ owner })
+    .expect(expectedStatus);
+
+    if (override) {
+      req.query({ override: 'admin' });
+    }
+
+    return req;
+  }
+
+  function putOwner({ modelName, key, newOwner, token, expectedStatus, override }) {
+    const owner = newOwner && newOwner.name;
+    expectedStatus = expectedStatus || constants.httpStatus.OK;
+    const u = getUtilForModel(modelName);
+    const toPut = u.getBasic({ owner });
+    Object.assign(toPut, dependencyProps);
+    const path = `/v1/${modelName}`;
+
+    const req = api.put(`${path}/${key}`)
+    .set('Authorization', token)
+    .expect(expectedStatus);
+
+    if (override) {
+      req.query({ override: 'admin' });
+    }
+
+    if (modelName === 'lenses') {
+      Object.entries(toPut).forEach(([key, value]) => {
+        if (key && value) {
+          req.field(key, value);
+        }
+      });
+      return req.attach('library', 'tests/api/v1/apiTestsUtils/lens.zip');
+    } else {
+      return req.send(toPut);
+    }
+  }
+
+  function startOwner({ modelName, owner, token, expectedStatus, override }) {
+    owner = owner && owner.name;
+    expectedStatus = expectedStatus || constants.httpStatus.OK;
+    const u = getUtilForModel(modelName);
+    const toCreate = u.getBasic({ owner });
+    Object.assign(toCreate, dependencyProps);
+    const path = `/v1/${modelName}/start`;
+    const req = api.post(`${path}`)
+    .set('Authorization', token)
+    .expect(expectedStatus);
+    if (override) {
+      req.query({ override: 'admin' });
+    }
+
+    return req.send(toCreate);
+  }
+
+  function createModel(modelName, createdBy, owner) {
+    createdBy = createdBy.id;
+    const installedBy = createdBy;
+    const userId = createdBy;
+    const ownerId = owner && owner.id || createdBy;
+    const u = getUtilForModel(modelName);
+    return u.createBasic({
+      createdBy,
+      installedBy,
+      userId,
+      ownerId,
+    })
+    .then((o) => {
+      obj = o.get && o.get() || o;
+      dependencyProps = {};
+      if (u.getDependencyProps) {
+        u.getDependencyProps().forEach((key) => {
+          dependencyProps[key] = obj[key];
+        });
+      }
+
+      keys = {
+        id: o.id,
+        name: o.name,
+      };
+    });
+  }
+
+  function createDependencies(modelName, createdBy) {
+    createdBy = createdBy.id;
+    const installedBy = createdBy;
+    const userId = createdBy;
+    const u = getUtilForModel(modelName);
+    if (u.doSetup) {
+      return u.doSetup({
+        createdBy,
+        installedBy,
+        userId,
+      })
+      .then((createdIds) => {
+        dependencyProps = createdIds;
+      });
+    }
+  }
+
+  function getUtilForModel(modelName) {
+    return require(`../${modelName}/utils`);
+  }
+
+  function runByKeyAndId(modelName, tests) {
+    let keyTypes = ['id', 'name'];
+    if (skipByName.includes(modelName)) {
+      keyTypes = ['id'];
+    }
+
+    keyTypes.forEach((keyType) => {
+      describe(`by ${keyType} >`, () => {
+        beforeEach(() => key = keys && keys[keyType]);
+        tests();
+      });
+    });
+  }
+}
+
+function createTokens() {
+  adminToken = tu.createAdminToken();
+  nonexistentUser = { name: 'nonexistentUser' };
+  return Promise.all([
+    tu.createUserAndToken('mainUser')
+    .then(({ user, token }) => {
+      mainUser = user;
+      token1 = token;
+    }),
+    tu.createUserAndToken('otherUser')
+    .then(({ user, token }) => {
+      otherUser = user;
+      token2 = token;
+    }),
+  ]);
+}

--- a/tests/api/v1/generatorTemplates/associations.js
+++ b/tests/api/v1/generatorTemplates/associations.js
@@ -30,6 +30,8 @@ describe(`tests/api/v1/generatorTemplates/associations.js, GET ${path} >`, () =>
     .then((user) => {
       template1.createdBy = user.id;
       template2.createdBy = user.id;
+      template1.ownerId = user.id;
+      template2.ownerId = user.id;
       conf.token = tu.createTokenFromUserName(user.name);
       done();
     })
@@ -46,9 +48,17 @@ describe(`tests/api/v1/generatorTemplates/associations.js, GET ${path} >`, () =>
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user'];
+  const associations = ['user', 'owner'];
   const schema = {
     user: Joi.object().keys({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
       name: Joi.string().required(),
       fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),

--- a/tests/api/v1/generatorTemplates/utils.js
+++ b/tests/api/v1/generatorTemplates/utils.js
@@ -79,11 +79,18 @@ module.exports = {
   forceDelete(done) {
     tu.forceDelete(tu.db.GeneratorTemplate, testStartTime)
     .then(() => tu.forceDelete(tu.db.Collector, testStartTime))
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
     .then(() => done())
     .catch(done);
   },
 
   getGeneratorTemplate,
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(GENERATOR_TEMPLATE_SIMPLE));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.GeneratorTemplate.create(toCreate);
+  },
 };

--- a/tests/api/v1/generators/associations.js
+++ b/tests/api/v1/generators/associations.js
@@ -56,6 +56,8 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
     .then((user) => {
       generatorOk.createdBy = user.id;
       generatorInfo.createdBy = user.id;
+      generatorOk.ownerId = user.id;
+      generatorInfo.ownerId = user.id;
       conf.token = tu.createTokenFromUserName(user.name);
       return GeneratorTemplate.create(generatorTemplate);
     })
@@ -83,9 +85,17 @@ describe(`tests/api/v1/generators/associations.js, GET ${path} >`, () => {
   after(gtUtil.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user', 'currentCollector', 'possibleCollectors'];
+  const associations = ['user', 'owner', 'currentCollector', 'possibleCollectors'];
   const schema = {
     user: Joi.object({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
       name: Joi.string().required(),
       fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),

--- a/tests/api/v1/lenses/associations.js
+++ b/tests/api/v1/lenses/associations.js
@@ -20,8 +20,8 @@ const Joi = require('joi');
 describe(`tests/api/v1/lenses/associations.js, GET ${path} >`, () => {
   let conf = {};
 
-  const lens1 = u.getLens();
-  const lens2 = u.getLens();
+  const lens1 = u.getBasic();
+  const lens2 = u.getBasic();
   lens1.name = 'lens1';
   lens2.name = 'lens2';
 
@@ -30,6 +30,8 @@ describe(`tests/api/v1/lenses/associations.js, GET ${path} >`, () => {
     .then((user) => {
       lens1.installedBy = user.id;
       lens2.installedBy = user.id;
+      lens1.ownerId = user.id;
+      lens2.ownerId = user.id;
       conf.token = tu.createTokenFromUserName(user.name);
       done();
     })
@@ -46,10 +48,18 @@ describe(`tests/api/v1/lenses/associations.js, GET ${path} >`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user'];
+  const associations = ['user', 'owner'];
   const schema = {
     user: Joi.object().keys({
       name: Joi.string().required(),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),
       profile: Joi.object().keys({
         name: Joi.string().required(),

--- a/tests/api/v1/lenses/delete.js
+++ b/tests/api/v1/lenses/delete.js
@@ -38,8 +38,7 @@ describe('tests/api/v1/lenses/delete.js >', () => {
   describe('with returnUser toggle on, user object should be returned: ', () => {
     before((done) => {
       tu.toggleOverride('returnUser', true);
-      const lens = u.getLens({ installedBy: userId });
-      u.doSetup(lens)
+      u.createBasic({ installedBy: userId })
       .then((lens) => {
         expect(lens.installedBy).to.equal(userId);
         lensId = lens.id;
@@ -70,7 +69,7 @@ describe('tests/api/v1/lenses/delete.js >', () => {
   describe('with returnUser toggle off, user object should not  ' +
     'be returned: ', () => {
     beforeEach((done) => {
-      u.doSetup()
+      u.createBasic()
       .then((lens) => {
         lensId = lens.id;
         done();

--- a/tests/api/v1/lenses/deleteWithoutPerms.js
+++ b/tests/api/v1/lenses/deleteWithoutPerms.js
@@ -29,7 +29,7 @@ describe('tests/api/v1/lenses/deleteWithoutPerms.js >', () => {
   });
 
   before((done) => {
-    u.doSetup()
+    u.createBasic()
     .then((lns) => {
       lens = lns;
     })

--- a/tests/api/v1/lenses/deleteWriters.js
+++ b/tests/api/v1/lenses/deleteWriters.js
@@ -37,7 +37,7 @@ describe('tests/api/v1/lenses/deleteWriters.js >', () => {
   });
 
   beforeEach((done) => {
-    u.doSetup()
+    u.createBasic()
     .then((lensInst) => {
       lens = lensInst;
     })

--- a/tests/api/v1/lenses/get.js
+++ b/tests/api/v1/lenses/get.js
@@ -40,8 +40,7 @@ describe('tests/api/v1/lenses/get.js >', () => {
   describe('with returnUser toggle on, user object should be returned: ', () => {
     before((done) => {
       tu.toggleOverride('returnUser', true);
-      const lens = u.getLens({ installedBy: userId });
-      u.doSetup(lens)
+      u.createBasic({ installedBy: userId })
       .then((lens) => {
         expect(lens.installedBy).to.equal(userId);
         lensId = lens.id;
@@ -95,7 +94,7 @@ describe('tests/api/v1/lenses/get.js >', () => {
 
   describe('returnUser toggle off, user object should NOT be returned: ', () => {
     before((done) => {
-      u.doSetup()
+      u.createBasic()
       .then((lens) => {
         lensId = lens.id;
         lensName = lens.name;

--- a/tests/api/v1/lenses/getWithLimit.js
+++ b/tests/api/v1/lenses/getWithLimit.js
@@ -21,7 +21,7 @@ describe('tests/api/v1/lenses/getWithLimit.js >', () => {
 
   before((done) => {
     for (let i = 0; i < 10; i++) {
-      const toCreate = u.getLens();
+      const toCreate = u.getBasic();
       toCreate.name += `-limitTest${i}-${i % 2 ? 'odd' : 'even'}`;
       modelList.push(toCreate);
     }

--- a/tests/api/v1/lenses/getWriters.js
+++ b/tests/api/v1/lenses/getWriters.js
@@ -34,7 +34,7 @@ describe('tests/api/v1/lenses/getWriters.js >', () => {
   });
 
   before((done) => {
-    u.doSetup()
+    u.createBasic()
     .then((lensInst) => {
       lens = lensInst;
     })

--- a/tests/api/v1/lenses/patch.js
+++ b/tests/api/v1/lenses/patch.js
@@ -37,8 +37,7 @@ describe('tests/api/v1/lenses/patch.js >', () => {
   describe('with returnUser toggle on, user object should be returned: ', () => {
     before((done) => {
       tu.toggleOverride('returnUser', true);
-      const lens = u.getLens({ installedBy: userId });
-      u.doSetup(lens)
+      u.createBasic({ installedBy: userId })
       .then((lens) => {
         expect(lens.installedBy).to.equal(userId);
         lensId = lens.id;
@@ -69,7 +68,7 @@ describe('tests/api/v1/lenses/patch.js >', () => {
 
   describe('with returnUser toggle off, user should not be returned', () => {
     before((done) => {
-      u.doSetup()
+      u.createBasic()
       .then((lens) => {
         lensId = lens.id;
         done();

--- a/tests/api/v1/lenses/post.js
+++ b/tests/api/v1/lenses/post.js
@@ -37,7 +37,7 @@ describe('tests/api/v1/lenses/post.js >', () => {
 
   describe('post duplicate fails >', () => {
     beforeEach((done) => {
-      u.doSetup()
+      u.createBasic()
       .then(() => done())
       .catch(done);
     });

--- a/tests/api/v1/lenses/postWriters.js
+++ b/tests/api/v1/lenses/postWriters.js
@@ -35,7 +35,7 @@ describe('tests/api/v1/lenses/postWriters.js >', () => {
   });
 
   before((done) => {
-    u.doSetup()
+    u.createBasic()
     .then((lensInst) => {
       lens = lensInst;
     })

--- a/tests/api/v1/lenses/put.js
+++ b/tests/api/v1/lenses/put.js
@@ -37,8 +37,7 @@ describe('tests/api/v1/lenses/put.js >', () => {
   describe('with returnUser toggle on, user object should be returned: ', () => {
     before((done) => {
       tu.toggleOverride('returnUser', true);
-      const lens = u.getLens({ installedBy: userId });
-      u.doSetup(lens)
+      u.createBasic({ installedBy: userId })
       .then((lens) => {
         expect(lens.installedBy).to.equal(userId);
         lensId = lens.id;
@@ -70,7 +69,7 @@ describe('tests/api/v1/lenses/put.js >', () => {
 
   describe('with returnUser toggle off, user should not be returned', () => {
     before((done) => {
-      u.doSetup()
+      u.createBasic()
       .then((lens) => {
         lensId = lens.id;
         done();

--- a/tests/api/v1/lenses/putPatchWithoutPerms.js
+++ b/tests/api/v1/lenses/putPatchWithoutPerms.js
@@ -29,7 +29,7 @@ describe('tests/api/v1/lenses/putPatchWithoutPerms.js >', () => {
   });
 
   before((done) => {
-    u.doSetup()
+    u.createBasic()
     .then((lns) => {
       lens = lns;
     })

--- a/tests/api/v1/lenses/utils.js
+++ b/tests/api/v1/lenses/utils.js
@@ -20,30 +20,26 @@ const willSendthis = fs.readFileSync(
   path.join(__dirname,
     '../apiTestsUtils/lens.zip')
 );
-
-/**
- * @param {Object} overWriteObject - to replace select key values.
- * @returns {Object} - an input to Lens.create
- */
-function getLens(overWriteObject) {
-  return Object.assign(overWriteObject || {}, { name,
-    sourceName: 'testSourceLensName',
-    description: 'test Description',
-    sourceDescription: 'test Source Description',
-    isPublished: true,
-    library: willSendthis,
-  });
+const basic = {
+  name: `${tu.namePrefix}testLensName`,
+  sourceName: 'testSourceLensName',
+  description: 'test Description',
+  sourceDescription: 'test Source Description',
+  isPublished: true,
 };
 
 module.exports = {
   name,
-  getLens,
-  doSetup(_lens) {
-    return new tu.db.Sequelize.Promise((resolve, reject) => {
-      tu.db.Lens.create(_lens || getLens())
-      .then((createdLens) => resolve(createdLens))
-      .catch((err) => reject(err));
-    });
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    defaultProps.library = willSendthis;
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Lens.create(toCreate);
   },
 
   forceDelete(done) {

--- a/tests/api/v1/perspectives/app.js
+++ b/tests/api/v1/perspectives/app.js
@@ -38,9 +38,9 @@ describe('tests/api/v1/perspectives/app.js, dropdown and modal data >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/associations.js
+++ b/tests/api/v1/perspectives/associations.js
@@ -47,6 +47,8 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
     .then((user) => {
       persp1.createdBy = user.id;
       persp2.createdBy = user.id;
+      persp1.ownerId = user.id;
+      persp2.ownerId = user.id;
       conf.token = tu.createTokenFromUserName(user.name);
       done();
     })
@@ -55,9 +57,9 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => {
-      persp1.lensId = createdLens.id;
-      persp2.lensId = createdLens.id;
+    .then(({ lensId }) => {
+      persp1.lensId = lensId;
+      persp2.lensId = lensId;
       return Perspective.create(persp1);
     })
     .then(() => Perspective.create(persp2))
@@ -68,10 +70,18 @@ describe(`tests/api/v1/perspectives/associations.js, GET ${path} >`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user', 'lens'];
+  const associations = ['user', 'owner', 'lens'];
   const schema = {
     user: Joi.object().keys({
       name: Joi.string().required(),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),
       profile: Joi.object().keys({
         name: Joi.string().required(),

--- a/tests/api/v1/perspectives/delete.js
+++ b/tests/api/v1/perspectives/delete.js
@@ -35,9 +35,9 @@ describe('tests/api/v1/perspectives/delete.js >', () => {
 
   beforeEach((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
     }))
     .then((createdPersp) => {

--- a/tests/api/v1/perspectives/deleteWithoutPerms.js
+++ b/tests/api/v1/perspectives/deleteWithoutPerms.js
@@ -30,9 +30,9 @@ describe('tests/api/v1/perspectives/deleteWithoutPerms.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/deleteWriters.js
+++ b/tests/api/v1/perspectives/deleteWriters.js
@@ -38,9 +38,9 @@ describe('tests/api/v1/perspectives/deleteWriters.js >', () => {
 
   beforeEach((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/get.js
+++ b/tests/api/v1/perspectives/get.js
@@ -37,9 +37,9 @@ describe('tests/api/v1/perspectives/get.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/getWithLimit.js
+++ b/tests/api/v1/perspectives/getWithLimit.js
@@ -21,10 +21,10 @@ describe('tests/api/v1/perspectives/getWithLimit.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => {
+    .then(({ lensId }) => {
       const obj = {
         name: `${tu.namePrefix}testPersp`,
-        lensId: createdLens.id,
+        lensId,
         rootSubject: 'myMainSubject',
         aspectFilter: ['temperature', 'humidity'],
         aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/getWriters.js
+++ b/tests/api/v1/perspectives/getWriters.js
@@ -36,9 +36,9 @@ describe('tests/api/v1/perspectives/getWriters.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/patch.js
+++ b/tests/api/v1/perspectives/patch.js
@@ -38,9 +38,9 @@ describe('tests/api/v1/perspectives/patch.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: aspectFilterArr,
       aspectTagFilter: aspectTagFilterArr,

--- a/tests/api/v1/perspectives/post.js
+++ b/tests/api/v1/perspectives/post.js
@@ -39,8 +39,8 @@ describe('tests/api/v1/perspectives/post.js >', () => {
 
   beforeEach((done) => {
     u.doSetup()
-    .then((lens) => {
-      createdLensId = lens.id;
+    .then(({ lensId }) => {
+      createdLensId = lensId;
       basicParams.lensId = createdLensId;
       done();
     })

--- a/tests/api/v1/perspectives/postWriters.js
+++ b/tests/api/v1/perspectives/postWriters.js
@@ -36,9 +36,9 @@ describe('tests/api/v1/perspectives/postWriters.js', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/perspectives/put.js
+++ b/tests/api/v1/perspectives/put.js
@@ -52,9 +52,9 @@ describe('tests/api/v1/perspectives/put.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: aspectFilterArr,
       aspectTagFilter: aspectTagFilterArr,

--- a/tests/api/v1/perspectives/putPatchWithoutPerms.js
+++ b/tests/api/v1/perspectives/putPatchWithoutPerms.js
@@ -32,9 +32,9 @@ describe('tests/api/v1/perspectives/putPatchWithoutPerms.js >', () => {
 
   before((done) => {
     u.doSetup()
-    .then((createdLens) => tu.db.Perspective.create({
+    .then(({ lensId }) => tu.db.Perspective.create({
       name: `${tu.namePrefix}testPersp`,
-      lensId: createdLens.id,
+      lensId,
       rootSubject: 'myMainSubject',
       aspectFilter: ['temperature', 'humidity'],
       aspectTagFilter: ['temp', 'hum'],

--- a/tests/api/v1/roomTypes/utils.js
+++ b/tests/api/v1/roomTypes/utils.js
@@ -165,6 +165,16 @@ module.exports = {
     return tu.db.RoomType.create(standard);
   },
 
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(standard));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.RoomType.create(toCreate);
+  },
+
   forceDelete(done) {
     tu.forceDelete(tu.db.RoomType, testStartTime)
     .then(() => done())

--- a/tests/api/v1/rooms/utils.js
+++ b/tests/api/v1/rooms/utils.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 const tu = require('../../../testUtils');
+const roomTypeUtil = require('../roomTypes/utils');
 
 const testStartTime = new Date();
 const n = `${tu.namePrefix}TestRoom`;
@@ -119,6 +120,36 @@ module.exports = {
 
   createStandard() {
     return tu.db.Room.create(standard);
+  },
+
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(standard));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  doSetup(props={}) {
+    const { createdBy } = props;
+    return roomTypeUtil.createBasic({ createdBy })
+    .then((roomType) => {
+      const createdIds = {
+        type: roomType.id,
+      };
+      return createdIds;
+    });
+  },
+
+  createBasic(overrideProps={}) {
+    const { createdBy } = overrideProps;
+    return this.doSetup({ createdBy })
+    .then(({ type }) => {
+      Object.assign(overrideProps, { type });
+      const toCreate = this.getBasic(overrideProps);
+      return tu.db.Room.create(toCreate);
+    });
+  },
+
+  getDependencyProps() {
+    return ['type'];
   },
 
   forceDelete(done) {

--- a/tests/api/v1/samples/delete.js
+++ b/tests/api/v1/samples/delete.js
@@ -38,8 +38,7 @@ describe('tests/api/v1/samples/delete.js >', () => {
     });
 
     beforeEach((done) => {
-      u.doSetup()
-      .then((samp) => Sample.create(samp))
+      u.createBasic()
       .then((samp) => {
         sampleName = samp.name;
         done();
@@ -119,9 +118,8 @@ describe('tests/api/v1/samples/delete.js >', () => {
     });
 
     beforeEach((done) => {
-      u.doSetup()
-      .then((samp) => {
-        samp.relatedLinks = [
+      u.createBasic({
+        relatedLinks: [
           {
             name: 'rlink0',
             url: 'https://samples.com',
@@ -130,10 +128,7 @@ describe('tests/api/v1/samples/delete.js >', () => {
             name: 'rlink1',
             url: 'https://samples.com',
           },
-        ];
-        return Sample.create(
-          samp
-        );
+        ],
       })
       .then((samp) => {
         sampleName = samp.name;

--- a/tests/api/v1/samples/deleteWithoutPerms.js
+++ b/tests/api/v1/samples/deleteWithoutPerms.js
@@ -43,9 +43,8 @@ describe('tests/api/v1/samples/deleteWithoutPerms.js >', () => {
     User.findOne({ where: { name: tu.userName } })
     .then((usr) => {
       user = usr;
-      return u.doSetup();
+      return u.createBasic();
     })
-    .then((samp) => Sample.create(samp))
     .then((samp) => {
       sampleName = samp.name;
       const aspectName = sampleName.split('|')[1].toLowerCase();

--- a/tests/api/v1/samples/get.js
+++ b/tests/api/v1/samples/get.js
@@ -40,8 +40,8 @@ describe(`tests/api/v1/samples/get.js, GET ${path} >`, () => {
 
   before((done) => {
     u.doSetup()
-    .then((samp) => {
-      samp.provider = userId;
+    .then(({ aspectId, subjectId }) => {
+      const samp = u.getBasic({ aspectId, subjectId, provider: userId });
       return Sample.create(samp, userObject);
     })
     .then((samp) => {
@@ -210,8 +210,7 @@ describe(`tests/api/v1/samples/get.js, GET ${path} > ` +
   });
 
   before((done) => {
-    u.doSetup()
-    .then((samp) => Sample.create(samp))
+    u.createBasic()
     .then((samp) => {
       sampleName = samp.name;
       done();

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -42,8 +42,7 @@ describe('tests/api/v1/samples/patch.js >', () => {
     let sampleValue;
 
     beforeEach((done) => {
-      u.doSetup()
-      .then((samp) => Sample.create(samp))
+      u.createBasic()
       .then((samp) => {
         sampleName = samp.name;
         sampUpdatedAt = samp.updatedAt;
@@ -340,8 +339,7 @@ describe('tests/api/v1/samples/patch.js >', () => {
     });
 
     before((done) => {
-      u.doSetup()
-      .then((samp) => Sample.create(samp))
+      u.createBasic()
       .then((samp) => {
         const subjectName = samp.name.split('|')[0].toLowerCase();
         return Subject.findOne({ where: { name: { [Op.iLike]: subjectName } } });
@@ -380,8 +378,7 @@ describe('tests/api/v1/samples/patch.js >', () => {
     });
 
     before((done) => {
-      u.doSetup()
-      .then((samp) => Sample.create(samp))
+      u.createBasic()
       .then((samp) => {
         sampleName = samp.name;
         const aspectName = sampleName.split('|')[1].toLowerCase();

--- a/tests/api/v1/samples/patchWithoutPerms.js
+++ b/tests/api/v1/samples/patchWithoutPerms.js
@@ -33,8 +33,7 @@ describe('tests/api/v1/samples/patchWithoutPerms.js, ' +
   });
 
   before((done) => {
-    u.doSetup()
-    .then((samp) => Sample.create(samp))
+    u.createBasic()
     .then((samp) => {
       sampleName = samp.name;
       const aspectName = sampleName.split('|')[1].toLowerCase();

--- a/tests/api/v1/samples/post.js
+++ b/tests/api/v1/samples/post.js
@@ -33,8 +33,8 @@ describe('tests/api/v1/samples/post.js >', () => {
   let sampleToPost;
   beforeEach((done) => {
     u.doSetup()
-    .then((samp) => {
-      sampleToPost = samp;
+    .then(({ aspectId, subjectId }) => {
+      sampleToPost = u.getBasic({ aspectId, subjectId });
       done();
     })
     .catch(done);
@@ -264,9 +264,9 @@ describe('tests/api/v1/samples/post.js > subject isPublished false >', () => {
 
   beforeEach((done) => {
     u.doSetup()
-    .then((samp) => {
-      sampleToPost = samp;
-      return tu.db.Subject.findById(samp.subjectId);
+    .then(({ aspectId, subjectId }) => {
+      sampleToPost = u.getBasic({ aspectId, subjectId });
+      return tu.db.Subject.findById(sampleToPost.subjectId);
     })
     .then((sub) => {
       sub.update({ isPublished: false });

--- a/tests/api/v1/samples/postWithProvider.js
+++ b/tests/api/v1/samples/postWithProvider.js
@@ -32,8 +32,8 @@ describe('tests/api/v1/samples/postWithProvider.js >', () => {
 
   beforeEach((done) => {
     u.doSetup()
-    .then((samp) => {
-      sampleToPost = samp;
+    .then(({ aspectId, subjectId }) => {
+      sampleToPost = u.getBasic({ aspectId, subjectId });
       done();
     })
     .catch(done);

--- a/tests/api/v1/samples/utils.js
+++ b/tests/api/v1/samples/utils.js
@@ -11,6 +11,8 @@
  */
 'use strict';
 const tu = require('../../../testUtils');
+const subjectUtil = require('../subjects/utils');
+const aspectUtil = require('../aspects/utils');
 const testStartTime = new Date();
 const aspectName = `${tu.namePrefix}TEST_ASPECT`;
 const subjectName = `${tu.namePrefix}TEST_SUBJECT`;
@@ -92,24 +94,48 @@ function doCustomSetup(aspectName, subjectName) {
   });
 }
 
+const basic = {
+  value: '1',
+};
+
 module.exports = {
   aspectToCreate,
   sampleName,
   doCustomSetup,
-  doSetup() {
-    return new tu.db.Sequelize.Promise((resolve, reject) => {
-      const samp = { value: '1' };
-      tu.db.Aspect.create(aspectToCreate)
-      .then((a) => {
-        samp.aspectId = a.id;
-        return tu.db.Subject.create(subjectToCreate);
-      })
-      .then((s) => {
-        samp.subjectId = s.id;
-        resolve(samp);
-      })
-      .catch((err) => reject(err));
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  doSetup(props={}) {
+    const { provider } = props;
+    const basicAspect = JSON.parse(JSON.stringify(aspectToCreate));
+    basicAspect.createdBy = provider;
+    return Promise.all([
+      tu.db.Aspect.create(basicAspect),
+      subjectUtil.createBasic({ createdBy: provider }),
+    ])
+    .then(([aspect, subject]) => {
+      const createdIds = {
+        aspectId: aspect.id,
+        subjectId: subject.id,
+      };
+      return createdIds;
     });
+  },
+
+  createBasic(overrideProps={}) {
+    const { provider } = overrideProps;
+    return this.doSetup({ provider })
+    .then(({ aspectId, subjectId }) => {
+      Object.assign(overrideProps, { aspectId, subjectId });
+      const toCreate = this.getBasic(overrideProps);
+      return tu.Sample.create(toCreate);
+    });
+  },
+
+  getDependencyProps() {
+    return ['aspectId', 'subjectId'];
   },
 
   doSetupAspectNotPublished() {
@@ -142,7 +168,7 @@ module.exports = {
     .catch(done);
   },
 
-  subjectToCreate,
+  subjectToCreate: subjectUtil.getBasic(),
 
   aspectToCreateNotPublished,
 };

--- a/tests/api/v1/subjects/associations.js
+++ b/tests/api/v1/subjects/associations.js
@@ -37,6 +37,8 @@ describe(`tests/api/v1/subjects/associations.js, GET ${path} >`, () => {
     .then((user) => {
       na.createdBy = user.id;
       us.createdBy = user.id;
+      na.ownerId = user.id;
+      us.ownerId = user.id;
       conf.token = tu.createTokenFromUserName(user.name);
       done();
     })
@@ -54,9 +56,17 @@ describe(`tests/api/v1/subjects/associations.js, GET ${path} >`, () => {
   after(u.forceDelete);
   after(tu.forceDeleteUser);
 
-  const associations = ['user'];
+  const associations = ['user', 'owner'];
   const schema = {
     user: Joi.object().keys({
+      name: Joi.string().required(),
+      fullName: Joi.string().optional().allow(null),
+      email: Joi.string().required(),
+      profile: Joi.object().keys({
+        name: Joi.string().required(),
+      }).required(),
+    }),
+    owner: Joi.object().keys({
       name: Joi.string().required(),
       fullName: Joi.string().optional().allow(null),
       email: Joi.string().required(),

--- a/tests/api/v1/subjects/utils.js
+++ b/tests/api/v1/subjects/utils.js
@@ -16,7 +16,22 @@ const testStartTime = new Date();
 const samstoinit = require('../../../../cache/sampleStoreInit');
 const rcli = require('../../../../cache/redisCache').client.sampleStore;
 
+const basic = {
+  name: `${tu.namePrefix}TEST_SUBJECT`,
+  isPublished: true,
+};
+
 module.exports = {
+  getBasic(overrideProps={}) {
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Subject.create(toCreate);
+  },
+
   forceDelete(done) {
     Promise.join(
       samstoinit.eradicate(),

--- a/tests/api/v1/verbs/doPost.js
+++ b/tests/api/v1/verbs/doPost.js
@@ -30,13 +30,11 @@ describe('api/v1/helpers/verbs/postUtils.js, Tests >', () => {
       },
     };
 
-    const params = {
-      queryBody: {
-        value: ASPECT,
-      },
+    const toPost = {
+      value: ASPECT,
     };
 
-    pu.makePostPromise(params, props, req)
+    pu.makePostPromise(toPost, props, req)
     .then((str) => {
       expect(str).to.equal(expectedStr);
       done();

--- a/tests/db/model/generatortemplate/classMethods.js
+++ b/tests/db/model/generatortemplate/classMethods.js
@@ -23,7 +23,7 @@ describe('tests/db/model/generatortemplate/classMethods.js >', () => {
   describe('getAssociation >', () => {
     it('should return all the associations', (done) => {
       const associations = GeneratorTemplate.getGeneratortemplateAssociations();
-      expect(associations).to.all.keys('writers', 'user');
+      expect(associations).to.all.keys('writers', 'user', 'owner');
       done();
     });
   });

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -18,7 +18,7 @@ const constants = require('../api/v1/constants');
 const db = require('../db');
 const sampleModel = require('../cache/models/samples');
 const testStartTime = new Date();
-const userName = `${pfx}testUser@refocus.com`;
+const defaultUserName = `${pfx}testUser`;
 const featureToggles = require('feature-toggles');
 const adminUser = require('../config').db.adminUser;
 const adminProfile = require('../config').db.adminProfile;
@@ -41,7 +41,7 @@ const Sample = {
   // Return all the samples in sample store
   findAll: () => {
     const commands = [];
-    return redisClient.sortAsync(sampleStore.constants.indexKey.sample,'alpha')
+    return redisClient.sortAsync(sampleStore.constants.indexKey.sample, 'alpha')
     .then((sampleKeys) => {
 
       sampleKeys.forEach((key) => {
@@ -62,6 +62,7 @@ const Sample = {
       if (!sample || !aspect) {
         return null;
       }
+
       sample.aspect = aspect;
       return sample;
     }).catch((err) => err);
@@ -199,8 +200,8 @@ module.exports = {
     .then((createdProfile) =>
       db.User.create({
         profileId: createdProfile.id,
-        name: userName + 'third',
-        email: userName + 'third',
+        name: defaultUserName + 'third',
+        email: `${defaultUserName}third@refocus.com`,
         password: 'user123password',
       })
     );
@@ -214,8 +215,8 @@ module.exports = {
     .then((createdProfile) =>
       db.User.create({
         profileId: createdProfile.id,
-        name: userName + 'second',
-        email: userName + 'second',
+        name: defaultUserName + 'second',
+        email: `${defaultUserName}second@refocus.com`,
         password: 'user123password',
       })
     );
@@ -228,22 +229,21 @@ module.exports = {
 
   // create user and corresponding token to be used in api tests.
   // returns both the user and the token object
-  createUserAndToken() {
+  createUserAndToken(userName=defaultUserName) {
     let profile;
-    return db.Profile.create({ name: `${pfx}testProfile` })
+    return db.Profile.create({ name: `${pfx}${userName}testProfile` })
     .then((createdProfile) => {
       profile = createdProfile;
       return db.User.create({
         profileId: createdProfile.id,
         name: userName,
-        email: userName,
+        email: `${userName}@refocus.com`,
         password: 'user123password', });
     })
     .then((user) => {
       user.profile = profile.dataValues;
-      const obj = { user };
-      obj.token = jwtUtil.createToken(userName, userName);
-      return obj;
+      const token = jwtUtil.createToken(userName, userName);
+      return { user, token };
     });
   },
 
@@ -260,12 +260,12 @@ module.exports = {
   },
 
   // create user and corresponding token to be used in api tests.
-  createToken() {
-    return db.Profile.create({ name: `${pfx}testProfile` })
+  createToken(userName=defaultUserName) {
+    return db.Profile.create({ name: `${pfx}${userName}testProfile` })
     .then((createdProfile) => db.User.create({
       profileId: createdProfile.id,
       name: userName,
-      email: userName,
+      email: `${userName}@refocus.com`,
       password: 'user123password',
     }))
     .then(() => jwtUtil.createToken(userName, userName));
@@ -274,7 +274,7 @@ module.exports = {
   createGeneratorToken(tokenName) {
     return jwtUtil.createToken(
       tokenName,
-      userName,
+      defaultUserName,
       { IsGenerator: true }
     );
   },
@@ -310,8 +310,7 @@ module.exports = {
     featureToggles._toggles[key] = value;
   }, // toggleOverride
 
-
   // username used to create the token in all the tests
-  userName,
+  userName: defaultUserName,
 
 }; // exports


### PR DESCRIPTION
This change adds an owner attribute to the following models:
  - aspects
  - botActions
  - botData
  - bots
  - collectorGroups
  - collectors
  - events
  - generators
  - generatorTemplates
  - lenses
  - perspectives
  - rooms
  - roomTypes
  - subjects

Things this change doesn't cover:
  - functional effects. Anything that's currently based on the user/createdBy will still be that way. This should be addressed in the spike for restricting permissions.
  - Reconciling with the existing User associations (with foreign key createdBy/installedBy/userId). Having both a user and an owner might be redundant in some cases, and it might make sense to change the name of the existing "user" field to "createdBy" and standardize the foreign key names; this change doesn't address that, it just creates a new owner attribute and leaves the existing ones as they are. We can clean this up in another story if necessary.
- The following models do not have an owner attribute. (Let me know if you think any of these should, or any of the above shouldn't)
  - auditEvent
  - globalConfig
  - profile
  - sample
  - ssoconfig
  - token
  - user

Changes are organized by commit.