### PR TITLE
Handle null subject tags and relatedLinks

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -35,10 +35,10 @@ function updateInstance(o, puttableFields, toPut) {
     const key = keys[i];
     if (toPut[key] === undefined) {
       let nullish = null;
-      if (puttableFields[key].type === 'boolean') {
-        nullish = false;
-      } else if (puttableFields[key].enum) {
+      if (puttableFields[key].default) { // could be enum | array etc
         nullish = puttableFields[key].default;
+      } else if (puttableFields[key].type === 'boolean') {
+        nullish = false;
       }
 
       o.set(key, nullish);

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -9662,6 +9662,7 @@ paths:
                   The absolutePath of the subject's parent.
               tags:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -9671,6 +9672,7 @@ paths:
                   underscore (_) and dash (-). Tag names cannot start with a dash (-).
               relatedLinks:
                 type: array
+                default: []
                 items:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -96,7 +96,7 @@ module.exports = function subject(seq, dataTypes) {
     },
     relatedLinks: {
       type: dataTypes.ARRAY(dataTypes.JSON),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultJsonArrayValue,
       validate: {
         validateJsonSchema(value) {
@@ -106,7 +106,7 @@ module.exports = function subject(seq, dataTypes) {
     },
     tags: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultArrayValue,
     },
     sortBy: {

--- a/migrations/20190208214407-subject-tags-rlinks-not-null.js
+++ b/migrations/20190208214407-subject-tags-rlinks-not-null.js
@@ -1,0 +1,70 @@
+'use strict';
+const Subject = require('../db/index').Subject;
+const constants = require('../db/constants');
+const TBL = 'Subjects';
+
+module.exports = {
+  up: (qi, Sequelize) =>
+    /* Get subjects with tags = null, update to [],
+     * Get subjects with rlinks = null, update to [],
+     * Update tags column to set allowNull: false,
+     * update relatedLinks column to set allowNull: false */
+    qi.sequelize.transaction(() => {
+      const promisesArr = [];
+      const subjTagQuery = 'SELECT * from "Subjects" where "tags" IS NULL';
+
+      // get subjects with null tags
+      return qi.sequelize.query(subjTagQuery, {
+        type: qi.sequelize.QueryTypes.SELECT,
+      }).then((subjects) => {
+        subjects.forEach((subj) => {
+          // update tags to empty array;
+          promisesArr.push(Subject.update(
+            { tags: [] }, { where: { id: subj.id } }
+          ));
+        });
+
+        // get subjects with null relatedLinks
+        const subjRlinksQuery =
+          'SELECT * from "Subjects" where "relatedLinks" IS NULL';
+        return qi.sequelize.query(subjRlinksQuery, {
+          type: qi.sequelize.QueryTypes.SELECT,
+        });
+      })
+      .then((subjects) => {
+        subjects.forEach((subj) => {
+          // update relatedLinks to empty array;
+          promisesArr.push(Subject.update(
+            { relatedLinks: [] }, { where: { id: subj.id } }
+          ));
+        });
+
+        return Promise.all(promisesArr);
+      })
+      .then(() => qi.changeColumn(TBL, 'tags', { // update tags column
+        type: Sequelize.ARRAY(
+          Sequelize.STRING(constants.fieldlen.normalName)
+        ),
+        allowNull: false, // change to false
+        defaultValue: constants.defaultArrayValue,
+      }))
+
+      // update relatedLinks column
+      .then(() => qi.changeColumn(TBL, 'relatedLinks', {
+        type: Sequelize.ARRAY(Sequelize.JSON),
+        allowNull: false, // change to false
+        defaultValue: constants.defaultJsonArrayValue,
+      }));
+    }),
+
+  down: (qi, Sequelize) => qi.changeColumn(TBL, 'tags', {
+    type: Sequelize.ARRAY(Sequelize.STRING(constants.fieldlen.normalName)),
+    allowNull: true, // back to true
+    defaultValue: constants.defaultArrayValue,
+  })
+  .then(() => qi.changeColumn(TBL, 'relatedLinks', {
+    type: Sequelize.ARRAY(Sequelize.JSON),
+    allowNull: true, // back to true
+    defaultValue: constants.defaultJsonArrayValue,
+  })),
+};

--- a/tests/api/v1/subjects/patch.js
+++ b/tests/api/v1/subjects/patch.js
@@ -329,6 +329,33 @@ describe(`tests/api/v1/subjects/patch.js, PATCH ${path} >`, () => {
     .end(done);
   });
 
+  it('tags and related links not provided, should set to empty array',
+    (done) => {
+      api.patch(`${path}/${i1}`)
+      .set('Authorization', token)
+      .send({
+        name: `${tu.namePrefix}Quebec`,
+        isPublished: true,
+      })
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.tags).to.have.length(0);
+        expect(res.body.relatedLinks).to.have.length(0);
+      })
+      .end((err /* , res */) => {
+        if (err) {
+          done(err);
+        }
+
+        Subject.findById(i1)
+          .then((subj) => {
+            expect(subj.tags).to.eql([]);
+            expect(subj.relatedLinks).to.eql([]);
+            done();
+          });
+      });
+    });
+
   it('patch child name and isPublished', (done) => {
     p1.relatedLinks = [];
     api.patch(`${path}/${i1}`)

--- a/tests/api/v1/subjects/post.js
+++ b/tests/api/v1/subjects/post.js
@@ -637,7 +637,7 @@ describe(`tests/api/v1/subjects/post.js, POST ${path} >`, () => {
             expect(subj.tags).to.eql([]);
             expect(subj.relatedLinks).to.eql([]);
             done();
-           });
+          });
         });
       });
   });

