### PR TITLE
tags|relatedLinks|filters not null for Aspects|Generators|GeneratorTemplates|Perspectives|Samples

### DIFF
--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -4541,6 +4541,7 @@ paths:
                   type: string
               tags:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6481,6 +6482,7 @@ paths:
                   - EXCLUDE
               statusFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   enum:
@@ -6563,6 +6565,7 @@ paths:
                   The absolute path of the root subject.
               aspectFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6572,6 +6575,7 @@ paths:
                   underscore (_) and dash (-).
               aspectTagFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6581,6 +6585,7 @@ paths:
                   underscore (_) and dash (-).
               subjectTagFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -800,6 +800,7 @@ paths:
                   their type.
               tags:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -809,6 +810,7 @@ paths:
                   underscore (_) and dash (-). Tag names cannot start with a dash (-).
               relatedLinks:
                 type: array
+                default: []
                 items:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >
@@ -4409,6 +4411,7 @@ paths:
                   type: string
               tags:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6433,6 +6436,7 @@ paths:
                   The absolute path of the root subject.
               aspectFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6442,6 +6446,7 @@ paths:
                   underscore (_) and dash (-).
               aspectTagFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6451,6 +6456,7 @@ paths:
                   underscore (_) and dash (-).
               subjectTagFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   maxLength: 60
@@ -6584,6 +6590,7 @@ paths:
                   underscore (_) and dash (-).
               statusFilter:
                 type: array
+                default: []
                 items:
                   type: string
                   enum:
@@ -8727,6 +8734,7 @@ paths:
                   occurs, value is set to null.
               relatedLinks:
                 type: array
