### PR TITLE
GET api endpoints - createdAt/updatedAt filter

### DIFF
--- a/api/v1/helpers/nouns/aspects.js
+++ b/api/v1/helpers/nouns/aspects.js
@@ -44,4 +44,5 @@ module.exports = {
   tagFilterName: 'tags',
   readOnlyFields: ['id', 'isDeleted'],
   requireAtLeastOneFields: ['helpEmail', 'helpUrl'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/auditEvents.js
+++ b/api/v1/helpers/nouns/auditEvents.js
@@ -89,4 +89,5 @@ module.exports = {
   modelName: 'AuditEvent',
   modifyWhereClause,
   timeUnits,
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/botActions.js
+++ b/api/v1/helpers/nouns/botActions.js
@@ -27,4 +27,5 @@ module.exports = {
   baseUrl: '/v1/botActions',
   model: BotActions,
   modelName: 'botActions',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/botData.js
+++ b/api/v1/helpers/nouns/botData.js
@@ -27,4 +27,5 @@ module.exports = {
   baseUrl: '/v1/botData',
   model: BotData,
   modelName: 'botData',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/bots.js
+++ b/api/v1/helpers/nouns/bots.js
@@ -32,4 +32,5 @@ module.exports = {
   baseUrl: '/v1/bots',
   model: Bots,
   modelName: 'Bots',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/collectorGroups.js
+++ b/api/v1/helpers/nouns/collectorGroups.js
@@ -29,4 +29,5 @@ module.exports = {
     generators: 'generators',
   },
   fieldsToExclude: ['createdBy', 'ownerId'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/collectors.js
+++ b/api/v1/helpers/nouns/collectors.js
@@ -39,4 +39,5 @@ module.exports = {
     currentGenerators: 'currentGenerators',
   },
   fieldsToExclude: ['createdBy', 'ownerId', 'collectorGroupId'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/events.js
+++ b/api/v1/helpers/nouns/events.js
@@ -22,4 +22,5 @@ module.exports = {
   baseUrl: '/v1/events',
   model: Events,
   modelName: 'events',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/generatorTemplates.js
+++ b/api/v1/helpers/nouns/generatorTemplates.js
@@ -40,6 +40,7 @@ module.exports = {
   fieldsToExclude: ['createdBy', 'ownerId'],
 
   hasMultipartKey: true,
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 
 }; // exports
 

--- a/api/v1/helpers/nouns/generators.js
+++ b/api/v1/helpers/nouns/generators.js
@@ -74,5 +74,6 @@ module.exports = {
    */
   sortArrayObjects: {},
   readOnlyFields: ['id', 'isDeleted', 'currentCollector'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 
 }; // exports

--- a/api/v1/helpers/nouns/globalconfig.js
+++ b/api/v1/helpers/nouns/globalconfig.js
@@ -25,4 +25,5 @@ module.exports = {
   model: GlobalConfig,
   modelName: 'GlobalConfig',
   nameFinder: 'key',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/lenses.js
+++ b/api/v1/helpers/nouns/lenses.js
@@ -36,4 +36,5 @@ module.exports = {
   belongsToManyAssoc: {
     users: 'writers',
   },
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/perspectives.js
+++ b/api/v1/helpers/nouns/perspectives.js
@@ -75,4 +75,5 @@ module.exports = {
   },
   cacheEnabled: featureToggles.isFeatureEnabled('enableCachePerspective'),
   resourceType,
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/profiles.js
+++ b/api/v1/helpers/nouns/profiles.js
@@ -29,4 +29,5 @@ module.exports = {
   },
   model: Profile,
   modelName: 'Profile',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/roomTypes.js
+++ b/api/v1/helpers/nouns/roomTypes.js
@@ -27,4 +27,5 @@ module.exports = {
   baseUrl: '/v1/roomTypes',
   model: RoomTypes,
   modelName: 'roomTypes',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/rooms.js
+++ b/api/v1/helpers/nouns/rooms.js
@@ -27,4 +27,5 @@ module.exports = {
   baseUrl: '/v1/rooms',
   model: Rooms,
   modelName: 'rooms',
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/subjects.js
+++ b/api/v1/helpers/nouns/subjects.js
@@ -71,4 +71,5 @@ module.exports = {
     'hierarchyLevel', 'absolutePath', 'childCount', 'id', 'isDeleted',
   ],
   requireAtLeastOneFields: ['helpEmail', 'helpUrl'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/nouns/users.js
+++ b/api/v1/helpers/nouns/users.js
@@ -38,4 +38,5 @@ module.exports = {
     profile: 'profile',
   },
   fieldsToExclude: ['profileId'],
+  timePeriodFilters: ['createdAt', 'updatedAt'],
 }; // exports

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -19,6 +19,7 @@ const ONE = 1;
 const MINUS_ONE = -1;
 const RADIX = 10;
 const Op = require('sequelize').Op;
+const ms = require('ms');
 
 /**
  * Escapes all percent literals so they're not treated as wildcards.
@@ -156,6 +157,7 @@ function toSequelizeWhere(filter, props) {
   for (let i = ZERO; i < keys.length; i++) {
     const key = keys[i];
     if (filter[key] !== undefined) {
+      const filterKeyValue = filter[key];
       if (!Array.isArray(filter[key])) {
         filter[key] = [filter[key]];
       }
@@ -196,6 +198,12 @@ function toSequelizeWhere(filter, props) {
       else if (props.tagFilterName && key === props.tagFilterName) {
         const tagArr = filter[key];
         Object.assign(where, toWhereClause(tagArr, props));
+      } else if (props.timePeriodFilters &&
+        props.timePeriodFilters.includes(key)) {
+        const whereClause = {};
+        whereClause[Op.lte] = new Date();
+        whereClause[Op.gte] = new Date(Date.now() + ms(filterKeyValue));
+        where[key] = whereClause;
       } else {
         for (let j = ZERO; j < filter[key].length; j++) {
           const v = filter[key][j];

--- a/api/v1/helpers/verbs/findUtils.js
+++ b/api/v1/helpers/verbs/findUtils.js
@@ -156,80 +156,81 @@ function toSequelizeWhere(filter, props) {
 
   for (let i = ZERO; i < keys.length; i++) {
     const key = keys[i];
-    if (filter[key] !== undefined) {
-      const filterKeyValue = filter[key];
-      if (!Array.isArray(filter[key])) {
-        filter[key] = [filter[key]];
-      }
-
-      const values = [];
-
-      /*
-       * If enum filter is enabled and key is an enumerable field
-       * then create an "in"
-       * clause and add it to where clause, e.g.
-       * {
-       *  where: {
-            valueType: { [Op.in]: ["PERCENT", "BOOLEAN"] },
-          },
-       * }
-       */
-      if (Array.isArray(props.fieldsWithEnum) &&
-        props.fieldsWithEnum.indexOf(key) > -ONE) {
-
-        // if specified in props, convert the array in query to camelcase.
-        const enumArr = (props.fieldsToCamelCase &&
-          props.fieldsToCamelCase.indexOf(key) > -ONE) ?
-          convertArrayElementsToCamelCase(filter[key]) : filter[key];
-
-        // to use $in instead of $contains in toWhereClause
-        props.isEnum = true;
-        values.push(toWhereClause(enumArr, props));
-        where[key] = values[ZERO];
-      }
-
-      /*
-       * If tag filter is enabled and key is "tags":
-       * If it's an inclusion, create a "contains" clause:
-       * { where : { tags: { '$contains': ['tag1', 'tag2'] }}}
-       * If it's an exclusion, create a "not" "overlap" clause:
-       * { where : { '$not': { tags: { '$overlap': ['tag1', 'tag2'] }}}}}
-       */
-      else if (props.tagFilterName && key === props.tagFilterName) {
-        const tagArr = filter[key];
-        Object.assign(where, toWhereClause(tagArr, props));
-      } else if (props.timePeriodFilters &&
+    let filterKeyValue = filter[key];
+    if (filterKeyValue !== undefined) {
+      if (props.timePeriodFilters &&
         props.timePeriodFilters.includes(key)) {
         const whereClause = {};
         whereClause[Op.lte] = new Date();
         whereClause[Op.gte] = new Date(Date.now() + ms(filterKeyValue));
         where[key] = whereClause;
       } else {
-        for (let j = ZERO; j < filter[key].length; j++) {
-          const v = filter[key][j];
-          if (typeof v === 'boolean') {
-            values.push(v);
-          } else if (typeof v === 'number') {
-            values.push(v);
-          } else if (u.looksLikeId(v)) {
-            values.push(v);
-          } else if (typeof v === 'string') {
-            const arr = v.split(constants.COMMA);
-            for (let k = ZERO; k < arr.length; k++) {
-              values.push(toWhereClause(arr[k]));
-            }
-          } else if (typeof v === 'object') {
-            for (const p in v) {
-              values.push({ [p]: toWhereClause(v[p]) });
-            }
-          }
+        if (!Array.isArray(filterKeyValue)) {
+          filterKeyValue = [filterKeyValue];
         }
 
-        if (values.length === ONE) {
+        const values = [];
+
+        /*
+         * If enum filter is enabled and key is an enumerable field
+         * then create an "in"
+         * clause and add it to where clause, e.g.
+         * {
+         *  where: {
+              valueType: { [Op.in]: ["PERCENT", "BOOLEAN"] },
+            },
+         * }
+         */
+        if (Array.isArray(props.fieldsWithEnum) &&
+          props.fieldsWithEnum.indexOf(key) > -ONE) {
+          // if specified in props, convert the array in query to camelcase.
+          const enumArr = (props.fieldsToCamelCase &&
+            props.fieldsToCamelCase.indexOf(key) > -ONE) ?
+            convertArrayElementsToCamelCase(filterKeyValue) : filterKeyValue;
+
+          // to use $in instead of $contains in toWhereClause
+          props.isEnum = true;
+          values.push(toWhereClause(enumArr, props));
           where[key] = values[ZERO];
-        } else if (values.length > ONE) {
-          where[key] = {};
-          where[key][Op.or] = values;
+        }
+
+        /*
+         * If tag filter is enabled and key is "tags":
+         * If it's an inclusion, create a "contains" clause:
+         * { where : { tags: { '$contains': ['tag1', 'tag2'] }}}
+         * If it's an exclusion, create a "not" "overlap" clause:
+         * { where : { '$not': { tags: { '$overlap': ['tag1', 'tag2'] }}}}}
+         */
+        else if (props.tagFilterName && key === props.tagFilterName) {
+          const tagArr = filterKeyValue;
+          Object.assign(where, toWhereClause(tagArr, props));
+        } else {
+          for (let j = ZERO; j < filterKeyValue.length; j++) {
+            const v = filterKeyValue[j];
+            if (typeof v === 'boolean') {
+              values.push(v);
+            } else if (typeof v === 'number') {
+              values.push(v);
+            } else if (u.looksLikeId(v)) {
+              values.push(v);
+            } else if (typeof v === 'string') {
+              const arr = v.split(constants.COMMA);
+              for (let k = ZERO; k < arr.length; k++) {
+                values.push(toWhereClause(arr[k]));
+              }
+            } else if (typeof v === 'object') {
+              for (const p in v) {
+                values.push({ [p]: toWhereClause(v[p]) });
+              }
+            }
+          }
+
+          if (values.length === ONE) {
+            where[key] = values[ZERO];
+          } else if (values.length > ONE) {
+            where[key] = {};
+            where[key][Op.or] = values;
+          }
         }
       }
     }

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -248,6 +248,22 @@ paths:
              include result set.
           type: array
           required: false
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when aspects were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when aspects were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -1298,6 +1314,22 @@ paths:
             Filter by auditEvent isError.
           required: false
           type: boolean
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when AuditEvents were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when AuditEvents were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -1489,6 +1521,22 @@ paths:
           in: query
           required: false
           type: boolean
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when BotActions were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when BotActions were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
         -
           $ref: "#/parameters/limitParam"
         -
@@ -1937,6 +1985,22 @@ paths:
           in: query
           required: false
           type: string
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when BotData was created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when BotData was updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
         -
           $ref: "#/parameters/limitParam"
         -
@@ -2430,6 +2494,22 @@ paths:
           in: query
           required: false
           type: boolean
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when Bots were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when Bots were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
         -
           $ref: "#/parameters/limitParam"
         -
@@ -3141,6 +3221,22 @@ paths:
             Filter by version; asterisk (*) wildcards ok.
           required: false
           type: string
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when collectors were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when collectors were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: Success, returns an array of zero or more Refocus collectors.
@@ -3848,6 +3944,22 @@ paths:
           required: false
           type: string
         -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when events were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when events were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
           $ref: "#/parameters/limitParam"
         -
           $ref: "#/parameters/offsetParam"
@@ -4188,6 +4300,22 @@ paths:
              include result set.
           type: array
           required: false
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when generators were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when generators were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -4844,6 +4972,22 @@ paths:
           type: boolean
           description: >-
             Filter by generatorTemplate isPublished (true|false)
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when GeneratorTemplates were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when GeneratorTemplates were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -5271,6 +5415,20 @@ paths:
           $ref: "#/parameters/limitParam"
         -
           $ref: "#/parameters/offsetParam"
+        - name: createdAt
+          in: query
+          description: >-
+            Filter by time period when globalConfigs were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        - name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when globalConfigs were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -5561,6 +5719,22 @@ paths:
           in: query
           required: false
           description: The version of the lens.
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when lenses were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when lenses were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -6181,6 +6355,22 @@ paths:
             Filter by root subject; asterisk (*) wildcards ok.
           required: false
           type: string
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when perspectives were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when perspectives were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -6913,6 +7103,20 @@ paths:
           $ref: "#/parameters/limitParam"
         -
           $ref: "#/parameters/offsetParam"
+        - name: createdAt
+          in: query
+          description: >-
+            Filter by time period when profiles were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        - name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when profiles were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -7511,6 +7715,22 @@ paths:
           required: false
           type: string
         -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when rooms were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when rooms were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
           name: sort
           description: >
             Specify the sort order using a field name, e.g. '...?sort=name'. Prepend the
@@ -8023,6 +8243,22 @@ paths:
           in: query
           required: false
           type: string
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when roomTypes were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when roomTypes were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
         -
           $ref: "#/parameters/limitParam"
         -
@@ -9408,6 +9644,22 @@ paths:
              tags are not included in the result set.
           type: array
           required: false
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when subjects were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when subjects were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -10773,6 +11025,22 @@ paths:
             Filter by name; asterisk (*) wildcards ok.
           required: false
           type: string
+        -
+          name: createdAt
+          in: query
+          description: >-
+            Filter by time period when users were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        -
+          name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when users were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: >-
@@ -11490,6 +11758,20 @@ paths:
             Filter by description; asterisk (*) wildcards ok.
           required: false
           type: string
+        - name: createdAt
+          in: query
+          description: >-
+            Filter by time period when CollectorGroups were created.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
+        - name: updatedAt
+          in: query
+          description: >-
+            Filter by time period when CollectorGroups were updated.
+          required: false
+          type: string
+          pattern: '^-\d+[smdh]$'
       responses:
         200:
           description: Success, returns an array of zero or more Refocus collectorGroups.

--- a/tests/api/v1/aspects/utils.js
+++ b/tests/api/v1/aspects/utils.js
@@ -42,6 +42,10 @@ module.exports = {
   subjectToCreate,
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -51,13 +55,13 @@ module.exports = {
     return tu.db.Aspect.create(toCreate);
   },
 
-  forceDelete(done) {
+  forceDelete(done, startTime=testStartTime) {
     Promise.join(
       samstoinit.eradicate(),
-      tu.forceDelete(tu.db.Aspect, testStartTime)
-      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-      .then(() => tu.forceDelete(tu.db.Generator, testStartTime))
-      .then(() => tu.forceDelete(tu.db.GeneratorTemplate, testStartTime))
+      tu.forceDelete(tu.db.Aspect, startTime)
+      .then(() => tu.forceDelete(tu.db.Subject, startTime))
+      .then(() => tu.forceDelete(tu.db.Generator, startTime))
+      .then(() => tu.forceDelete(tu.db.GeneratorTemplate, startTime))
     )
     .then(() => done())
     .catch(done);

--- a/tests/api/v1/auditEvents/utils.js
+++ b/tests/api/v1/auditEvents/utils.js
@@ -62,4 +62,18 @@ module.exports = {
     .then(() => done())
     .catch(done);
   },
+
+  getBasic(overrideProps={}) {
+    if (!overrideProps.resourceName) {
+      delete overrideProps.resourceName;
+    }
+
+    const defaultProps = getAuditEventObject();
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.AuditEvent.create(toCreate);
+  },
 };

--- a/tests/api/v1/authenticate/utils.js
+++ b/tests/api/v1/authenticate/utils.js
@@ -25,10 +25,10 @@ module.exports = {
     username: `${tu.namePrefix}user1`,
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.User, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Token, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.User, startTime)
+    .then(() => tu.forceDelete(tu.db.Profile, startTime))
+    .then(() => tu.forceDelete(tu.db.Token, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/botActions/utils.js
+++ b/tests/api/v1/botActions/utils.js
@@ -62,6 +62,10 @@ module.exports = {
   },
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(standard));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -82,8 +86,14 @@ module.exports = {
   },
 
   createBasic(overrideProps={}) {
-    const { userId } = overrideProps;
-    return this.doSetup({ userId })
+    const { userId, name } = overrideProps;
+
+    if (overrideProps.botId && overrideProps.roomId) {
+      const toCreate = this.getBasic(overrideProps);
+      return tu.db.BotAction.create(toCreate);
+    }
+
+    return this.doSetup({ userId, name })
     .then(({ botId, roomId }) => {
       Object.assign(overrideProps, { botId, roomId });
       const toCreate = this.getBasic(overrideProps);
@@ -91,15 +101,53 @@ module.exports = {
     });
   },
 
+  createBasicWithActionName(overrideProps={}) {
+    const { name, userId } = overrideProps;
+
+    if (overrideProps.botId && overrideProps.roomId) {
+      return tu.db.Bot.findById(overrideProps.botId)
+        .then((bot) => {
+          const botActions = bot.actions;
+          botActions.push({ name, parameters: standard.parameters });
+          return bot.update({ actions: botActions });
+        })
+      .then(() => {
+        const toCreate = this.getBasic(overrideProps);
+        return tu.db.BotAction.create(toCreate);
+      });
+    }
+
+    const botObj = {
+      installedBy: userId,
+      actions: [{ name, parameters: standard.parameters }],
+    };
+    return Promise.all([
+      botUtil.createBasic(botObj),
+      roomUtil.createBasic(),
+    ])
+      .then(([bot, room]) => {
+        const createdIds = {
+          botId: bot.id,
+          roomId: room.id,
+        };
+        return createdIds;
+      })
+      .then(({ botId, roomId }) => {
+        Object.assign(overrideProps, { botId, roomId });
+        const toCreate = this.getBasic(overrideProps);
+        return tu.db.BotAction.create(toCreate);
+      });
+  },
+
   getDependencyProps() {
     return ['botId', 'roomId'];
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.BotAction, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Bot, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Room, testStartTime))
-    .then(() => tu.forceDelete(tu.db.RoomType, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.BotAction, startTime)
+    .then(() => tu.forceDelete(tu.db.Bot, startTime))
+    .then(() => tu.forceDelete(tu.db.Room, startTime))
+    .then(() => tu.forceDelete(tu.db.RoomType, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/bots/utils.js
+++ b/tests/api/v1/bots/utils.js
@@ -145,6 +145,10 @@ module.exports = {
   },
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(standard));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -154,8 +158,8 @@ module.exports = {
     return tu.db.Bot.create(toCreate);
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Bot, testStartTime)
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Bot, startTime)
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/collectorGroups/utils.js
+++ b/tests/api/v1/collectorGroups/utils.js
@@ -30,13 +30,17 @@ module.exports = {
   },
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     return Object.assign(defaultProps, overrideProps);
   },
 
   doSetup(props={}) {
-    const { createdBy } = props;
-    return collectorUtil.createBasic({ createdBy })
+    const { createdBy, name } = props;
+    return collectorUtil.createBasic({ createdBy, name })
     .then((collector) => {
       const createdIds = {
         collectorName: collector.name,
@@ -46,8 +50,8 @@ module.exports = {
   },
 
   createBasic(overrideProps={}) {
-    const { createdBy } = overrideProps;
-    return this.doSetup({ createdBy })
+    const { createdBy, name } = overrideProps;
+    return this.doSetup({ createdBy, name })
     .then(({ collectorName }) => {
       Object.assign(overrideProps, { collectors: [collectorName] });
       const toCreate = this.getBasic(overrideProps);
@@ -59,11 +63,11 @@ module.exports = {
     return ['collectorName'];
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Generator, testStartTime)
-      .then(() => tu.forceDelete(tu.db.GeneratorTemplate, testStartTime))
-      .then(() => tu.forceDelete(tu.db.Collector, testStartTime))
-      .then(() => tu.forceDelete(tu.db.CollectorGroup, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Generator, startTime)
+      .then(() => tu.forceDelete(tu.db.GeneratorTemplate, startTime))
+      .then(() => tu.forceDelete(tu.db.Collector, startTime))
+      .then(() => tu.forceDelete(tu.db.CollectorGroup, startTime))
       .then(() => done())
       .catch(done);
   },

--- a/tests/api/v1/collectors/utils.js
+++ b/tests/api/v1/collectors/utils.js
@@ -19,7 +19,7 @@ const status = require('../../../../api/v1/constants').httpStatus;
 const collectorConfig = require('../../../../config/collectorConfig');
 const Generator = tu.db.Generator;
 const Collector = tu.db.Collector;
-const collectorToCreate =  {
+const collectorToCreate = {
   name: tu.namePrefix + 'Coll',
   description: 'This is my collector description.',
   helpEmail: 'a@bcd.com',
@@ -180,6 +180,10 @@ function getCollectorToCreate() {
 
 module.exports = {
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(collectorToCreate));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -189,12 +193,12 @@ module.exports = {
     return tu.db.Collector.create(toCreate);
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Collector, testStartTime)
-    .then(() => tu.forceDelete(tu.db.GeneratorTemplate, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Generator, testStartTime))
-    .then(() => tu.forceDelete(tu.db.CollectorGroup, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.CollectorGroup, startTime)
+    .then(() => tu.forceDelete(tu.db.Collector, startTime))
+    .then(() => tu.forceDelete(tu.db.GeneratorTemplate, startTime))
+    .then(() => tu.forceDelete(tu.db.Generator, startTime))
+    .then(() => tu.forceDelete(tu.db.Aspect, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/common/createdAtUpdatedAtFilters.js
+++ b/tests/api/v1/common/createdAtUpdatedAtFilters.js
@@ -1,0 +1,460 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/api/v1/common/createdAtUpdatedAtFilters.js
+ */
+'use strict';
+const supertest = require('supertest');
+const api = supertest(require('../../../../index').app);
+const tu = require('../../../testUtils');
+const constants = require('../../../../api/v1/constants');
+const expect = require('chai').expect;
+const Promise = require('bluebird');
+const sinon = require('sinon');
+const ms = require('ms');
+supertest.Test.prototype.end = Promise.promisify(supertest.Test.prototype.end);
+supertest.Test.prototype.then = function (resolve, reject) {
+  return this.end().then(resolve).catch(reject);
+};
+
+let clock;
+
+/* Admin token is created at Date.now().
+Fake test start time =  now - 2000d
+User created at fake start time + 1d
+Fake now = now - 1000d (or test start time + 1000d)
+This setup helps clean teardown and test results, like only delete records
+created in this test, do not delete something created before the test like
+admin user, only return records created in setup, etc. */
+
+const testStartTime = Date.now() - ms('2000d');
+const createUserTime = testStartTime - ms('1d');
+const recordCreateTime = testStartTime + ms('1000d');
+
+function fakeTime(time) {
+  if (clock && clock.restore) {
+    clock.restore();
+  }
+
+  clock = sinon.useFakeTimers(time);
+}
+
+const modelsToTest = {
+  aspects: 'name',
+  auditEvents: 'resourceName',
+  collectorGroups: 'name',
+  collectors: 'name',
+  events: 'log',
+  generators: 'name',
+  generatorTemplates: 'name',
+  lenses: 'name',
+  perspectives: 'name',
+  rooms: 'name',
+  roomTypes: 'name',
+  subjects: 'name',
+  botActions: 'name',
+  botData: 'name',
+  bots: 'name',
+  globalconfig: 'key',
+  profiles: 'name',
+  users: 'name',
+};
+
+let userToken;
+let createdResources;
+let createdUser;
+
+describe('tests/api/v1/common/createdAtUpdatedAtFilters >', () => {
+  before(() => {
+    fakeTime(createUserTime);
+    return tu.createUserAndToken('someUser')
+      .then(({ user, token }) => {
+        createdUser = user;
+        userToken = token;
+      });
+  });
+
+  after((done) => tu.forceDeleteUser(done, createUserTime));
+  after(() => {
+    clock.restore();
+    return Promise.resolve();
+  });
+
+  Object.entries(modelsToTest).forEach(runFilterTestsForModel);
+});
+
+function getResources({ modelName, filterString, expectedStatus }) {
+  let path;
+  if (modelName === 'botData' || modelName === 'botActions') {
+    path = `/v1/${modelName}?botId=${createdResources[0].botId}` +
+    `&${filterString}`;
+  } else {
+    path = `/v1/${modelName}?${filterString}`;
+  }
+
+  return api.get(`${path}`)
+    .set('Authorization', userToken)
+    .expect(expectedStatus);
+}
+
+function createModelRecord({ filterStr, overrideProps, modelName, util }) {
+  const recordCreatedAtTime = recordCreateTime - ms(filterStr);
+  fakeTime(recordCreatedAtTime);
+
+  const resourceName = `${tu.namePrefix}-${modelName}-${filterStr.slice(-1)}`;
+  overrideProps[modelsToTest[modelName]] = resourceName;
+  overrideProps.installedBy = createdUser.id;
+  overrideProps.userId = createdUser.id;
+  if (modelName === 'botActions') {
+    return util.createBasicWithActionName(overrideProps);
+  }
+
+  return util.createBasic(overrideProps);
+}
+
+function createMultipleRecordsAtDifferentTimes(modelName, nameAttr, util) {
+  const overrideProps = {};
+  createdResources = [];
+
+  const filterStrings = ['10s', '10m', '10h', '10d'];
+  return Promise.mapSeries(filterStrings, (filterStr) => createModelRecord(
+      { filterStr, overrideProps, modelName, util })
+  )
+  .then((results) => {
+    createdResources = results;
+    fakeTime(recordCreateTime);
+  });
+}
+
+function getUtilForModel(modelName) {
+  return require(`../${modelName}/utils`);
+}
+
+function updateRecordsAtDifferentTimes() {
+  const filterStrings = ['5s', '5m', '5h', '5d'];
+  return Promise.all(createdResources.map((createdObj, index) => {
+    const recordUpdatedAtTime = recordCreateTime - ms(filterStrings[index]);
+    fakeTime(recordUpdatedAtTime);
+    createdObj.changed('updatedAt', true);
+    return createdObj.save();
+  }));
+}
+
+function runFilterTestsForModel([modelName, nameAttr]) {
+  const util = getUtilForModel(modelName);
+
+  describe(`${modelName} createdAt/updatedAt query filters >`, () => {
+    before(() => createMultipleRecordsAtDifferentTimes(
+        modelName, nameAttr, util));
+    after((done) => util.forceDelete(done, testStartTime));
+
+    describe('GET, createdAt for specific time period >', () => {
+      it('createdAt=-5 seconds', () => {
+        const filterString = 'createdAt=-5s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(0);
+          });
+      });
+
+      it('createdAt=-50 seconds', () => {
+        const filterString = 'createdAt=-50s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(1);
+            expect(res.body[0][nameAttr]).to.equal(`___-${modelName}-s`);
+          });
+      });
+
+      it('createdAt=-30 minutes', () => {
+        const filterString = 'createdAt=-30m';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(2);
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+          });
+      });
+
+      it('createdAt=-5 hours', () => {
+        const filterString = 'createdAt=-5h';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(2);
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+          });
+      });
+
+      it('createdAt=-15 hours', () => {
+        const filterString = 'createdAt=-15h';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(3);
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+            expect(resultNames).includes(`___-${modelName}-h`);
+          });
+      });
+
+      it('createdAt=-100 days', () => {
+        const filterString = 'createdAt=-100d';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(4);
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+            expect(resultNames).includes(`___-${modelName}-h`);
+            expect(resultNames).includes(`___-${modelName}-d`);
+          });
+      });
+
+      it('createdAt=-12345678 seconds', () => {
+        const filterString = 'createdAt=-12345678s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(4);
+          });
+      });
+
+      it('error, invalid query param value, non negative', () => {
+        const filterString = 'createdAt=15d';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (createdAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, non integer', () => {
+        const filterString = 'createdAt=-xxd';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (createdAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, invalid trailing char', () => {
+        const filterString = 'createdAt=-5e';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (createdAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, only digits', () => {
+        const filterString = 'createdAt=-5';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (createdAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+    });
+
+    describe('GET, updatedAt for specific time period >', () => {
+      before(() => updateRecordsAtDifferentTimes()
+          .then(() => {
+            fakeTime(recordCreateTime);
+          })
+      );
+
+      it('updatedAt=-4 seconds', () => {
+        const filterString = 'updatedAt=-4s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(0);
+          });
+      });
+
+      it('updatedAt=-50 seconds', () => {
+        const filterString = 'updatedAt=-50s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+
+            expect(res.body.length).to.equal(1);
+            expect(res.body[0][nameAttr]).to.equal(`___-${modelName}-s`);
+          });
+      });
+
+      it('updatedAt=-30 minutes', () => {
+        const filterString = 'updatedAt=-30m';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(2);
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+          });
+      });
+
+      it('updatedAt=-4 hours', () => {
+        const filterString = 'updatedAt=-4h';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(2);
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+          });
+      });
+
+      it('updatedAt=-15 hours', () => {
+        const filterString = 'updatedAt=-15h';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(3);
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+            expect(resultNames).includes(`___-${modelName}-h`);
+          });
+      });
+
+      it('updatedAt=-100 days', () => {
+        const filterString = 'updatedAt=-100d';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(4);
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+            const resultNames = res.body.map((obj) => obj[nameAttr]);
+            expect(resultNames).includes(`___-${modelName}-m`);
+            expect(resultNames).includes(`___-${modelName}-s`);
+            expect(resultNames).includes(`___-${modelName}-h`);
+            expect(resultNames).includes(`___-${modelName}-d`);
+          });
+      });
+
+      it('updatedAt=-12345678 seconds', () => {
+        const filterString = 'updatedAt=-12345678s';
+        const expectedStatus = constants.httpStatus.OK;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            res.body.forEach((retObj) => {
+              expect(new Date(retObj.updatedAt) - new Date(retObj.createdAt))
+                .to.be.above(0);
+            });
+            expect(createdResources.length).equals(4);
+            expect(res.body.length).to.equal(4);
+          });
+      });
+
+      it('error, invalid query param value, non negative', () => {
+        const filterString = 'updatedAt=15d';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (updatedAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, non integer', () => {
+        const filterString = 'updatedAt=-xxd';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (updatedAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, invalid trailing char', () => {
+        const filterString = 'updatedAt=-5e';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (updatedAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+
+      it('error, invalid query param value, only digits', () => {
+        const filterString = 'updatedAt=-5';
+        const expectedStatus = constants.httpStatus.BAD_REQUEST;
+        return getResources({ modelName, filterString, expectedStatus })
+          .then((res) => {
+            expect(res.body.errors[0].type).to.equal('Error');
+            expect(res.body.errors[0].message).to.equal('Request validation ' +
+              'failed: Parameter (updatedAt) does not match required pattern:' +
+              ' ^-\\d+[smdh]$');
+          });
+      });
+    });
+  });
+}

--- a/tests/api/v1/generatorTemplates/utils.js
+++ b/tests/api/v1/generatorTemplates/utils.js
@@ -76,15 +76,19 @@ function getGeneratorTemplate() {
 } // getGenerator
 
 module.exports = {
-  forceDelete(done) {
-    tu.forceDelete(tu.db.GeneratorTemplate, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Collector, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.GeneratorTemplate, startTime)
+    .then(() => tu.forceDelete(tu.db.Collector, startTime))
     .then(() => done())
     .catch(done);
   },
 
   getGeneratorTemplate,
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(GENERATOR_TEMPLATE_SIMPLE));
     return Object.assign(defaultProps, overrideProps);
   },

--- a/tests/api/v1/generators/utils.js
+++ b/tests/api/v1/generators/utils.js
@@ -70,12 +70,12 @@ function createGeneratorAspects() {
 }
 
 module.exports = {
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Generator, testStartTime)
-    .then(() => tu.forceDelete(tu.db.GeneratorTemplate, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Collector, testStartTime))
-    .then(() => tu.forceDelete(tu.db.CollectorGroup, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Generator, startTime)
+    .then(() => tu.forceDelete(tu.db.GeneratorTemplate, startTime))
+    .then(() => tu.forceDelete(tu.db.Collector, startTime))
+    .then(() => tu.forceDelete(tu.db.CollectorGroup, startTime))
+    .then(() => tu.forceDelete(tu.db.Aspect, startTime))
     .then(() => done())
     .catch(done);
   },
@@ -86,15 +86,19 @@ module.exports = {
   createGeneratorAspects,
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(GENERATOR_SIMPLE));
     return Object.assign(defaultProps, overrideProps);
   },
 
   doSetup(props={}) {
-    const { createdBy } = props;
+    const { createdBy, name } = props;
     return Promise.all([
-      gtUtil.createBasic({ createdBy }),
-      aspectUtil.createBasic({ createdBy }),
+      gtUtil.createBasic({ createdBy, name }),
+      aspectUtil.createBasic({ createdBy, name }),
     ])
     .then(([sgt, aspect]) => {
         const createdIds = {
@@ -109,8 +113,8 @@ module.exports = {
   },
 
   createBasic(overrideProps={}) {
-    const { createdBy } = overrideProps;
-    return this.doSetup({ createdBy })
+    const { createdBy, name } = overrideProps;
+    return this.doSetup({ createdBy, name })
     .then(({ generatorTemplate, aspects }) => {
       Object.assign(overrideProps, { generatorTemplate, aspects });
       const toCreate = this.getBasic(overrideProps);

--- a/tests/api/v1/globalconfig/utils.js
+++ b/tests/api/v1/globalconfig/utils.js
@@ -14,22 +14,42 @@ const tu = require('../../../testUtils');
 const Op = require('sequelize').Op;
 
 const testStartTime = new Date();
+const basic = {
+  key: `${tu.namePrefix}testKeyName`,
+  value: 'some-value',
+};
 
 module.exports = {
-  forceDelete() {
-    return tu.db.GlobalConfig.destroy({
+  getBasic(overrideProps={}) {
+    if (!overrideProps.key) {
+      delete overrideProps.key;
+    }
+
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.GlobalConfig.create(toCreate);
+  },
+
+  forceDelete(done, startTime=testStartTime) {
+    tu.db.GlobalConfig.destroy({
       where: {
         key: {
           [Op.iLike]: tu.namePrefix + '%',
         },
         createdAt: {
           [Op.lt]: new Date(),
-          [Op.gte]: testStartTime,
+          [Op.gte]: startTime,
         },
       },
       force: true,
     })
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Token, testStartTime));
+    .then(() => tu.forceDelete(tu.db.User, startTime))
+    .then(() => tu.forceDelete(tu.db.Token, startTime))
+    .then(() => done())
+    .catch(done);
   },
 };

--- a/tests/api/v1/lenses/utils.js
+++ b/tests/api/v1/lenses/utils.js
@@ -32,6 +32,10 @@ module.exports = {
   name,
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     defaultProps.library = willSendthis;
     return Object.assign(defaultProps, overrideProps);
@@ -42,9 +46,9 @@ module.exports = {
     return tu.db.Lens.create(toCreate);
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Perspective, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Lens, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Perspective, startTime)
+    .then(() => tu.forceDelete(tu.db.Lens, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/perspectives/utils.js
+++ b/tests/api/v1/perspectives/utils.js
@@ -31,13 +31,17 @@ const basic = {
 
 module.exports = {
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     return Object.assign(defaultProps, overrideProps);
   },
 
   doSetup(props={}) {
-    const { createdBy } = props;
-    return lensUtil.createBasic({ installedBy: createdBy })
+    const { createdBy, name } = props;
+    return lensUtil.createBasic({ installedBy: createdBy, name })
     .then((lens) => {
       const createdIds = {
         lensId: lens.id,
@@ -47,8 +51,8 @@ module.exports = {
   },
 
   createBasic(overrideProps={}) {
-    const { createdBy } = overrideProps;
-    return this.doSetup({ createdBy })
+    const { createdBy, name } = overrideProps;
+    return this.doSetup({ createdBy, name })
     .then(({ lensId }) => {
       Object.assign(overrideProps, { lensId });
       const toCreate = this.getBasic(overrideProps);
@@ -60,9 +64,9 @@ module.exports = {
     return ['lensId'];
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Perspective, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Lens, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Perspective, startTime)
+    .then(() => tu.forceDelete(tu.db.Lens, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/profiles/utils.js
+++ b/tests/api/v1/profiles/utils.js
@@ -13,10 +13,28 @@
 const tu = require('../../../testUtils');
 const testStartTime = new Date();
 
+const basic = {
+  name: `${tu.namePrefix}testProfileName`,
+};
+
 module.exports = {
-  forceDelete(done) {
-    tu.forceDelete(tu.db.User, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+  getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
+    const defaultProps = JSON.parse(JSON.stringify(basic));
+    return Object.assign(defaultProps, overrideProps);
+  },
+
+  createBasic(overrideProps={}) {
+    const toCreate = this.getBasic(overrideProps);
+    return tu.db.Profile.create(toCreate);
+  },
+
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.User, startTime)
+    .then(() => tu.forceDelete(tu.db.Profile, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/register/utils.js
+++ b/tests/api/v1/register/utils.js
@@ -20,10 +20,10 @@ module.exports = {
     password: 'fakePasswd',
     username: `${tu.namePrefix}user1`,
   },
-  forceDelete(done) {
-    tu.forceDelete(tu.db.User, testStartTime)
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Token, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.User, startTime)
+    .then(() => tu.forceDelete(tu.db.Profile, startTime))
+    .then(() => tu.forceDelete(tu.db.Token, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/roomTypes/utils.js
+++ b/tests/api/v1/roomTypes/utils.js
@@ -166,6 +166,10 @@ module.exports = {
   },
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(standard));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -175,8 +179,8 @@ module.exports = {
     return tu.db.RoomType.create(toCreate);
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.RoomType, testStartTime)
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.RoomType, startTime)
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/rooms/utils.js
+++ b/tests/api/v1/rooms/utils.js
@@ -123,13 +123,17 @@ module.exports = {
   },
 
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(standard));
     return Object.assign(defaultProps, overrideProps);
   },
 
   doSetup(props={}) {
-    const { createdBy } = props;
-    return roomTypeUtil.createBasic({ createdBy })
+    const { createdBy, name } = props;
+    return roomTypeUtil.createBasic({ createdBy, name })
     .then((roomType) => {
       const createdIds = {
         type: roomType.id,
@@ -139,8 +143,8 @@ module.exports = {
   },
 
   createBasic(overrideProps={}) {
-    const { createdBy } = overrideProps;
-    return this.doSetup({ createdBy })
+    const { createdBy, name } = overrideProps;
+    return this.doSetup({ createdBy, name })
     .then(({ type }) => {
       Object.assign(overrideProps, { type });
       const toCreate = this.getBasic(overrideProps);
@@ -152,9 +156,9 @@ module.exports = {
     return ['type'];
   },
 
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Room, testStartTime)
-    .then(() => tu.forceDelete(tu.db.RoomType, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Room, startTime)
+    .then(() => tu.forceDelete(tu.db.RoomType, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/samples/utils.js
+++ b/tests/api/v1/samples/utils.js
@@ -103,6 +103,10 @@ module.exports = {
   sampleName,
   doCustomSetup,
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -154,10 +158,10 @@ module.exports = {
     });
   },
 
-  forceDelete(done) {
+  forceDelete(done, startTime=testStartTime) {
     samstoinit.eradicate()
-    .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Subject, startTime))
+    .then(() => tu.forceDelete(tu.db.Aspect, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/subjects/utils.js
+++ b/tests/api/v1/subjects/utils.js
@@ -23,6 +23,10 @@ const basic = {
 
 module.exports = {
   getBasic(overrideProps={}) {
+    if (!overrideProps.name) {
+      delete overrideProps.name;
+    }
+
     const defaultProps = JSON.parse(JSON.stringify(basic));
     return Object.assign(defaultProps, overrideProps);
   },
@@ -32,11 +36,11 @@ module.exports = {
     return tu.db.Subject.create(toCreate);
   },
 
-  forceDelete(done) {
+  forceDelete(done, startTime=testStartTime) {
     Promise.join(
       samstoinit.eradicate(),
-      tu.forceDelete(tu.db.Aspect, testStartTime)
-      .then(() => tu.forceDelete(tu.db.Subject, testStartTime))
+      tu.forceDelete(tu.db.Aspect, startTime)
+      .then(() => tu.forceDelete(tu.db.Subject, startTime))
     )
     .then(() => done())
     .catch(done);

--- a/tests/api/v1/tokens/utils.js
+++ b/tests/api/v1/tokens/utils.js
@@ -20,10 +20,10 @@ module.exports = {
     password: 'fakePasswd',
     username: 'user1@abc.com',
   },
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Token, testStartTime)
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Token, startTime)
+    .then(() => tu.forceDelete(tu.db.User, startTime))
+    .then(() => tu.forceDelete(tu.db.Profile, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/api/v1/userTokens/utils.js
+++ b/tests/api/v1/userTokens/utils.js
@@ -20,10 +20,10 @@ module.exports = {
     password: 'fakePasswd',
     username: 'user1@abc.com',
   },
-  forceDelete(done) {
-    tu.forceDelete(tu.db.Token, testStartTime)
-    .then(() => tu.forceDelete(tu.db.User, testStartTime))
-    .then(() => tu.forceDelete(tu.db.Profile, testStartTime))
+  forceDelete(done, startTime=testStartTime) {
+    tu.forceDelete(tu.db.Token, startTime)
+    .then(() => tu.forceDelete(tu.db.User, startTime))
+    .then(() => tu.forceDelete(tu.db.Profile, startTime))
     .then(() => done())
     .catch(done);
   },

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -289,12 +289,12 @@ module.exports = {
   }, // createAdminToken
 
   // delete user
-  forceDeleteUser(done) {
-    forceDelete(db.User, testStartTime)
-    .then(() => forceDelete(db.Token, testStartTime))
-    .then(() => forceDelete(db.Profile, testStartTime))
-    .then(() => done())
-    .catch(done);
+  forceDeleteUser(done, startTime=testStartTime) {
+    forceDelete(db.User, startTime)
+      .then(() => forceDelete(db.Token, startTime))
+      .then(() => forceDelete(db.Profile, startTime))
+      .then(() => done())
+      .catch(done);
   }, // forceDeleteUser
 
   // delete subject


### PR DESCRIPTION
Organized by commits.

e.g. ?createdAt=-7d or ?updatedAt=-12h
All times relative to "now"
Supported these units: second (s), minute (m), hour (h), day (d).
Invalid request if no minus sign or if no number or if no unit.

Tests cover following endpoints:
GET /v1/aspects
GET /v1/auditEvents
GET /v1/collectorGroups
GET /v1/collectors
GET /v1/events
GET /v1/generators
GET /v1/generatorTemplates
GET /v1/perspectives
GET /v1/rooms
GET /v1/roomTypes
GET /v1/botActions?botId=<>
GET /v1/botData?botId=<>
GET /v1/bots
GET /v1/globalconfig
GET /v1/profiles
GET /v1/users