### PR TITLE
Remove emit event when active changes

### DIFF
--- a/db/model/room.js
+++ b/db/model/room.js
@@ -146,13 +146,6 @@ module.exports = function room(seq, dataTypes) {
           }
         }
 
-        if (instance.changed('active')) {
-          if (instance.active) {
-            return realTime.publishObject(instance.toJSON(), roomEventNames.add,
-              null, null, pubOpts);
-          }
-        }
-
         return seq.Promise.resolve();
       }, // hooks.afterUpdate
 

--- a/db/model/room.js
+++ b/db/model/room.js
@@ -146,6 +146,13 @@ module.exports = function room(seq, dataTypes) {
           }
         }
 
+        if (instance.changed('active')) {
+          if (instance.active) {
+            return realTime.publishObject(instance.toJSON(), roomEventNames.upd,
+              null, null, pubOpts);
+          }
+        }
+
         return seq.Promise.resolve();
       }, // hooks.afterUpdate
 


### PR DESCRIPTION
We are starting to emit events from the bdk to bots when a new room is created. We do not currently use the roomEventNames.add at all. We just want roomEventNames.add to be used for when a new room is created. The bots will get the roomEventNames.add event every time a new room is created