### PR TITLE
update the sample's updatedAt timestamp when deleting it

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -683,6 +683,7 @@ module.exports = {
       }
 
       sampObjToReturn = sampleObj;
+      sampObjToReturn.updatedAt = new Date().toISOString();
 
       cmds.push(redisOps.getHashCmd(aspectType, aspName));
 

--- a/tests/cache/models/samples/delete.js
+++ b/tests/cache/models/samples/delete.js
@@ -87,6 +87,7 @@ describe('tests/cache/models/samples/delete.js >', () => {
           return done(err);
         }
 
+        expect(res.body.updatedAt).to.be.gt(res.body.createdAt);
         expect(res.body.aspect).to.be.an('object');
         expect(tu.looksLikeId(res.body.aspectId)).to.be.true;
         expect(tu.looksLikeId(res.body.subjectId)).to.be.true;


### PR DESCRIPTION
so that we can calculate the pub/sub elapsed times correctly.

test confirms that updatedAt > createdAt (they were equal before this change)