+                default: []
                 items:
                   $ref: "#/definitions/RelatedLinkRequest"
                 description: >

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -120,7 +120,7 @@ module.exports = function aspect(seq, dataTypes) {
     },
     relatedLinks: {
       type: dataTypes.ARRAY(dataTypes.JSON),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultJsonArrayValue,
       validate: {
         validateJsonSchema(value) {
@@ -130,7 +130,7 @@ module.exports = function aspect(seq, dataTypes) {
     },
     tags: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultArrayValue,
     },
   }, {

--- a/db/model/generator.js
+++ b/db/model/generator.js
@@ -117,7 +117,7 @@ module.exports = function generator(seq, dataTypes) {
     },
     tags: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultArrayValue,
     },
     generatorTemplate: {

--- a/db/model/generatortemplate.js
+++ b/db/model/generatortemplate.js
@@ -104,7 +104,7 @@ module.exports = function user(seq, dataTypes) {
     },
     tags: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultArrayValue,
     },
     author: {

--- a/db/model/perspective.js
+++ b/db/model/perspective.js
@@ -47,7 +47,7 @@ module.exports = function perspective(seq, dataTypes) {
     aspectFilter: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
       defaultValue: constants.defaultArrayValue,
-      allowNull: true,
+      allowNull: false,
     },
     aspectTagFilterType: {
       type: dataTypes.ENUM('INCLUDE', 'EXCLUDE'),
@@ -57,7 +57,7 @@ module.exports = function perspective(seq, dataTypes) {
     aspectTagFilter: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
       defaultValue: constants.defaultArrayValue,
-      allowNull: true,
+      allowNull: false,
     },
     subjectTagFilterType: {
       type: dataTypes.ENUM('INCLUDE', 'EXCLUDE'),
@@ -67,7 +67,7 @@ module.exports = function perspective(seq, dataTypes) {
     subjectTagFilter: {
       type: dataTypes.ARRAY(dataTypes.STRING(constants.fieldlen.normalName)),
       defaultValue: constants.defaultArrayValue,
-      allowNull: true,
+      allowNull: false,
     },
     statusFilterType: {
       type: dataTypes.ENUM('INCLUDE', 'EXCLUDE'),
@@ -77,7 +77,7 @@ module.exports = function perspective(seq, dataTypes) {
     statusFilter: {
       type: dataTypes.ARRAY(dataTypes.STRING),
       defaultValue: constants.defaultArrayValue,
-      allowNull: true,
+      allowNull: false,
     },
   }, {
     hooks: {

--- a/db/model/sample.js
+++ b/db/model/sample.js
@@ -62,7 +62,7 @@ module.exports = function sample(seq, dataTypes) {
     },
     relatedLinks: {
       type: dataTypes.ARRAY(dataTypes.JSON),
-      allowNull: true,
+      allowNull: false,
       defaultValue: constants.defaultJsonArrayValue,
       validate: {
         validateJsonSchema(value) {

--- a/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
+++ b/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
@@ -9,7 +9,6 @@ const modelsAndCols = {
   GeneratorTemplate: ['tags'],
   Perspective:
     ['aspectFilter', 'aspectTagFilter', 'subjectTagFilter', 'statusFilter'],
-  Sample: ['relatedLinks'],
 };
 
 function updateRowsAndColumns(qi, seq, modelName, colNamesArr) {

--- a/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
+++ b/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
@@ -21,7 +21,7 @@ function updateRowsAndColumns(qi, seq, modelName, colNamesArr) {
 
   const model = db[modelName];
   return model.findAll({ // find records with any of given columns = null
-    where: { $or: whereArr },
+    where: { $or: whereArr }, paranoid: false,
   })
     .then((records) => Promise.mapSeries(records, (record) => {
       const toUpdate = {};

--- a/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
+++ b/migrations/20190212004845-tags-rlinks-not-null-multiple-models.js
@@ -1,0 +1,77 @@
+'use strict';
+const db = require('../db/index');
+const constants = require('../db/constants');
+
+const modelsAndCols = {
+  Aspect: ['tags', 'relatedLinks'],
+  Generator: ['tags'],
+  GeneratorTemplate: ['tags'],
+  Perspective:
+    ['aspectFilter', 'aspectTagFilter', 'subjectTagFilter', 'statusFilter'],
+  Sample: ['relatedLinks'],
+};
+
+function updateRowsAndColumns(qi, seq, modelName, colNamesArr) {
+  const whereArr = [];
+  colNamesArr.forEach((cname) => {
+    const o = {};
+    o[cname] = { $eq: null };
+    whereArr.push(o);
+  });
+
+  const model = db[modelName];
+  return model.findAll({ // find records with any of given columns = null
+    where: { $or: whereArr },
+  })
+    .then((records) => Promise.all(
+      records.map((record) => {
+        const toUpdate = {};
+        colNamesArr.forEach((colName) => {
+          if (record[colName] === null) {
+            toUpdate[colName] = []; // set the record column to empty array
+          }
+        });
+
+        return record.update(toUpdate);
+      })
+    ))
+    .then(() => Promise.all(colNamesArr.map((colName) => {
+      if (colName === 'relatedLinks') {
+        return qi.changeColumn(`${modelName}s`, colName, {
+          type: seq.ARRAY(seq.JSON),
+          allowNull: false, // change relatedLinks column to allowNull: false
+          defaultValue: constants.defaultJsonArrayValue,
+        });
+      }
+
+      return qi.changeColumn(`${modelName}s`, colName, {
+        type: seq.ARRAY(seq.STRING(constants.fieldlen.normalName)),
+        allowNull: false, // change tags column to allowNull: false
+        defaultValue: constants.defaultArrayValue,
+      });
+    })));
+}
+
+module.exports = {
+  up: (qi, seq) => Promise.all(Object.keys(modelsAndCols).map((model) =>
+    updateRowsAndColumns(qi, seq, model, modelsAndCols[model]))),
+
+  down: (qi, seq) => Promise.all(Object.keys(modelsAndCols).map((modelName) => {
+    const colNamesArr = modelsAndCols[modelName];
+    return Promise.all(colNamesArr.map((colName) => {
+      if (colName === 'relatedLinks') {
+        return qi.changeColumn(`${modelName}s`, colName, {
+          type: seq.ARRAY(seq.JSON),
+          allowNull: true, // change relatedLinks column to allowNull: true
+          defaultValue: constants.defaultJsonArrayValue,
+        });
+      }
+
+      return qi.changeColumn(`${modelName}s`, colName, {
+        type: seq.ARRAY(seq.STRING(constants.fieldlen.normalName)),
+        allowNull: true, // change tags column to allowNull: false
+        defaultValue: constants.defaultArrayValue,
+      });
+    }));
+  })),
+};

--- a/tests/api/v1/aspects/patch.js
+++ b/tests/api/v1/aspects/patch.js
@@ -67,6 +67,10 @@ describe('tests/api/v1/aspects/patch.js >', () => {
           throw new Error('expecting aspect');
         }
 
+        // tags and relatedLinks should be empty
+        expect(res.body.tags).to.eql([]);
+        expect(res.body.relatedLinks).to.eql([]);
+
         if (res.body.timeout !== newTimeout) {
           throw new Error('Incorrect timeout Value');
         }

--- a/tests/api/v1/aspects/post.js
+++ b/tests/api/v1/aspects/post.js
@@ -207,6 +207,22 @@ describe('tests/api/v1/aspects/post.js >', () => {
       })
       .end(done);
     });
+
+    it('tags and related links set to empty array if not provided', (done) => {
+      const aspectToPost = {
+        name: `${tu.namePrefix}Weight`,
+        timeout: '110s',
+      };
+      api.post(path)
+      .set('Authorization', token)
+      .send(aspectToPost)
+      .expect(constants.httpStatus.CREATED)
+      .expect((res) => {
+        expect(res.body.tags).to.eql([]);
+        expect(res.body.relatedLinks).to.eql([]);
+      })
+      .end(done);
+    });
   });
 
   describe('validate helpEmail/helpUrl required >', () => {

--- a/tests/api/v1/aspects/put.js
+++ b/tests/api/v1/aspects/put.js
@@ -338,6 +338,22 @@ describe('tests/api/v1/aspects/put.js >', () => {
         done();
       });
     });
+
+    it('tags and related links set to empty array if not provided', (done) => {
+      const toPut = {
+        name: `${tu.namePrefix}newName`,
+        timeout: '220s',
+      };
+      api.put(`${path}/${aspectId}`)
+      .set('Authorization', token)
+      .send(toPut)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.tags).to.eql([]);
+        expect(res.body.relatedLinks).to.eql([]);
+      })
+      .end(done);
+    });
   });
 
   describe('validate helpEmail/helpUrl required >', () => {

--- a/tests/api/v1/generators/patch.js
+++ b/tests/api/v1/generators/patch.js
@@ -138,4 +138,19 @@ describe('tests/api/v1/generators/patch.js >', () => {
       return done();
     });
   });
+
+  it('tags set to empty array if not provided', (done) => {
+    Generator.findById(i)
+    .then((gen) => gen.update({ tags: [] }))
+    .then(() => {
+      api.patch(`${path}/${i}`)
+        .set('Authorization', token)
+        .send({ name: 'New_Name' })
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body.tags).to.eql([]);
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/api/v1/generators/post.js
+++ b/tests/api/v1/generators/post.js
@@ -148,6 +148,19 @@ describe('tests/api/v1/generators/post.js >', () => {
       );
       done();
     });
+
+    it('tags set to empty array if not provided', (done) => {
+      generator.name += '-other';
+      delete generator.tags;
+      api.post(path)
+        .set('Authorization', token)
+        .send(generator)
+        .expect(constants.httpStatus.CREATED)
+        .expect((res) => {
+          expect(res.body.tags).to.eql([]);
+        })
+        .end(done);
+    });
   });
 
   describe('post duplicate fails >', () => {

--- a/tests/api/v1/generators/put.js
+++ b/tests/api/v1/generators/put.js
@@ -373,4 +373,32 @@ describe('tests/api/v1/generators/put.js >', () => {
       return done();
     });
   });
+
+  it('tags set to empty array if not provided', (done) => {
+    const toPut = {
+      name: 'refocus-ok-generator',
+      description: 'Collect status data',
+      generatorTemplate: {
+        name: generatorTemplate.name,
+        version: generatorTemplate.version,
+      },
+      context: {
+        okValue: {
+          required: false,
+          default: '0',
+          description: 'An ok sample\'s value, e.g. \'0\'',
+        },
+      },
+      subjectQuery: '?absolutePath=Foo.*',
+      aspects: ['Temperature', 'Weather'],
+    };
+    api.put(`${path}/${generatorId}`)
+      .set('Authorization', token)
+      .send(toPut)
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.tags).to.eql([]);
+      })
+      .end(done);
+  });
 });

--- a/tests/api/v1/perspectives/patch.js
+++ b/tests/api/v1/perspectives/patch.js
@@ -185,4 +185,36 @@ describe('tests/api/v1/perspectives/patch.js >', () => {
     .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
+
+  it('filters set to empty array if not provided', (done) => {
+    Perspective.findById(perspectiveId)
+      .then((p) => p.update({
+        subjectTagFilter: [],
+        aspectFilter: [],
+        aspectTagFilter: [],
+        statusFilter: [],
+        aspectFilterType: 'EXCLUDE',
+        statusFilterType: 'EXCLUDE',
+        subjectTagFilterType: 'EXCLUDE',
+        aspectTagFilterType: 'EXCLUDE',
+      }))
+      .then(() => {
+        api.patch(`${path}/${perspectiveId}`)
+          .set('Authorization', token)
+          .send({ rootSubject: 'changedMainSubject' })
+          .expect(constants.httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(res.body.subjectTagFilter).to.eql([]);
+            expect(res.body.aspectFilter).to.eql([]);
+            expect(res.body.aspectTagFilter).to.eql([]);
+            expect(res.body.statusFilter).to.eql([]);
+
+            done();
+          });
+      });
+  });
 });

--- a/tests/api/v1/perspectives/post.js
+++ b/tests/api/v1/perspectives/post.js
@@ -172,7 +172,6 @@ describe('tests/api/v1/perspectives/post.js >', () => {
       lensId: createdLensId,
       rootSubject: 'myMainSubject',
       aspectTagFilter: ['ea', 'na'],
-
     })
     .expect(constants.httpStatus.CREATED)
     .end((err, res) => {

--- a/tests/api/v1/perspectives/put.js
+++ b/tests/api/v1/perspectives/put.js
@@ -195,4 +195,32 @@ describe('tests/api/v1/perspectives/put.js >', () => {
     .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
+
+  it('filters set to empty array if not provided', (done) => {
+    delete toPut.subjectTagFilter;
+    delete toPut.aspectFilter;
+    delete toPut.aspectTagFilter;
+    delete toPut.statusFilter;
+    toPut.aspectFilterType = 'EXCLUDE';
+    toPut.statusFilterType = 'EXCLUDE';
+    toPut.subjectTagFilterType = 'EXCLUDE';
+    toPut.aspectTagFilterType = 'EXCLUDE';
+
+    api.put(`${path}/${perspectiveId}`)
+      .set('Authorization', token)
+      .send(toPut)
+      .expect(constants.httpStatus.OK)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.subjectTagFilter).to.eql([]);
+        expect(res.body.aspectFilter).to.eql([]);
+        expect(res.body.aspectTagFilter).to.eql([]);
+        expect(res.body.statusFilter).to.eql([]);
+
+        done();
+      });
+  });
 });

--- a/tests/api/v1/samples/patch.js
+++ b/tests/api/v1/samples/patch.js
@@ -246,6 +246,18 @@ describe('tests/api/v1/samples/patch.js >', () => {
         .end(done);
       });
 
+      it('related links set to empty array if not provided', (done) => {
+        api.patch(`${path}/${sampleName}`)
+          .set('Authorization', token)
+          .send({
+            value: '2',
+          })
+          .expect((res) => {
+            expect(res.body.relatedLinks).to.eql([]);
+          })
+          .end(done);
+      });
+
       it('patching with readOnly field id should fail', (done) => {
         api.patch(`${path}/${sampleName}`)
         .set('Authorization', token)

--- a/tests/api/v1/samples/post.js
+++ b/tests/api/v1/samples/post.js
@@ -197,6 +197,18 @@ describe('tests/api/v1/samples/post.js >', () => {
     .end(done);
   });
 
+  it('related links set to empty array if not provided', (done) => {
+    delete sampleToPost.relatedLinks;
+    api.post(path)
+      .set('Authorization', token)
+      .send(sampleToPost)
+      .expect(constants.httpStatus.CREATED)
+      .expect((res) => {
+        expect(res.body.relatedLinks).to.eql([]);
+      })
+      .end(done);
+  });
+
   it('posting with readOnly field previousStatus should fail', (done) => {
     sampleToPost.previousStatus = 'Invalid';
     api.post(path)

--- a/tests/api/v1/samples/put.js
+++ b/tests/api/v1/samples/put.js
@@ -180,6 +180,17 @@ describe(`tests/api/v1/samples/put.js, PUT ${path} >`, () => {
     });
   });
 
+  it('related links set to empty array if not provided', (done) => {
+    api.put(`${path}/${sampleName1}`)
+      .set('Authorization', token)
+      .send({ subjectId2, aspectId2, value: '3' })
+      .expect(constants.httpStatus.OK)
+      .expect((res) => {
+        expect(res.body.relatedLinks).to.eql([]);
+      })
+      .end(done);
+  });
+
   describe('subject isPublished false >', () => {
     beforeEach((done) => {
       tu.db.Subject.findById(subjectId1)


### PR DESCRIPTION
**Swagger changes**: Add default:[] to corresponding atributes
**Model changes**: Update columns, allowNull: false
**Tests**: Put|Patch|Post tests to check these attributes return empty array when not set.
**Migration**: To update rows with empty array if column is null, and update columns to disallow null.