### PR TITLE
prevent logging an error when updating the aspect in the sample store.

### DIFF
--- a/api/v1/helpers/verbs/utils.js
+++ b/api/v1/helpers/verbs/utils.js
@@ -36,15 +36,17 @@ function updateInstance(o, puttableFields, toPut) {
     let key = keys[i];
     const fieldDef = puttableFields[key];
     if (key === 'owner') key = 'ownerId';
-    if (toPut[key] === undefined && key !== 'ownerId') {
-      let nullish = null;
-      if (fieldDef.default) { // could be enum | array etc
-        nullish = fieldDef.default;
-      } else if (fieldDef.type === 'boolean') {
-        nullish = false;
-      }
+    if (toPut[key] === undefined) {
+      if (key !== 'ownerId') {
+        let nullish = null;
+        if (fieldDef.default) { // could be enum | array etc
+          nullish = fieldDef.default;
+        } else if (fieldDef.type === 'boolean') {
+          nullish = false;
+        }
 
-      o.set(key, nullish);
+        o.set(key, nullish);
+      }
     } else {
       /*
        * value may be set but not changed. set changed to true to

--- a/utils/common.js
+++ b/utils/common.js
@@ -26,9 +26,9 @@ function logInvalidHmsetValues(key, obj) {
       if (_key === null || obj[_key] === null ||
         (obj[_key] === undefined) || Array.isArray(obj[_key])) {
         // eslint-disable-next-line no-console
+        const stringified = JSON.stringify(obj, (k, v) => v === undefined ? 'undefined' : v);
         console.trace('Invalid hmset params: key ' + key +
-          ' with invalid field: ' + _key + ', received: ' +
-          JSON.stringify(obj));
+          ' with invalid field: ' + _key + ', received: ' + stringified);
         break;
       }
     }


### PR DESCRIPTION
This fixes the warning log lines coming from logInvalidHmsetValues on aspect PUT. It also includes a fix to that method to log undefined values correctly.

Previously, when owner is not specified in a PUT, it went to the final else, which sets it to undefined and sets changed to true. This works fine for other models, but for aspects we also update fields in the sample store based on whether they are changed, so it ends up updating ownerId to undefined, which triggers the logging in logInvalidHmsetValues.  Adding a separate condition specifically for this case prevents this.

No test changes because this has no functional impact; the only effect is on the logging. I have verified manually that the logging is correct now for both changes.