### PR TITLE
split out realtime app config variables for perspectives and rooms

### DIFF
--- a/cache/redisCache.js
+++ b/cache/redisCache.js
@@ -73,7 +73,7 @@ rconf.instanceUrl.pubsubPerspectives.forEach((rp) => {
 
 // Only create subscribers here if we're doing real-time events from main app
 let subBot;
-if (!featureToggles.isFeatureEnabled('enableRealtimeApplication')) {
+if (!featureToggles.isFeatureEnabled('enableRealtimeApplicationImc')) {
   subBot = redis.createClient(rconf.instanceUrl.pubsubBots, opts);
   subBot.subscribe(rconf.botChannelName);
 }

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -118,12 +118,18 @@ const longTermToggles = {
   hideRoutes: environmentVariableTrue(pe, 'HIDE_ROUTES'),
 
   /*
-   * Use separate realtime application if the env var exists and is not equal
+   * Use separate realtime application for perspectives if the env var exists and is not equal
    * to "/".
    */
-  enableRealtimeApplication:
-    (pe.hasOwnProperty('REALTIME_APPLICATION') && pe.REALTIME_APPLICATION !== '/')
-    || (pe.hasOwnProperty('REALTIME_APPLICATION_IMC') && pe.REALTIME_APPLICATION_IMC !== '/'),
+  enableRealtimeApplication: pe.hasOwnProperty('REALTIME_APPLICATION')
+    && pe.REALTIME_APPLICATION !== '/',
+
+  /*
+   * Use separate realtime application for Imc rooms if the env var exists and is not equal
+   * to "/".
+   */
+  enableRealtimeApplicationImc: pe.hasOwnProperty('REALTIME_APPLICATION_IMC')
+    && pe.REALTIME_APPLICATION !== '/',
 
   // Enable redis client connection logging.
   enableRedisConnectionLogging: environmentVariableTrue(pe,

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -121,8 +121,9 @@ const longTermToggles = {
    * Use separate realtime application if the env var exists and is not equal
    * to "/".
    */
-  enableRealtimeApplication: pe.hasOwnProperty('REALTIME_APPLICATION') &&
-    pe.REALTIME_APPLICATION !== '/',
+  enableRealtimeApplication:
+    (pe.hasOwnProperty('REALTIME_APPLICATION') && pe.REALTIME_APPLICATION !== '/')
+    || (pe.hasOwnProperty('REALTIME_APPLICATION_IMC') && pe.REALTIME_APPLICATION_IMC !== '/'),
 
   // Enable redis client connection logging.
   enableRedisConnectionLogging: environmentVariableTrue(pe,

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -129,7 +129,7 @@ const longTermToggles = {
    * to "/".
    */
   enableRealtimeApplicationImc: pe.hasOwnProperty('REALTIME_APPLICATION_IMC')
-    && pe.REALTIME_APPLICATION !== '/',
+    && pe.REALTIME_APPLICATION_IMC !== '/',
 
   // Enable redis client connection logging.
   enableRedisConnectionLogging: environmentVariableTrue(pe,

--- a/view/loadView.js
+++ b/view/loadView.js
@@ -194,6 +194,7 @@ function loadView(app, passport) {
           trackingId: viewConfig.trackingId,
           user: JSON.stringify(copyOfUser).replace(/'/g,"apos;"),
           realtimeApplication: viewConfig.realtimeApplication,
+          realtimeApplicationImc: viewConfig.realtimeApplicationImc,
           eventThrottle: viewConfig.realtimeEventThrottleMilliseconds,
         };
 

--- a/view/rooms/index.pug
+++ b/view/rooms/index.pug
@@ -73,7 +73,7 @@ html
   script(src='/static/scripts/jquery-1.11.1.min.js')
   script(src='/static/scripts/moment.min.js')
   script.
-    var realtimeApplication = '#{realtimeApplication}';
+    var realtimeApplication = '#{realtimeApplicationImc}';
     var trackingId = '#{trackingId}';
     var user = '#{user}';
     var userSession = '#{userSession}';

--- a/viewConfig.js
+++ b/viewConfig.js
@@ -32,6 +32,7 @@ const realtimeEventThrottleMilliseconds =
  * via the main Refocus application itself.
  */
 const realtimeApplication = pe.REALTIME_APPLICATION || '/';
+const realtimeApplicationImc = pe.REALTIME_APPLICATION_IMC || '/';
 
 module.exports = {
   // Password stored in the db for SSO users (never used for authentication).
@@ -40,8 +41,11 @@ module.exports = {
   // Make the Google Analytics trackingId available in /view.
   trackingId: pe.GOOGLE_ANALYTICS_ID || 'N/A',
 
-  // Make the real-time app endpoint available in /view
+  // Make the real-time app endpoint available in /view for perspectives
   realtimeApplication,
+
+  // Make the real-time app endpoint available in /view for Imc rooms
+  realtimeApplicationImc,
 
   // Make the throttle time available in /view.
   realtimeEventThrottleMilliseconds,


### PR DESCRIPTION
Use different config variables to specify the realtime app for perspectives and rooms. This way we can move over perspectives but let rooms continue to use the main app until imc is ready to switch.