--- a/tests/api/v1/subjects/post.js
+++ b/tests/api/v1/subjects/post.js
@@ -614,6 +614,32 @@ describe(`tests/api/v1/subjects/post.js, POST ${path} >`, () => {
       })
       .end(done);
     });
+
+    it('tags and related links not provided, should set to empty array',
+      (done) => {
+        const subjectToPost = { name: `${tu.namePrefix}SouthAmerica` };
+        api.post(path)
+        .set('Authorization', token)
+        .send(subjectToPost)
+        .expect(constants.httpStatus.CREATED)
+        .expect((res) => {
+          expect(res.body.tags).to.have.length(0);
+          expect(res.body.relatedLinks).to.have.length(0);
+        })
+        .end((err /* , res */) => {
+          if (err) {
+            console.log(err);
+            return done(err);
+          }
+
+          Subject.findOne({ where: { name: `${tu.namePrefix}SouthAmerica` } })
+          .then((subj) => {
+            expect(subj.tags).to.eql([]);
+            expect(subj.relatedLinks).to.eql([]);
+            done();
+           });
+        });
+      });
   });
 
   describe('validate helpEmail/helpUrl required >', () => {

--- a/tests/api/v1/subjects/put.js
+++ b/tests/api/v1/subjects/put.js
@@ -656,12 +656,12 @@ describe('tests/api/v1/subjects/put.js >', () => {
               done(err);
             }
 
-            Subject.findOne({ where: { id: subjectId } })
-              .then((subj) => {
-                expect(subj.tags).to.eql([]);
-                expect(subj.relatedLinks).to.eql([]);
-                done();
-              });
+            Subject.findById(subjectId)
+            .then((subj) => {
+              expect(subj.tags).to.eql([]);
+              expect(subj.relatedLinks).to.eql([]);
+              done();
+            });
           });
       });
   });

--- a/tests/api/v1/subjects/put.js
+++ b/tests/api/v1/subjects/put.js
@@ -637,6 +637,33 @@ describe('tests/api/v1/subjects/put.js >', () => {
         done();
       });
     });
+
+    it('tags and related links not provided, should set to empty array',
+      (done) => {
+        const toPut = {
+          name: `${tu.namePrefix}newName`,
+          timeout: '220s',
+        };
+        api.put(`${path}/${subjectId}`)
+          .set('Authorization', token)
+          .send(toPut)
+          .expect(constants.httpStatus.OK)
+          .expect((res) => {
+            expect(res.body.tags).to.have.length(ZERO);
+          })
+          .end((err /* , res */) => {
+            if (err) {
+              done(err);
+            }
+
+            Subject.findOne({ where: { id: subjectId } })
+              .then((subj) => {
+                expect(subj.tags).to.eql([]);
+                expect(subj.relatedLinks).to.eql([]);
+                done();
+              });
+          });
+      });
   });
 
   describe('api: PUT subjects, validate helpEmail/helpUrl required >', () => {


### PR DESCRIPTION
**What was the problem?**
When doing PUT /subjects/{name} without tags, we were explicitly settings tags = null, and since our db is fine with tags being null (allowNull: true) - it will bypass setting it to default value.

**Resolution:** 
1. Change PUT logic to set tags to default value (provided in swagger) if tags are not present in request.
2. Since we do not have a use-case for tags to be null, we should enforce tags to be notNull

This problem applies to almost all the array columns in our models including samples (related links) When it came to migration, I realized it will be too much for one PR. So, I am taking **staggered** **approach**. This PR is only for subjects model. Next would be - **aspects, perspectives, generators, generatorTemplates**. And then final PR for **samples** (db is redis - so migration will not work to update data).

Note: There is a sortBy column on Subjects model as well - allowNull: true, default: ''. This needs to be further looked into, I have a feeling we might have use cases for this one to be as is. I will create another user story for this.
