### PR TITLE
attachSamplesPrefilterAspects

### DIFF
--- a/cache/models/subject.js
+++ b/cache/models/subject.js
@@ -10,7 +10,7 @@
  * cache/model/subject.js
  */
 'use strict'; // eslint-disable-line strict
-
+const featureToggles = require('feature-toggles');
 const helper = require('../../api/v1/helpers/nouns/subjects');
 const fu = require('../../api/v1/helpers/verbs/findUtils.js');
 const utils = require('../../api/v1/helpers/verbs/utils');
@@ -99,11 +99,33 @@ function attachSamples(res) {
   return redisClient.smembersAsync(subjectKey).then((aspectNames) => {
     const cmds = [];
     aspectNames.forEach((aspect) => {
-      const sampleKey = sampleStore.toKey(constants.objectType.sample,
-               res.absolutePath + '|' + aspect);
-      const aspectKey = sampleStore.toKey(constants.objectType.aspect, aspect);
-      cmds.push(['hgetall', sampleKey]);
-      cmds.push(['hgetall', aspectKey]);
+
+      if (featureToggles.isFeatureEnabled('attachSamplesPrefilterAspects')) {
+        /*
+         * If there is an aspect name filter, do it now instead of doing extra
+         * hgetall calls for aspects and samples we don't need!
+         */
+        let aspectPassesFilter = true; // default true if no aspect name filter
+        if (filters.aspect.includes && filters.aspect.includes.size) {
+          aspectPassesFilter = filters.aspect.includes.has(aspect.toLowerCase());
+        } else if (filters.aspect.excludes && filters.aspect.excludes.size) {
+          aspectPassesFilter = !filters.aspect.excludes.has(aspect.toLowerCase());
+        }
+
+        if (aspectPassesFilter) {
+          const sampleKey = sampleStore.toKey(constants.objectType.sample,
+            res.absolutePath + '|' + aspect);
+          const aspectKey = sampleStore.toKey(constants.objectType.aspect, aspect);
+          cmds.push(['hgetall', sampleKey]);
+          cmds.push(['hgetall', aspectKey]);
+        }
+      } else {
+        const sampleKey = sampleStore.toKey(constants.objectType.sample,
+          res.absolutePath + '|' + aspect);
+        const aspectKey = sampleStore.toKey(constants.objectType.aspect, aspect);
+        cmds.push(['hgetall', sampleKey]);
+        cmds.push(['hgetall', aspectKey]);
+      }
     });
 
     return redisClient.batch(cmds).execAsync();
@@ -115,8 +137,9 @@ function attachSamples(res) {
 
         // parse the array fields to JSON before adding them to the sample list
         sampleStore.arrayObjsStringsToJson(sample,
-                                    constants.fieldsToStringify.sample);
-        sampleStore.arrayObjsStringsToJson(asp, constants.fieldsToStringify.aspect);
+          constants.fieldsToStringify.sample);
+        sampleStore.arrayObjsStringsToJson(asp,
+          constants.fieldsToStringify.aspect);
         sampleStore.convertAspectStrings(asp);
 
         sample.aspect = asp;
@@ -124,7 +147,14 @@ function attachSamples(res) {
       }
     }
 
-    // apply aspect, aspectTag and sampleStatus filters to the samples
+    if (featureToggles.isFeatureEnabled('attachSamplesPrefilterAspects')) {
+      /*
+       * We already applied aspect name filter so clear that one, but apply
+       * aspectTag and sampleStatus filters to the samples here now.
+       */
+      filters.aspects = {};
+    }
+
     filterSamples(res);
 
     /* filterOnSubject: returns true(integer > 0) only if the subjecttags are

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -164,6 +164,9 @@ const longTermToggles = {
  * things from getting out of hand and keeping tons of dead unused code around.
  */
 const shortTermToggles = {
+  attachSamplesPrefilterAspects: environmentVariableTrue(pe,
+    'ATTACH_SAMPLES_PREFILTER_ASPECTS'),
+
   // turn on logging to log invalid hmset values
   logInvalidHmsetValues: environmentVariableTrue(pe,
     'LOG_INVALID_HMSET_VALUES'),

--- a/tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js
+++ b/tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js
@@ -279,7 +279,7 @@ describe('tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js, ' +
     it('should return samples with temperature and humidity aspects',
     (done) => {
       const endpoint = path.replace('{key}', par.id) +
-        '?aspect=humidity,temperature';
+        '?aspect=Humidity,TEMPERATURE';
       api.get(endpoint)
       .set('Authorization', token)
       .expect(constants.httpStatus.OK)
@@ -398,6 +398,136 @@ describe('tests/api/v1/subjects/getHierarchyAspectAndTagsFilters.js, ' +
         expect(res.body.children[0].children).to.not.exist;
       })
       .end(done);
+    });
+  });
+
+  describe('Aspect Filter on Hierarchy with ' +
+    'attachSamplesPrefilterAspects >', () => {
+    before(() => tu.toggleOverride('attachSamplesPrefilterAspects', true));
+    after(() => tu.toggleOverride('attachSamplesPrefilterAspects', false));
+
+    it('should return samples with temperature and humidity aspects',
+      (done) => {
+        const endpoint = path.replace('{key}', par.id) +
+          '?aspect=Humidity,TEMPERATURE';
+        api.get(endpoint)
+          .set('Authorization', token)
+          .expect(constants.httpStatus.OK)
+          .expect((res) => {
+            expect(res.body).to.not.equal(null);
+            expect(res.body.samples).to.have.length(2);
+          })
+          .end(done);
+      });
+
+    it('should return sample with just humidity aspect', (done) => {
+      const endpoint = path.replace('{key}', par.id) + '?aspect=humidity';
+      api.get(endpoint)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.not.equal(null);
+          expect(res.body.children).to.have.length(1);
+          expect(res.body.samples).to.have.length(1);
+          expect(res.body.samples[0]).to.have.deep
+            .property('aspect.name', 'humidity');
+          expect(res.body.children[0].samples[0]).to.have.deep
+            .property('aspect.name', 'humidity');
+          expect(res.body.children[0].children).to.not.exist;
+        })
+        .end(done);
+    });
+
+    it('test negitation humidity but no temperature', (done) => {
+      const endpoint = path.replace('{key}', par.id) + '?aspect=-temperature';
+      api.get(endpoint)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.not.equal(null);
+          expect(res.body.samples).to.have.length(1);
+          expect(res.body.samples[0]).to.have.deep
+            .property('aspect.name', 'humidity');
+          expect(res.body.children).to.have.length(1);
+          expect(res.body.children[0].samples[0]).to.have.deep
+            .property('aspect.name', 'humidity');
+          expect(res.body.children[0].children).to.have.length(1);
+          expect(res.body.children[0].children[0].samples[0]).to.have.deep
+            .property('aspect.name', 'wind-speed');
+        })
+        .end(done);
+    });
+
+    it('test with aspect name not in the hierarchy', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=invalidName';
+      api.get(endpoint2)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.not.equal(null);
+          expect(Object.keys(res.body.samples)).to.have.length(0);
+        })
+        .end(done);
+    });
+
+    it('filter should apply to all levels of hierarchy', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) +
+        '?aspect=humidity,temperature';
+      api.get(endpoint2)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(res.body).to.not.equal(null);
+          expect(res.body.samples).to.have.length(2);
+          const aspectNames = [];
+          aspectNames.push(res.body.samples[0].aspect.name);
+          aspectNames.push(res.body.samples[1].aspect.name);
+          expect(aspectNames).to.include.members(['humidity', 'temperature']);
+          expect(res.body.children).to.have.length(1);
+          expect(res.body.children[0].samples).to.have.length(1);
+          expect(res.body.children[0].children).to.not.exist;
+          expect(res.body.children[0].samples[0])
+            .to.have.deep.property('aspect.name', 'humidity');
+          done();
+        });
+    });
+
+    it('filter with aspect name having a hyphen', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=wind-speed';
+      api.get(endpoint2)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.not.equal(null);
+          expect(res.body.samples).to.have.length(0);
+          expect(res.body.children).to.have.length(1);
+          expect(res.body.children[0].samples).to.have.length(0);
+          expect(res.body.children[0].children).to.have.length(1);
+          expect(res.body.children[0].children[0].samples).to.have.length(1);
+          expect(res.body.children[0].children[0].samples[0])
+            .to.have.deep.property('aspect.name', 'wind-speed');
+        })
+        .end(done);
+    });
+
+    it('negation on aspect name filter with aspect name ' +
+      'having a hyphen', (done) => {
+      const endpoint2 = path.replace('{key}', par.id) + '?aspect=-wind-speed';
+      api.get(endpoint2)
+        .set('Authorization', token)
+        .expect(constants.httpStatus.OK)
+        .expect((res) => {
+          expect(res.body).to.not.equal(null);
+          expect(res.body.samples).to.have.length(2);
+          expect(res.body.children).to.have.length(1);
+          expect(res.body.children[0].samples).to.have.length(1);
+          expect(res.body.children[0].children).to.not.exist;
+        })
+        .end(done);
     });
   });
 


### PR DESCRIPTION
If there is an aspect name filter, do it earlier in attachSamples instead of doing extra hgetall calls for aspects and samples we don't need!
Add short-term toggle "attachSamplesPrefilterAspects" (env var "ATTACH_SAMPLES_PREFILTER_ASPECTS")