### PR TITLE
Token based authentication to join socket server

### DIFF
--- a/realtime/setupSocketIO.js
+++ b/realtime/setupSocketIO.js
@@ -185,7 +185,7 @@ function init(io, redisStore) {
 
     // check if connection using an authorization header
     } else if (socket.handshake.headers.authorization) {
-      jwtUtils.verifyBotSocketToken(socket.handshake.headers.authorization)
+      jwtUtils.verifySocketToken(socket.handshake.headers.authorization)
       .then((isValid) => {
         if (!isValid) {
           socket.disconnect();

--- a/tests/realtime/setupSocketIO.js
+++ b/tests/realtime/setupSocketIO.js
@@ -17,9 +17,30 @@ const express = require('express');
 const app = express();
 const httpServer = require('http').Server(app);
 const io = require('socket.io')(httpServer);
+const sioClient = require('socket.io-client');
 const u = require('./utils');
 
 describe('tests/realtime/setupSocketIO.js, socket.io setup >', () => {
+  describe('socket io setup >', () => {
+    it('authorization token is received on connection if passed in headers',
+    (done) => {
+      const token = 'abcd-token-abcd';
+      const options = {
+        transports: ['websocket'],
+        extraHeaders: {
+          authorization: token,
+        },
+      };
+
+      io.listen(5000);
+      sioClient.connect('http://0.0.0.0:5000', options);
+      io.sockets.on('connection', (socket) => {
+        expect(socket.handshake.headers.authorization).to.equal(token);
+        done();
+      });
+    });
+  });
+
   describe('with logging disabled >', () => {
     const rootSubjNAUS = 'NA.US';
     const rootSubjNA = 'NA';

--- a/tests/utils/jwtUtil.js
+++ b/tests/utils/jwtUtil.js
@@ -24,6 +24,7 @@ const Bot = tu.db.Bot;
 const n = `${tu.namePrefix}Testing`;
 const User = tu.db.User;
 const Profile = tu.db.Profile;
+const Token = tu.db.Token;
 const Collector = tu.db.Collector;
 const gu = require('../api/v1/generators/utils');
 
@@ -79,7 +80,8 @@ describe('tests/utils/jwtUtil.js >', () => {
     })
     .then((token) => {
       userToken = token;
-      return jwtUtil.createToken(collectorInst.name, userInst.name, { IsCollector: true }
+      return jwtUtil.createToken(
+        collectorInst.name, userInst.name, { IsCollector: true }
       );
     })
     .then((token) => {
@@ -92,7 +94,7 @@ describe('tests/utils/jwtUtil.js >', () => {
       { IsGenerator: true }))
     .then((token) => generatorToken = token)
     .then(() => done())
-    .catch((err) => done());
+    .catch((err) => done(err));
   });
 
   after((done) => {
@@ -104,6 +106,7 @@ describe('tests/utils/jwtUtil.js >', () => {
     .then(() => tu.forceDelete(tu.db.Bot, testStartTime))
     .then(() => tu.forceDelete(tu.db.Aspect, testStartTime))
     .then(() => tu.forceDelete(tu.db.User, testStartTime))
+    .then(() => tu.forceDelete(tu.db.Token, testStartTime))
     .then(() => done())
     .catch(done);
   });
@@ -440,6 +443,43 @@ describe('tests/utils/jwtUtil.js >', () => {
       expect(req.headers.IsBot).to.be.equal(false);
       expect(req.headers.Random).to.be.equal(undefined);
       return done();
+    });
+  });
+
+  describe('verifySocketToken > ', () => {
+    it('bot token', (done) => {
+      Bot.create(newBot)
+        .then((o) => {
+          const token = jwtUtil.createToken(o.name, userInst.name,
+            { IsBot: true });
+          return jwtUtil.verifySocketToken(token);
+        })
+        .then((ret) => {
+          expect(ret.name).to.equal(newBot.name);
+        })
+        .then(() => done())
+        .catch(done);
+    });
+
+    it('user token', (done) => {
+      const tokenName = 'myTokenName';
+      const token = jwtUtil.createToken(tokenName, userInst.name);
+      Token.create({ name: tokenName, createdBy: userInst.id })
+        .then(() => jwtUtil.verifySocketToken(token))
+        .then((ret) => {
+          expect(ret).to.have.property('id');
+        })
+        .then(() => done())
+        .catch(done);
+    });
+
+    it('non user/bot token', (done) => {
+      jwtUtil.verifySocketToken(generatorToken)
+      .then((ret) => {
+        expect(ret).to.be.null;
+      })
+      .then(() => done())
+      .catch(done);
     });
   });
 });

--- a/utils/jwtUtil.js
+++ b/utils/jwtUtil.js
@@ -180,7 +180,7 @@ function verifySocketToken(token) {
           method: ['notRevoked', payload.tokenname, user.id],
         }).findOne());
     });
-} // verifyBotSocketToken
+} // verifySocketToken
 
 /**
  * Function to verify if a bot token is valid or not, i.e. does the token
@@ -207,8 +207,7 @@ function verifyBotToken(payload, req, cb) {
     assignHeaderValues(req, payload);
     return cb ? cb() : undefined;
   })
-  .catch((err) => {
-    console.log(err);
+  .catch(() => {
     throw new apiErrors.ForbiddenError({
       explanation: 'Authentication Failed',
     });


### PR DESCRIPTION
**Previously:**
We had only cookie based authentication to join socket server (we had token-based authentication for Bots though). 

**After these changes:**
Added token based authentication for the socket client to connect to socket server for user tokens

**Impact:**
This will make it easier for us to test socket communication using supertest.

**Tests:**
Added some tests.
Also tested manually for realtime events