### PR TITLE
Add more publish tests for real-time events

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -1097,7 +1097,7 @@ module.exports = {
   /**
    * Retrieves the sample from redis and sends it back in the response. Get
    * sample and corresponsing aspect from redis and then apply field list
-   * filter is needed. Then attach aspect to sample and return.
+   * filter if needed. Then attach aspect to sample and return.
    *
    * @param  {String} params - Req Query parameters
    * @returns {Promise} - Resolves to a sample object

--- a/clock/scheduledJobs/sampleTimeout.js
+++ b/clock/scheduledJobs/sampleTimeout.js
@@ -23,19 +23,10 @@ const sampleStoreTimeout = require('../../cache/sampleStoreTimeout');
  */
 function execute() {
   return sampleStoreTimeout.doTimeout()
-  .then((dbRes) => {
-    // send the timeoutsample to the client by publishing it to redis channel
-    if (dbRes.timedOutSamples) {
-      dbRes.timedOutSamples.forEach((sample) => {
-        publisher.publishSample(sample, dbSubject, sampleEvent.upd);
-      });
-    }
-
-    return {
-      recordCount: dbRes.numberTimedOut,
-      errorCount: dbRes.numberEvaluated - dbRes.numberTimedOut,
-    };
-  });
+  .then((dbRes) => ({
+    recordCount: dbRes.numberTimedOut,
+    errorCount: dbRes.numberEvaluated - dbRes.numberTimedOut,
+  }));
 } // execute
 
 module.exports = {

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -47,11 +47,6 @@ module.exports = function aspect(seq, dataTypes) {
       primaryKey: true,
       defaultValue: dataTypes.UUIDV4,
     },
-    isDeleted: {
-      type: dataTypes.BIGINT,
-      defaultValue: 0,
-      allowNull: false,
-    },
     imageUrl: {
       type: dataTypes.STRING(constants.fieldlen.url),
       validate: { isUrl: true },

--- a/db/model/aspect.js
+++ b/db/model/aspect.js
@@ -165,21 +165,7 @@ module.exports = function aspect(seq, dataTypes) {
        * @returns {Promise}
        */
       beforeDestroy(inst /* , opts */) {
-        const promiseArr = [];
-
-        promiseArr.push(redisOps.getSamplesFromAspectName(inst.name)
-          .each((samp) => {
-            if (samp) {
-              publishSample(
-                samp, seq.models.Subject, sampleEventNames.del,
-                seq.models.Aspect
-              );
-            }
-          })
-        );
-
-        promiseArr.push(inst.checkGeneratorReferences('delete'));
-        return seq.Promise.all(promiseArr);
+        return inst.checkGeneratorReferences('delete');
       }, // hooks.beforeDestroy
 
       /**

--- a/db/model/botData.js
+++ b/db/model/botData.js
@@ -134,7 +134,7 @@ module.exports = function botData(seq, dataTypes) {
         // Publish delete
         const changedKeys = Object.keys(instance._changed);
         return realTime.publishObject(instance.toJSON(),
-          botDataEventNames.del, changedKeys, [], pubOpts);
+          botDataEventNames.del, ['updatedAt'], [], pubOpts);
       }, // hooks.afterDestroy
     },
     indexes: [

--- a/db/model/event.js
+++ b/db/model/event.js
@@ -8,7 +8,7 @@
  */
 
 /**
- * db/model/event.js
+ * db/model/events.js
  *
  * This model is to store any log that might need to be searched
  * for later. The context JSON can be any format that log line

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -304,6 +304,8 @@ module.exports = function subject(seq, dataTypes) {
                * If subject tags or parent were not updated, just send the usual
                * "update" event.
                */
+              pubPromises.push(subjectUtils.removeRelatedSamples(
+                inst._previousDataValues, seq, true));
               pubPromises.push(publishObject(inst._previousDataValues,
                 eventName.del, changedKeys, ignoreAttributes));
               pubPromises.push(publishObject(inst, eventName.add, changedKeys,

--- a/db/model/subject.js
+++ b/db/model/subject.js
@@ -148,7 +148,7 @@ module.exports = function subject(seq, dataTypes) {
       afterCreate(inst /* , opts */) {
         const promiseArr = [];
         if (inst.getDataValue('isPublished') === true) {
-          publishObject(inst, eventName.add);
+          promiseArr.push(publishObject(inst, eventName.add));
         }
 
         // Prevent any changes to original inst dataValues object
@@ -277,22 +277,23 @@ module.exports = function subject(seq, dataTypes) {
         return Promise.all(promiseArr)
           .then(() => redisOps.executeBatchCmds(cmds))
           .then(() => {
+            const pubPromises = [];
             if (isSubjectUnpublished) {
               // Treat unpublishing a subject as a "delete" event.
-              publishObject(inst, eventName.del);
+              pubPromises.push(publishObject(inst, eventName.del));
             } else if (isSubjectPublished) {
               // Treat publishing a subject as an "add" event.
-              publishObject(inst, eventName.add);
+              pubPromises.push(publishObject(inst, eventName.add));
             } else if (inst.isPublished && inst.changed('absolutePath')) {
               /*
                * When an absolutePath is changed, send a subject delete event with
                * the old subject instance, followed by a subject add event with
                * the new subject instance
                */
-              publishObject(inst._previousDataValues, eventName.del,
-                changedKeys, ignoreAttributes);
-              publishObject(inst, eventName.add, changedKeys,
-                ignoreAttributes);
+              pubPromises.push((publishObject(inst._previousDataValues,
+                eventName.del, changedKeys, ignoreAttributes)));
+              pubPromises.push(publishObject(inst, eventName.add, changedKeys,
+                ignoreAttributes));
             } else if (inst.isPublished && (common.tagsChanged(inst) ||
               inst.changed('parentId'))) {
               /*
@@ -303,14 +304,16 @@ module.exports = function subject(seq, dataTypes) {
                * If subject tags or parent were not updated, just send the usual
                * "update" event.
                */
-              publishObject(inst._previousDataValues, eventName.del,
-                changedKeys, ignoreAttributes);
-              publishObject(inst, eventName.add, changedKeys,
-                ignoreAttributes);
+              pubPromises.push(publishObject(inst._previousDataValues,
+                eventName.del, changedKeys, ignoreAttributes));
+              pubPromises.push(publishObject(inst, eventName.add, changedKeys,
+                ignoreAttributes));
             } else if (inst.getDataValue('isPublished')) {
-              publishObject(inst, eventName.upd, changedKeys,
-                ignoreAttributes);
+              pubPromises.push(publishObject(inst, eventName.upd, changedKeys,
+                ignoreAttributes));
             }
+
+            return Promise.all(pubPromises);
           });
       }, // hooks.afterUpdate
 

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -159,8 +159,8 @@ function publishObject(inst, event, changedKeys, ignoreAttributes, opts) {
     }
   }
 
-  pubClient.publish(channelName, JSON.stringify(obj));
-  return obj;
+  return pubClient.publishAsync(channelName, JSON.stringify(obj))
+    .then((numClients) => obj);
 } // publishObject
 
 /**
@@ -196,8 +196,8 @@ function publishSample(sampleInst, subjectModel, event, aspectModel) {
     .then((sample) => {
       if (sample) {
         sample.absolutePath = sample.subject.absolutePath; // reqd for filtering
-        publishObject(sample, eventType);
-        return sample;
+        return publishObject(sample, eventType)
+          .then(() => sample);
       }
     })
     .catch((err) => {
@@ -233,11 +233,8 @@ function publishSampleNoChange(sample) {
       timeout: sample.aspectTimeout,
     },
   };
-  return Promise.resolve(true)
-  .then(() => {
-    publishObject(s, sampleEvent.nc);
-    return sample;
-  });
+  return publishObject(s, sampleEvent.nc)
+    .then(() => sample);
 } // publishSampleNoChange
 
 module.exports = {

--- a/tests/api/v1/botActions/utils.js
+++ b/tests/api/v1/botActions/utils.js
@@ -7,7 +7,7 @@
  */
 
 /**
- * tests/db/api/botActions/utils.js
+ * tests/api/v1/botActions/utils.js
  */
 'use strict';
 const tu = require('../../../testUtils');

--- a/tests/publish/botActions.js
+++ b/tests/publish/botActions.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/publish/botActions.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const redis = require('redis');
+const rconf = require('../../config/redisConfig');
+const constants = require('../../api/v1/constants');
+const api = supertest(require('../../express').app);
+const tu = require('../testUtils');
+const Room = tu.db.Room;
+const RoomType = tu.db.RoomType;
+const Bot = tu.db.Bot;
+const BotAction = tu.db.BotAction;
+const botActionEvents = require('../../realtime/constants').events.botAction;
+const path = '/v1/botActions';
+const u = require('../api/v1/botActions/utils');
+const r = require('../api/v1/rooms/utils');
+const rt = require('../api/v1/roomTypes/utils');
+const b = require('../api/v1/bots/utils');
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+
+describe('tests/publish/botActions.js >', () => {
+  let token;
+  let subscriber;
+  let subscribeTracker = [];
+  let testBotAction;
+
+  before((done) => {
+    subscriber = redis.createClient(DEFAULT_LOCAL_REDIS_URL);
+    subscriber.subscribe(rconf.botChannelName);
+    subscriber.on('message', (channel, msg) => subscribeTracker.push(msg));
+
+    tu.createToken()
+      .then((returnedToken) => (token = returnedToken))
+      .then(() => done())
+      .catch(done);
+  });
+
+  beforeEach((done) => {
+    testBotAction = u.getStandard();
+    RoomType.create(rt.getStandard())
+      .then((roomType) => {
+        const room = r.getStandard();
+        room.type = roomType.id;
+        return Room.create(room);
+      })
+      .then((room) => {
+        testBotAction.roomId = room.id;
+        return Bot.create(b.getStandard());
+      })
+      .then((bot) => {
+        testBotAction.botId = bot.id;
+        subscribeTracker = [];
+        done();
+      })
+      .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+
+  after(tu.forceDeleteToken);
+
+  afterEach(() => subscribeTracker = []);
+
+  it('POST then PATCH then DELETE, subscriber gets events', (done) => {
+    api.post(path)
+      .set('Authorization', token)
+      .send(testBotAction)
+      .expect(constants.httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(subscribeTracker).to.have.length(1);
+        const evt = JSON.parse(subscribeTracker[0]);
+        expect(evt).to.have.property(botActionEvents.add);
+        const evtBody = evt[botActionEvents.add];
+        expect(evtBody).to.include.keys('new', 'old');
+        expect(evtBody.old).to.include.keys('id', 'isPending', 'name',
+          'parameters', 'roomId', 'botId', 'ownerId', 'updatedAt',
+          'createdAt', 'actionLog', 'response', 'userId', 'pubOpts');
+        expect(evtBody.new).to.include.keys('id', 'isPending', 'name',
+          'parameters', 'roomId', 'botId', 'ownerId', 'updatedAt',
+          'createdAt', 'actionLog', 'response', 'userId', 'pubOpts');
+        expect(evtBody.new).to.have.property('name', 'Action1');
+        subscribeTracker = [];
+
+        api.patch(`${path}/${evtBody.new.id}`)
+          .set('Authorization', token)
+          .send({ name: 'NewName'})
+          .expect(constants.httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(subscribeTracker).to.have.length(1);
+            const evt = JSON.parse(subscribeTracker[0]);
+            expect(evt).to.have.property(botActionEvents.upd);
+            const evtBody = evt[botActionEvents.upd];
+            expect(evtBody).to.include.keys('id', 'isPending', 'name',
+              'actionLog', 'parameters', 'response', 'createdAt',
+              'updatedAt', 'roomId', 'botId', 'ownerId', 'userId', 'User',
+              'owner', 'pubOpts');
+            expect(evtBody).to.have.property('name', 'NewName');
+            subscribeTracker = [];
+
+            api.delete(`${path}/${evtBody.id}`)
+              .set('Authorization', token)
+              .send()
+              .expect(constants.httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(subscribeTracker).to.have.length(1);
+                const evt = JSON.parse(subscribeTracker[0]);
+                expect(evt).to.have.property(botActionEvents.del);
+                const evtBody = evt[botActionEvents.del];
+                console.log(evtBody)
+                expect(evtBody).to.include.keys('id', 'isPending', 'name',
+                  'actionLog', 'parameters', 'response', 'createdAt',
+                  'updatedAt', 'roomId', 'botId', 'ownerId', 'userId', 'User',
+                  'owner', 'pubOpts');
+                expect(evtBody).to.have.property('name', 'NewName');
+
+                done();
+              });
+          });
+      });
+  });
+});

--- a/tests/publish/botActions.js
+++ b/tests/publish/botActions.js
@@ -129,7 +129,6 @@ describe('tests/publish/botActions.js >', () => {
                 const evt = JSON.parse(subscribeTracker[0]);
                 expect(evt).to.have.property(botActionEvents.del);
                 const evtBody = evt[botActionEvents.del];
-                console.log(evtBody)
                 expect(evtBody).to.include.keys('id', 'isPending', 'name',
                   'actionLog', 'parameters', 'response', 'createdAt',
                   'updatedAt', 'roomId', 'botId', 'ownerId', 'userId', 'User',

--- a/tests/publish/botData.js
+++ b/tests/publish/botData.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/publish/botData.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const redis = require('redis');
+const rconf = require('../../config/redisConfig');
+const constants = require('../../api/v1/constants');
+const api = supertest(require('../../express').app);
+const tu = require('../testUtils');
+const Room = tu.db.Room;
+const RoomType = tu.db.RoomType;
+const Bot = tu.db.Bot;
+const BotData = tu.db.BotData;
+const botDataEvents = require('../../realtime/constants').events.botData;
+const path = '/v1/botData';
+const u = require('../api/v1/botData/utils');
+const r = require('../api/v1/rooms/utils');
+const rt = require('../api/v1/roomTypes/utils');
+const b = require('../api/v1/bots/utils');
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+
+describe('tests/publish/botData.js >', () => {
+  let token;
+  let subscriber;
+  let subscribeTracker = [];
+  const testBotData = u.getStandard();
+
+  before((done) => {
+    subscriber = redis.createClient(DEFAULT_LOCAL_REDIS_URL);
+    subscriber.subscribe(rconf.botChannelName);
+    subscriber.on('message', (channel, msg) => subscribeTracker.push(msg));
+
+    tu.createToken()
+      .then((returnedToken) => (token = returnedToken))
+      .then(() => done())
+      .catch(done);
+  });
+
+  beforeEach((done) => {
+    RoomType.create(rt.getStandard())
+      .then((roomType) => {
+        const room = r.getStandard();
+        room.type = roomType.id;
+        return Room.create(room);
+      })
+      .then((room) => {
+        testBotData.roomId = room.id;
+        return Bot.create(b.getStandard());
+      })
+      .then((bot) => {
+        testBotData.botId = bot.id;
+        subscribeTracker = [];
+        done();
+      })
+      .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+  afterEach(() => subscribeTracker = []);
+
+  after(tu.forceDeleteToken);
+  after(tu.forceDeleteUser);
+
+  it('POST then PATCH then DELETE, subscriber gets events', (done) => {
+    api.post(path)
+      .set('Authorization', token)
+      .send(testBotData)
+      .expect(constants.httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(subscribeTracker).to.have.length(1);
+        const evt = JSON.parse(subscribeTracker[0]);
+        expect(evt).to.have.property(botDataEvents.add);
+        const evtBody = evt[botDataEvents.add];
+        expect(evtBody).to.include.keys('new', 'old');
+        expect(evtBody.old).to.include.keys('id', 'name', 'value', 'roomId',
+          'botId', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'pubOpts');
+        expect(evtBody.new).to.include.keys('id', 'name', 'value', 'roomId',
+          'botId', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'pubOpts');
+        expect(evtBody.new).to.have.property('name', '___TestBotData');
+        expect(evtBody.new).to.have.property('value', 'String1');
+        subscribeTracker = [];
+
+        api.patch(`${path}/${evtBody.new.id}`)
+          .set('Authorization', token)
+          .send({ name: 'NewName'})
+          .expect(constants.httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(subscribeTracker).to.have.length(1);
+            const evt = JSON.parse(subscribeTracker[0]);
+            expect(evt).to.have.property(botDataEvents.upd);
+            const evtBody = evt[botDataEvents.upd];
+            expect(evtBody).to.include.keys('new', 'old');
+            expect(evtBody.old).to.include.keys('id', 'name', 'value',
+              'createdAt', 'updatedAt', 'roomId', 'botId', 'ownerId',
+              'createdBy', 'user', 'owner', 'pubOpts');
+            expect(evtBody.new).to.include.keys('id', 'name', 'value',
+              'createdAt', 'updatedAt', 'roomId', 'botId', 'ownerId',
+              'createdBy', 'user', 'owner', 'pubOpts');
+            expect(evtBody.new).to.have.property('name', 'NewName');
+            subscribeTracker = [];
+
+            api.delete(`${path}/${evtBody.new.id}`)
+              .set('Authorization', token)
+              .send()
+              .expect(constants.httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(subscribeTracker).to.have.length(1);
+                const evt = JSON.parse(subscribeTracker[0]);
+                expect(evt).to.have.property(botDataEvents.del);
+                const evtBody = evt[botDataEvents.del];
+                expect(evtBody).to.include.keys('new', 'old');
+                expect(evtBody.old).to.include.keys('id', 'name', 'value',
+                  'createdAt', 'updatedAt', 'roomId', 'botId', 'ownerId',
+                  'createdBy', 'user', 'owner', 'pubOpts');
+                expect(evtBody.new).to.include.keys('id', 'name', 'value',
+                  'createdAt', 'updatedAt', 'roomId', 'botId', 'ownerId',
+                  'createdBy', 'user', 'owner', 'pubOpts');
+                expect(evtBody.new).to.have.property('name', 'NewName');
+
+                done();
+              });
+          });
+      });
+  });
+});

--- a/tests/publish/events.js
+++ b/tests/publish/events.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/publish/events.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const redis = require('redis');
+const rconf = require('../../config/redisConfig');
+const constants = require('../../api/v1/constants');
+const api = supertest(require('../../express').app);
+const tu = require('../testUtils');
+const u = require('../api/v1/events/utils');
+const botEventEvents = require('../../realtime/constants').events.botEvent;
+const path = '/v1/events';
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+
+describe('tests/publish/events.js >', () => {
+  let token;
+  let subscriber;
+  let subscribeTracker = [];
+
+  before((done) => {
+    subscriber = redis.createClient(DEFAULT_LOCAL_REDIS_URL);
+    subscriber.subscribe(rconf.botChannelName);
+    subscriber.on('message', (channel, msg) => subscribeTracker.push(msg));
+
+    tu.createToken()
+      .then((returnedToken) => (token = returnedToken))
+      .then(() => done())
+      .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+  afterEach(() => subscribeTracker = []);
+
+  after(tu.forceDeleteToken);
+
+  it('POST, subscriber gets events', (done) => {
+    api.post(path)
+      .set('Authorization', token)
+      .send(u.getStandard())
+      .expect(constants.httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(subscribeTracker).to.have.length(1);
+        const evt = JSON.parse(subscribeTracker[0]);
+        expect(evt).to.have.property(botEventEvents.add);
+        const evtBody = evt[botEventEvents.add];
+        expect(evtBody).to.include.keys('new', 'old');
+        expect(evtBody.old).to.include.keys('id', 'log', 'actionType',
+          'context', 'ownerId', 'updatedAt', 'createdAt', 'roomId', 'botId',
+          'botDataId', 'botActionId', 'userId', 'pubOpts');
+        expect(evtBody.old).to.include.keys('id', 'log', 'actionType',
+          'context', 'ownerId', 'updatedAt', 'createdAt', 'roomId', 'botId',
+          'botDataId', 'botActionId', 'userId', 'pubOpts');
+        expect(evtBody.new).to.have.property('log', 'Sample Event');
+        expect(evtBody.new).to.have.property('actionType', 'EventType');
+        done();
+      });
+  });
+});

--- a/tests/publish/rooms.js
+++ b/tests/publish/rooms.js
@@ -1,7 +1,181 @@
-// Room
-// PUT, PATCH
-//  confirm we got a settingsChanged event if settings, name or active attribute was modified
-//  confirm no event if those three attributes were not modified
-// DELETE
-//  confirm we got a settingsChanged event if active
-//  confirm no event if not active
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/publish/rooms.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const supertest = require('supertest');
+const redis = require('redis');
+const rconf = require('../../config/redisConfig');
+const constants = require('../../api/v1/constants');
+const api = supertest(require('../../express').app);
+const tu = require('../testUtils');
+const Room = tu.db.Room;
+const RoomType = tu.db.RoomType;
+const u = require('../api/v1/rooms/utils');
+const roomEvents = require('../../realtime/constants').events.room;
+const path = '/v1/rooms';
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+
+describe('tests/publish/rooms.js >', () => {
+  let token;
+  let subscriber;
+  let subscribeTracker = [];
+  let testRoomType;
+
+  before((done) => {
+    subscriber = redis.createClient(DEFAULT_LOCAL_REDIS_URL);
+    subscriber.subscribe(rconf.botChannelName);
+    subscriber.on('message', (channel, msg) => subscribeTracker.push(msg));
+
+    tu.createToken()
+      .then((returnedToken) => (token = returnedToken))
+      .then(() => done())
+      .catch(done);
+  });
+
+  beforeEach((done) => {
+    tu.db.RoomType.create(u.rtSchema)
+      .then((newRoomType) => {
+        testRoomType = newRoomType;
+        done();
+      })
+      .catch(done);
+  });
+
+  afterEach(u.forceDelete);
+  afterEach(() => subscribeTracker = []);
+
+  after(tu.forceDeleteToken);
+
+  describe('POST >', () => {
+    it('POST active room', (done) => {
+      let room = u.getStandard();
+      room.type = testRoomType.id;
+
+      api.post(`${path}`)
+        .set('Authorization', token)
+        .send(room)
+        .expect(constants.httpStatus.CREATED)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const evt = JSON.parse(subscribeTracker[0]);
+          expect(evt).to.have.property(roomEvents.add);
+          const evtBody = evt[roomEvents.add];
+          expect(evtBody).to.include.keys('new', 'old');
+          expect(evtBody.old).to.include.keys('id', 'name', 'active', 'origin',
+            'type', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'settings',
+            'bots', 'externalId', 'pubOpts');
+          expect(evtBody.new).to.include.keys('id', 'name', 'active', 'origin',
+            'type', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'settings',
+            'bots', 'externalId', 'pubOpts');
+          expect(evtBody.new).to.have.property('name', '___TestRoom');
+          expect(evtBody.new).to.have.property('active', true);
+          done();
+        });
+    });
+
+    // TODO ask IMC if this is a valid test, i.e. should we even be emitting an event here?
+    it('POST inactive room', (done) => {
+      const room = u.getStandard();
+      room.type = testRoomType.id;
+      room.active = false;
+
+      api.post(`${path}`)
+        .set('Authorization', token)
+        .send(room)
+        .expect(constants.httpStatus.CREATED)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const evt = JSON.parse(subscribeTracker[0]);
+          expect(evt).to.have.property(roomEvents.add);
+          const evtBody = evt[roomEvents.add];
+          expect(evtBody).to.include.keys('new', 'old');
+          expect(evtBody.old).to.include.keys('id', 'name', 'active', 'origin',
+            'type', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'settings',
+            'bots', 'externalId', 'pubOpts');
+          expect(evtBody.new).to.include.keys('id', 'name', 'active', 'origin',
+            'type', 'ownerId', 'createdBy', 'updatedAt', 'createdAt', 'settings',
+            'bots', 'externalId', 'pubOpts');
+          expect(evtBody.new).to.have.property('name', '___TestRoom');
+          expect(evtBody.new).to.have.property('active', false);
+          done();
+        });
+    });
+  });
+
+  describe('PATCH >', () => {
+    let rm;
+
+    beforeEach((done) => {
+      const room = u.getStandard();
+      room.type = testRoomType.id;
+      Room.create(room)
+        .then((newRoom) => {
+          rm = newRoom;
+          subscribeTracker = [];
+          done();
+        })
+        .catch(done);
+    });
+
+    // Ran into this when trying to implement these tests:
+    //   Unhandled rejection SequelizeEagerLoadingError:
+    //   RoomType is associated to Room using an alias. You've included an
+    //   alias (type), but it does not match the alias(es) defined in your
+    //   association (RoomType).
+
+    it('modify settings of active room, get settingsChanged event');
+    it('modify name of active room, get settingsChanged event');
+    it('modify active false>>true, get settingsChanged event');
+    it('modify active true>>false, get settingsChanged event');
+    it('no event if origin is modified');
+    it('no event if type is modified');
+    it('no event if bots is modified');
+    it('no event if externalId is modified');
+
+    // TODO ask IMC if we should be emitting events for changes to settings/name for an inactive room
+    it('modify name of inactive room, get settingsChanged event?');
+    it('modify settings of inactive room, get settingsChanged event?');
+
+  });
+
+  describe('DELETE >', () => {
+    let rm;
+
+    beforeEach((done) => {
+      const room = u.getStandard();
+      room.type = testRoomType.id;
+      Room.create(room)
+        .then((newRoom) => {
+          rm = newRoom;
+          subscribeTracker = [];
+          done();
+        })
+        .catch(done);
+    });
+
+    // Ran into this when trying to implement these tests:
+    //   Unhandled rejection SequelizeEagerLoadingError:
+    //   RoomType is associated to Room using an alias. You've included an
+    //   alias (type), but it does not match the alias(es) defined in your
+    //   association (RoomType).
+    it('got settingsChanged event if room was active');
+    it('no event if room was inactive');
+  });
+});

--- a/tests/publish/rooms.js
+++ b/tests/publish/rooms.js
@@ -1,0 +1,7 @@
+// Room
+// PUT, PATCH
+//  confirm we got a settingsChanged event if settings, name or active attribute was modified
+//  confirm no event if those three attributes were not modified
+// DELETE
+//  confirm we got a settingsChanged event if active
+//  confirm no event if not active

--- a/tests/publish/samples.js
+++ b/tests/publish/samples.js
@@ -1,0 +1,342 @@
+/**
+ * Copyright (c) 2019, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * tests/publish/samples.js
+ */
+'use strict'; // eslint-disable-line strict
+const expect = require('chai').expect;
+const featureToggles = require('feature-toggles');
+const supertest = require('supertest');
+const redis = require('redis');
+const rconf = require('../../config/redisConfig');
+const constants = require('../../api/v1/constants');
+const api = supertest(require('../../express').app);
+const tu = require('../testUtils');
+const Subject = tu.db.Subject;
+const redisPublisher = require('../../realtime/redisPublisher');
+const sampleEvents = require('../../realtime/constants').events.sample;
+const samstoinit = require('../../cache/sampleStoreInit');
+const doTimeout = require('../../cache/sampleStoreTimeout').doTimeout;
+const DEFAULT_LOCAL_REDIS_URL = '//127.0.0.1:6379';
+
+const addSubject = (name, token) => api.post('/v1/subjects')
+  .set('Authorization', token)
+  .send({ name, isPublished: true })
+  .then(() => api.get(`/v1/subjects/${name}`).set('Authorization', token));
+
+const addAspect = (name, token, timeout = '1h') => api.post('/v1/aspects')
+  .set('Authorization', token)
+  .send({
+    name,
+    timeout,
+    isPublished: true,
+    criticalRange: [0, 0],
+  })
+  .then(() => api.get(`/v1/aspects/${name}`).set('Authorization', token));
+
+const upsertSample = (name, token) => api.post('/v1/samples/upsert')
+  .set('Authorization', token)
+  .send({
+    name,
+    value: '1',
+    relatedLinks: [
+      { name: 'a', url: 'a.com' },
+      { name: 'b', url: 'b.com' },
+      { name: 'c', url: 'c.com' },
+    ],
+  })
+  .then(() => api.get(`/v1/samples/${name}`).set('Authorization', token));
+
+describe('tests/publish/samples.js >', () => {
+  let token;
+  let subscriber;
+  let subscribeTracker = [];
+
+  before((done) => {
+    before(() => tu.toggleOverride('enableRedisSampleStore', true));
+    subscriber = redis.createClient(DEFAULT_LOCAL_REDIS_URL);
+    subscriber.subscribe(rconf.perspectiveChannelName);
+    subscriber.on('message', (channel, msg) => subscribeTracker.push(msg));
+
+    samstoinit.eradicate()
+      .then(() => tu.createToken())
+      .then((returnedToken) => {
+        token = returnedToken;
+        done();
+      })
+      .catch(done);
+  });
+
+  after(() => tu.forceDelete(tu.db.Subject)
+    .then(() => tu.forceDelete(tu.db.Aspect))
+    .then(() => tu.forceDelete(tu.db.User))
+    .then(() => tu.forceDelete(tu.db.Profile))
+    .then(() => samstoinit.eradicate()));
+
+  afterEach(() => subscribeTracker = []);
+
+  describe('delete aspect >', () => {
+    before(() => addSubject(`${tu.namePrefix}S1`, token)
+      .then(() => addSubject(`${tu.namePrefix}S2`, token))
+      .then(() => addAspect(`${tu.namePrefix}A1`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S1|${tu.namePrefix}A1`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S2|${tu.namePrefix}A1`, token))
+      .then(() => (subscribeTracker = [])));
+
+    it('one sample.remove event per sample for the deleted aspect', (done) => {
+      api.delete(`/v1/aspects/${tu.namePrefix}A1`)
+        .set('Authorization', token)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(2);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.del);
+          const s0Body = s0[sampleEvents.del];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+
+          const s1 = JSON.parse(subscribeTracker[1]);
+          expect(s1).to.have.property(sampleEvents.del);
+          const s1Body = s1[sampleEvents.del];
+          expect(s1Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          done();
+        })
+    });
+  });
+
+  describe('patch aspect >', () => {
+    before(() => addSubject(`${tu.namePrefix}S3`, token)
+      .then(() => addAspect(`${tu.namePrefix}A2`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S3|${tu.namePrefix}A2`, token))
+      .then(() => (subscribeTracker = [])));
+
+    it('edit tags, sample.remove followed by sample.add', (done) => {
+      api.patch(`/v1/aspects/${tu.namePrefix}A2`)
+        .set('Authorization', token)
+        .send({ tags: ['T1'] })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(2);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.del);
+          const s0Body = s0[sampleEvents.del];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+
+          const s1 = JSON.parse(subscribeTracker[1]);
+          expect(s1).to.have.property(sampleEvents.add);
+          const s1Body = s1[sampleEvents.add];
+          expect(s1Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          done();
+        });
+    });
+  });
+
+  describe('post sample >', () => {
+    let subj;
+    let asp;
+    before(() => addSubject(`${tu.namePrefix}S4`, token)
+      .then((s) => (subj = s.body))
+      .then(() => addAspect(`${tu.namePrefix}A3`, token))
+      .then((a) => (asp = a.body))
+      .then(() => (subscribeTracker = [])));
+
+    it('sample.add event', (done) => {
+      api.post('/v1/samples', token)
+        .set('Authorization', token)
+        .send({ subjectId: subj.id, aspectId: asp.id})
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.add);
+          const s0Body = s0[sampleEvents.add];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          done();
+        });
+    });
+  });
+
+  describe('upsert sample >', () => {
+    before(() => addSubject(`${tu.namePrefix}S5`, token)
+      .then(() => addAspect(`${tu.namePrefix}A4`, token))
+      .then(() => addAspect(`${tu.namePrefix}A5`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S5|${tu.namePrefix}A5`, token))
+      .then(() => (subscribeTracker = [])));
+
+    it('new sample, sample.add event', (done) => {
+      upsertSample(`${tu.namePrefix}S5|${tu.namePrefix}A4`, token)
+        .then(() => {
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.add);
+          const s0Body = s0[sampleEvents.add];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          done();
+        });
+    });
+
+    it('sample.update event, sample.nochange event', (done) => {
+      api.post('/v1/samples/upsert')
+        .set('Authorization', token)
+        .send({
+          name: `${tu.namePrefix}S5|${tu.namePrefix}A5`,
+          value: '0',
+        })
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.upd);
+          const s0Body = s0[sampleEvents.upd];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          subscribeTracker = [];
+
+          api.post('/v1/samples/upsert')
+            .set('Authorization', token)
+            .send({
+              name: `${tu.namePrefix}S5|${tu.namePrefix}A5`,
+              value: '0',
+            })
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(subscribeTracker).to.have.length(1);
+              const s0 = JSON.parse(subscribeTracker[0]);
+              expect(s0).to.have.property(sampleEvents.nc);
+              const s0Body = s0[sampleEvents.nc];
+              expect(s0Body).to.include.keys('absolutePath', 'aspect', 'name',
+                'status', 'subject', 'updatedAt');
+              done();
+            });
+        });
+    });
+  });
+
+  describe('sample timeout >', () => {
+    let mockUpdatedAt;
+    before(() => addSubject(`${tu.namePrefix}S8`, token)
+      .then(() => addAspect(`${tu.namePrefix}A8`, token, '9m'))
+      .then(() => upsertSample(`${tu.namePrefix}S8|${tu.namePrefix}A8`, token))
+      .then((samp) => {
+        mockUpdatedAt = new Date(samp.body.updatedAt);
+        mockUpdatedAt.setMinutes(mockUpdatedAt.getMinutes() + 10);
+      })
+      .then(() => (subscribeTracker = [])));
+
+    it('got sample.update event', (done) => {
+      doTimeout(mockUpdatedAt)
+        .then((timeoutResponse) => {
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.upd);
+          const s0Body = s0[sampleEvents.upd];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          expect(s0Body).to.have.property('status', 'Timeout');
+        })
+        .then(() => done())
+        .catch(done);
+    });
+  });
+
+  describe('delete one sample related link', () => {
+    before(() => addSubject(`${tu.namePrefix}S6`, token)
+      .then(() => addAspect(`${tu.namePrefix}A6`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S6|${tu.namePrefix}A6`, token))
+      .then(() => (subscribeTracker = [])));
+
+    it('sample update event', (done) => {
+      api.delete(`/v1/samples/${tu.namePrefix}S6|${tu.namePrefix}A6/relatedLinks/a`)
+        .set('Authorization', token)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.upd);
+          const s0Body = s0[sampleEvents.upd];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          expect(s0Body.relatedLinks).to.deep.equal([
+            { name: 'b', url: 'b.com' },
+            { name: 'c', url: 'c.com' },
+          ]);
+          done();
+        });
+    });
+  });
+
+  describe('delete all sample related links', () => {
+    before(() => addSubject(`${tu.namePrefix}S7`, token)
+      .then(() => addAspect(`${tu.namePrefix}A7`, token))
+      .then(() => upsertSample(`${tu.namePrefix}S7|${tu.namePrefix}A7`, token))
+      .then(() => (subscribeTracker = [])));
+
+    it('sample update event', (done) => {
+      api.delete(`/v1/samples/${tu.namePrefix}S7|${tu.namePrefix}A7/relatedLinks`)
+        .set('Authorization', token)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          expect(subscribeTracker).to.have.length(1);
+          const s0 = JSON.parse(subscribeTracker[0]);
+          expect(s0).to.have.property(sampleEvents.upd);
+          const s0Body = s0[sampleEvents.upd];
+          expect(s0Body).to.include.keys('createdAt', 'subjectId', 'aspectId',
+            'user', 'status', 'name', 'relatedLinks', 'provider', 'updatedAt',
+            'previousStatus', 'statusChangedAt', 'aspect', 'subject',
+            'absolutePath');
+          expect(s0Body.relatedLinks).to.deep.equal([]);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
Add publish tests for real-time events for samples
Fix bugs found while testing (!!!)
- Use redis publishAsync and always call publishObject expecting a promise to be returned.
- In samples api controller, always call publish inside the promise chain.
- Fix the sampleStoreTimeout so it publishes sample update.
- Stop double-publishing sample delete events when an aspect is deleted.
- In subject db model, always call publish inside the promise chain.

Add publish tests for real-time events for botActions, botData, events
Fix bugs found while testing (!!!)
- When deleting botData, explicitly add something to the "changedKeys" array, otherwise the prepareToPublish fn determines that there's nothing to publish, so we were not emitting an event.