### PR TITLE
Add api endpoints to allow associating collectorGroups with collectors and generators from either side.

### DIFF
--- a/api/v1/controllers/collectorGroups.js
+++ b/api/v1/controllers/collectorGroups.js
@@ -171,6 +171,16 @@ function patchCollectorGroup(req, res, next) {
       return collectorGroup;
     })
     .then((patched) => (cg = patched))
+    .then((collectorGroup) => {
+      if (requestBody.hasOwnProperty('generators')) {
+        const gens = requestBody.generators;
+        delete requestBody.collectors;
+        return collectorGroup.patchGenerators(gens);
+      }
+
+      return collectorGroup;
+    })
+    .then((patched) => (cg = patched))
     .then(() => cg.update(requestBody))
     .then((o) => o.reload())
     .then(() => {
@@ -223,6 +233,15 @@ function putCollectorGroup(req, res, next) {
       }
 
       return collectorGroup.patchCollectors(colls);
+    })
+    .then((collectorGroup) => {
+      let gens = [];
+      if (requestBody.hasOwnProperty('generators')) {
+        gens = requestBody.generators;
+        delete requestBody.generators;
+      }
+
+      return collectorGroup.patchGenerators(gens);
     })
     .then((patched) => (cg = patched))
     .then(() => cg.update(requestBody))

--- a/api/v1/controllers/collectors.js
+++ b/api/v1/controllers/collectors.js
@@ -175,7 +175,15 @@ function patchCollector(req, res, next) {
     return u.handleError(next, err, helper.modelName);
   }
 
-  return doPatch(req, res, next, helper);
+  const requestBody = req.swagger.params.queryBody.value;
+  return u.findByKey(helper, req.swagger.params)
+  .then((o) =>
+    o.updateCollectorGroup(requestBody)
+  )
+  .then(() =>
+    doPatch(req, res, next, helper)
+  )
+  .catch((err) => u.handleError(next, err, helper.modelName));
 } // patchCollector
 
 /**

--- a/api/v1/swagger.yaml
+++ b/api/v1/swagger.yaml
@@ -3374,6 +3374,9 @@ paths:
             type: object
             description: Fields permitted for patching.
             properties:
+              collectorGroup:
+                description: Name of the collectorGroup this collector belongs to.
+                type: string
               description:
                 type: string
                 maxLength: 4096
@@ -11714,6 +11717,11 @@ paths:
                 type: array
                 items:
                   type: string
+              generators:
+                description: List of generators assigned to this group.
+                type: array
+                items:
+                  type: string
               owner:
                 type: string
                 description: >
@@ -11903,6 +11911,11 @@ paths:
                 type: array
                 items:
                   type: string
+              generators:
+                description: List of generators assigned to this group.
+                type: array
+                items:
+                  type: string
               owner:
                 type: string
                 description: >
@@ -11958,6 +11971,11 @@ paths:
                   A unique and descriptive name for the collector group.
               collectors:
                 description: List of collectors for the group.
+                type: array
+                items:
+                  type: string
+              generators:
+                description: List of generators assigned to this group.
                 type: array
                 items:
                   type: string

--- a/db/dbErrors.js
+++ b/db/dbErrors.js
@@ -147,6 +147,14 @@ errors.create({
   parent: this.ValidationError,
   defaultMessage: 'Invalid aspect status range.',
 });
+errors.create({
+  scope: exports,
+  code: 10123,
+  status: 400,
+  name: 'DuplicateGeneratorError',
+  parent: this.ValidationError,
+  defaultMessage: 'You cannot map duplicate Generators to this Object.',
+});
 
 // ----------------------------------------------------------------------------
 // Not Found

--- a/db/helpers/collectorUtils.js
+++ b/db/helpers/collectorUtils.js
@@ -197,6 +197,39 @@ function validate(seq, collectorNames) {
 }
 
 /**
+ * Used by db model.
+ * Validate the collectorGroup name field: if succeed, return a promise with
+ * the collectorGroup.
+ * If fail, reject Promise with the appropriate error
+ *
+ * @param {Object} seq - the Sequelize object
+ * @param {String} collectorGroupName - name of a collectorGroup
+ * @returns {Promise} with collectorGroup if validation pass,
+ * rejected promise with the appropriate error otherwise.
+ */
+function validateCollectorGroup(seq, collectorGroupName) {
+  if (!collectorGroupName) {
+    return Promise.resolve(null);
+  }
+
+  return new seq.Promise((resolve, reject) =>
+    seq.models.CollectorGroup.findOne({ where: { name: collectorGroupName } })
+    .then((_cg) => {
+      if (_cg) {
+        resolve(_cg);
+      }
+
+      const err = new dbErrors.ResourceNotFoundError(
+        `CollectorGroup "${collectorGroupName}" not found.`
+      );
+      err.resourceType = 'CollectorGroup';
+      err.resourceKey = collectorGroupName;
+      reject(err);
+    })
+  );
+}
+
+/**
  * Checks if any of the collectors in the array is already assigned to a group.
  * @param {Array<Object>} arr - array of collector objects
  * @returns {Array<Object>} the original array
@@ -242,4 +275,5 @@ module.exports = {
   validateVersion,
   assignUnassignedGenerators,
   validate,
+  validateCollectorGroup,
 }; // exports

--- a/db/model/collector.js
+++ b/db/model/collector.js
@@ -335,6 +335,30 @@ module.exports = function collector(seq, dataTypes) {
       .map((g) => g.assignToCollector().then(() => g.save()));
   };
 
+  /**
+   * Set the collector group.
+   *
+   * @param {Object} requestBody From API
+   * @returns {Promise}
+   */
+  Collector.prototype.updateCollectorGroup = function (requestBody) {
+    const oldGroup = this.collectorGroup;
+    let newGroup;
+    return u.validateCollectorGroup(seq, requestBody.collectorGroup)
+    .then((cg) => {
+      if (cg) {
+        newGroup = cg;
+        delete requestBody.collectorGroup;
+        return this.setCollectorGroup(newGroup);
+      }
+    })
+    .then(() => this.reload())
+    .then(() => oldGroup && oldGroup.reload(oldGroup._modelOptions.defaultScope))
+    .then(() => newGroup && newGroup.reload(newGroup._modelOptions.defaultScope))
+    .then(() => oldGroup && oldGroup.handleCollectorUpdates())
+    .then(() => newGroup && newGroup.handleCollectorUpdates());
+  }; // updateCollectorGroup
+
   Collector.prototype.isWritableBy = function (who) {
     return new seq.Promise((resolve /* , reject */) =>
       this.getWriters()

--- a/tests/api/v1/collectorGroups/create.js
+++ b/tests/api/v1/collectorGroups/create.js
@@ -15,14 +15,21 @@ const api = supertest(require('../../../../express').app);
 const httpStatus = require('../../../../api/v1/constants').httpStatus;
 const tu = require('../../../testUtils');
 const u = require('./utils');
+const gu = require('../generators/utils');
+const gtu = require('../generatorTemplates/utils');
 const Collector = tu.db.Collector;
+const Generator = tu.db.Generator;
+const GeneratorTemplate = tu.db.GeneratorTemplate;
 const expect = require('chai').expect;
 
 describe('tests/api/v1/collectorGroups/create.js >', () => {
   let token;
-  let collector1;
-  let collector2;
-  let collector3;
+  let coll1;
+  let coll2;
+  let coll3;
+  let gen1;
+  let gen2;
+  let gen3;
 
   before((done) => {
     tu.createToken()
@@ -33,23 +40,54 @@ describe('tests/api/v1/collectorGroups/create.js >', () => {
   });
 
   beforeEach(() => {
-    collector1 = u.getCollectorToCreate();
-    collector1.name += '1';
-    Collector.create(collector1);
-    collector2 = u.getCollectorToCreate();
-    collector2.name += '2';
-    Collector.create(collector2);
-    collector3 = u.getCollectorToCreate();
-    collector3.name += '3';
-    Collector.create(collector3);
+    coll1 = u.getCollectorToCreate();
+    coll1.name += '1';
+    coll2 = u.getCollectorToCreate();
+    coll2.name += '2';
+    coll3 = u.getCollectorToCreate();
+    coll3.name += '3';
+    return Promise.all([
+      Collector.create(coll1),
+      Collector.create(coll2),
+      Collector.create(coll3),
+    ]);
+  });
+
+  beforeEach(() => {
+    gen1 = gu.getBasic({ name: 'gen1' });
+    gen2 = gu.getBasic({ name: 'gen2' });
+    gen3 = gu.getBasic({ name: 'gen3' });
+    const generatorTemplate = gtu.getGeneratorTemplate();
+    gu.createSGtoSGTMapping(generatorTemplate, gen1);
+    gu.createSGtoSGTMapping(generatorTemplate, gen2);
+    gu.createSGtoSGTMapping(generatorTemplate, gen3);
+    gen1.isActive = true;
+    gen2.isActive = true;
+    gen3.isActive = true;
+    return GeneratorTemplate.create(generatorTemplate)
+    .then(() => Promise.all([
+      Generator.create(gen1, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+      Generator.create(gen2, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+      Generator.create(gen3, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+    ]));
   });
 
   afterEach(u.forceDelete);
 
   after(tu.forceDeleteUser);
 
-  it('create collector group with empty collector list', (done) => {
-    api.post('/v1/collectorGroups')
+  describe('create with collectors', () => {
+    it('create collector group with empty collector list', (done) => {
+      api.post('/v1/collectorGroups')
       .set('Authorization', token)
       .send({
         name: 'coll-group-name-empty-colls',
@@ -65,20 +103,20 @@ describe('tests/api/v1/collectorGroups/create.js >', () => {
         expect(res.body).to.have.property('description');
         expect(res.body.name).to.be.equal('coll-group-name-empty-colls');
         expect(res.body.description)
-          .to.be.equal('coll-group-description-empty-colls');
+        .to.be.equal('coll-group-description-empty-colls');
         expect(res.body).to.have.property('collectors');
         expect(res.body.collectors.length).to.be.equal(0);
         return done();
       });
-  });
+    });
 
-  it('create collector group with 1 collector', (done) => {
-    api.post('/v1/collectorGroups')
+    it('create collector group with 1 collector', (done) => {
+      api.post('/v1/collectorGroups')
       .set('Authorization', token)
       .send({
         name: 'coll-group-name-one-collector',
         description: 'coll-group-description-one-collector',
-        collectors: [collector1.name],
+        collectors: [coll1.name],
       })
       .expect(httpStatus.CREATED)
       .end((err, res) => {
@@ -99,15 +137,15 @@ describe('tests/api/v1/collectorGroups/create.js >', () => {
         expect(coll.status).to.equal('Stopped');
         return done();
       });
-  });
+    });
 
-  it('create collector group with more than one collector', (done) => {
-    api.post('/v1/collectorGroups')
+    it('create collector group with more than one collector', (done) => {
+      api.post('/v1/collectorGroups')
       .set('Authorization', token)
       .send({
         name: 'coll-group-name-2-collectors',
         description: 'coll-group-description-2-collectors',
-        collectors: [collector1.name, collector2.name],
+        collectors: [coll1.name, coll2.name],
       })
       .expect(httpStatus.CREATED)
       .end((err, res) => {
@@ -124,108 +162,297 @@ describe('tests/api/v1/collectorGroups/create.js >', () => {
         expect(res.body.collectors.length).to.be.equal(2);
         return done();
       });
-  });
+    });
 
-  it('fail when one collector is already assigned', (done) => {
-    api.post('/v1/collectorGroups')
+    it('fail when one collector is already assigned', (done) => {
+      api.post('/v1/collectorGroups')
       .set('Authorization', token)
       .send({ // Creating a Collector Group with Collector 3
         name: 'coll-group',
         description: 'coll-description',
-        collectors: [collector3.name],
+        collectors: [coll3.name],
       })
       .expect(httpStatus.CREATED)
       .end(() => {
-        api.post('/v1/collectorGroups')
-          .set('Authorization', token)
-          .send({ // Creating a new Collector Group with one Coll assigned
-            name: 'coll-group-must-fail',
-            description: 'coll-description-must-fail',
-            collectors: [collector1.name, collector3.name],
-          })
-          .expect(httpStatus.BAD_REQUEST)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            // Must inform that coll 3 is already assigned
-            const expectedMessage =
-              'Cannot double-assign collector(s) [___Coll3] to collector groups';
-            expect(res.body.errors[0])
-              .to.have.property('message', expectedMessage);
-            return done();
-          });
-      });
-  });
-
-  it('fail when more than one collector already assigned', (done) => {
-    api.post('/v1/collectorGroups')
-      .set('Authorization', token)
-      .send({
-        name: 'coll-group',
-        description: 'coll-group-description',
-        collectors: [collector1.name, collector2.name],
-      })
-      .expect(httpStatus.CREATED)
-      .end(() => {
-        api.post('/v1/collectorGroups')
-          .set('Authorization', token)
-          .send({
-            name: 'coll-group-name-fail-2',
-            description: 'coll-group-description-fail-2',
-            collectors: [collector1.name, collector2.name],
-          })
-          .expect(httpStatus.BAD_REQUEST)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            const expectedMessage = 'Cannot double-assign collector(s) ' +
-              '[___Coll1, ___Coll2] to collector groups';
-
-            expect(res.body.errors[0])
-              .to.have.property('message', expectedMessage);
-            return done();
-          });
-      });
-  });
-
-  it('ok when collector was previously assigned but group was deleted', (done) => {
-    api.post('/v1/collectorGroups')
-    .set('Authorization', token)
-    .send({ // Creating a Collector Group with Collector 3
-      name: 'coll-group',
-      description: 'coll-description',
-      collectors: [collector3.name],
-    })
-    .expect(httpStatus.CREATED)
-    .end(() => {
-      api.delete('/v1/collectorGroups/coll-group')
-      .set('Authorization', token)
-      .expect(httpStatus.OK)
-      .end((err, res) => {
-        if (err) {
-          return done(err);
-        }
-
         api.post('/v1/collectorGroups')
         .set('Authorization', token)
         .send({ // Creating a new Collector Group with one Coll assigned
-          name: 'coll-group-2',
-          description: 'coll-description',
-          collectors: [collector3.name],
+          name: 'coll-group-must-fail',
+          description: 'coll-description-must-fail',
+          collectors: [coll1.name, coll3.name],
         })
-        .expect(httpStatus.CREATED)
+        .expect(httpStatus.BAD_REQUEST)
         .end((err, res) => {
           if (err) {
             return done(err);
           }
 
-          expect(res.body.collectors[0].name).to.equal(collector3.name);
+          // Must inform that coll 3 is already assigned
+          const expectedMessage =
+            'Cannot double-assign collector(s) [___Coll3] to collector groups';
+          expect(res.body.errors[0])
+          .to.have.property('message', expectedMessage);
           return done();
         });
+      });
+    });
+
+    it('fail when more than one collector already assigned', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group',
+        description: 'coll-group-description',
+        collectors: [coll1.name, coll2.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end(() => {
+        api.post('/v1/collectorGroups')
+        .set('Authorization', token)
+        .send({
+          name: 'coll-group-name-fail-2',
+          description: 'coll-group-description-fail-2',
+          collectors: [coll1.name, coll2.name],
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const expectedMessage = 'Cannot double-assign collector(s) ' +
+            '[___Coll1, ___Coll2] to collector groups';
+
+          expect(res.body.errors[0])
+          .to.have.property('message', expectedMessage);
+          return done();
+        });
+      });
+    });
+
+    it('ok when collector was previously assigned but group was deleted', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({ // Creating a Collector Group with Collector 3
+        name: 'coll-group',
+        description: 'coll-description',
+        collectors: [coll3.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end(() => {
+        api.delete('/v1/collectorGroups/coll-group')
+        .set('Authorization', token)
+        .expect(httpStatus.OK)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          api.post('/v1/collectorGroups')
+          .set('Authorization', token)
+          .send({ // Creating a new Collector Group with one Coll assigned
+            name: 'coll-group-2',
+            description: 'coll-description',
+            collectors: [coll3.name],
+          })
+          .expect(httpStatus.CREATED)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            expect(res.body.collectors[0].name).to.equal(coll3.name);
+            return done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('create with generators', () => {
+    it('create collector group with 1 generator', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group-name-one-generator',
+        description: 'coll-group-description-one-generator',
+        generators: [gen1.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('name');
+        expect(res.body.name).to.be.equal('coll-group-name-one-generator');
+        expect(res.body).to.have.property('description');
+        expect(res.body.description)
+        .to.be.equal('coll-group-description-one-generator');
+        expect(res.body).to.have.property('generators');
+        expect(res.body.generators.length).to.be.equal(1);
+        const gen = res.body.generators[0];
+        expect(gen).to.have.keys('id', 'name', 'description', 'isActive', 'collectorGroup');
+        expect(gen.name).to.equal('gen1');
+        return done();
+      });
+    });
+
+    it('create collector group with more than one generator', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group-name-2-generators',
+        description: 'coll-group-description-2-generators',
+        generators: [gen1.name, gen2.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('name');
+        expect(res.body.name).to.be.equal('coll-group-name-2-generators');
+        expect(res.body).to.have.property('description');
+        expect(res.body.description)
+        .to.be.equal('coll-group-description-2-generators');
+        expect(res.body).to.have.property('generators');
+        expect(res.body.generators.length).to.be.equal(2);
+        return done();
+      });
+    });
+
+    it('fail when one generator is already assigned', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group',
+        description: 'coll-description',
+        generators: [gen3.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end(() => {
+        api.post('/v1/collectorGroups')
+        .set('Authorization', token)
+        .send({
+          name: 'coll-group-must-fail',
+          description: 'coll-description-must-fail',
+          generators: [gen1.name, gen3.name],
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          // Must inform that gen 3 is already assigned
+          const expectedMessage =
+            'Cannot double-assign generator(s) [gen3] to collector groups';
+          expect(res.body.errors[0])
+          .to.have.property('message', expectedMessage);
+          return done();
+        });
+      });
+    });
+
+    it('fail when more than one generator already assigned', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group',
+        description: 'coll-group-description',
+        generators: [gen1.name, gen2.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end(() => {
+        api.post('/v1/collectorGroups')
+        .set('Authorization', token)
+        .send({
+          name: 'coll-group-name-fail-2',
+          description: 'coll-group-description-fail-2',
+          generators: [gen1.name, gen2.name],
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          const expectedMessage = 'Cannot double-assign generator(s) ' +
+            '[gen1, gen2] to collector groups';
+
+          expect(res.body.errors[0])
+          .to.have.property('message', expectedMessage);
+          return done();
+        });
+      });
+    });
+  });
+
+  describe('create with collectors and generators', () => {
+    it('create collector group with 1 collector and 1 generator', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group-name-one-collector-one-generator',
+        description: 'coll-group-description-one-collector-one-generator',
+        collectors: [coll1.name],
+        generators: [gen1.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('name');
+        expect(res.body.name).to.be.equal('coll-group-name-one-collector-one-generator');
+        expect(res.body).to.have.property('description');
+        expect(res.body.description)
+        .to.be.equal('coll-group-description-one-collector-one-generator');
+
+        expect(res.body).to.have.property('collectors');
+        expect(res.body.collectors.length).to.be.equal(1);
+        const coll = res.body.collectors[0];
+        expect(coll).to.have.keys('id', 'name', 'status');
+        expect(coll.name).to.equal('___Coll1');
+        expect(coll.status).to.equal('Stopped');
+
+        expect(res.body).to.have.property('generators');
+        expect(res.body.generators.length).to.be.equal(1);
+        const gen = res.body.generators[0];
+        expect(gen).to.have.keys('id', 'name', 'description', 'isActive', 'collectorGroup');
+        expect(gen.name).to.equal('gen1');
+        return done();
+      });
+    });
+
+    it('create collector group with multiple collectors and generators', (done) => {
+      api.post('/v1/collectorGroups')
+      .set('Authorization', token)
+      .send({
+        name: 'coll-group-name-2-collectors-2-generators',
+        description: 'coll-group-description-2-collectors-2-generators',
+        collectors: [coll1.name, coll2.name],
+        generators: [gen1.name, gen2.name],
+      })
+      .expect(httpStatus.CREATED)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body).to.have.property('name');
+        expect(res.body.name).to.be.equal('coll-group-name-2-collectors-2-generators');
+        expect(res.body).to.have.property('description');
+        expect(res.body.description)
+        .to.be.equal('coll-group-description-2-collectors-2-generators');
+        expect(res.body).to.have.property('collectors');
+        expect(res.body.collectors.length).to.be.equal(2);
+        expect(res.body).to.have.property('generators');
+        expect(res.body.generators.length).to.be.equal(2);
+        return done();
       });
     });
   });

--- a/tests/api/v1/collectorGroups/patch.js
+++ b/tests/api/v1/collectorGroups/patch.js
@@ -12,6 +12,7 @@
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
 const sinon = require('sinon');
+const Promise = require('bluebird');
 const api = supertest(require('../../../../express').app);
 const httpStatus = require('../../../../api/v1/constants').httpStatus;
 const tu = require('../../../testUtils');
@@ -28,11 +29,21 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
   let user;
   let token;
   let token2;
-  let collector1;
-  let collector2;
-  let collector3;
+  let coll1;
+  let coll2;
+  let coll3;
   let cg = { name: '' };
   let cg2;
+
+  let gen1;
+  let gen2;
+  let g1 = gu.getBasic({ name: 'gen1' });
+  let g2 = gu.getBasic({ name: 'gen2' });
+  const generatorTemplate = gtu.getGeneratorTemplate();
+  gu.createSGtoSGTMapping(generatorTemplate, g1);
+  gu.createSGtoSGTMapping(generatorTemplate, g2);
+  g1.isActive = true;
+  g2.isActive = true;
 
   before((done) => {
     tu.createUserAndToken()
@@ -48,15 +59,37 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
   });
 
   beforeEach(() => {
-    collector1 = u.getCollectorToCreate();
+    const collector1 = u.getCollectorToCreate();
     collector1.name += '1';
-    Collector.create(collector1);
-    collector2 = u.getCollectorToCreate();
+    const collector2 = u.getCollectorToCreate();
     collector2.name += '2';
-    Collector.create(collector2);
-    collector3 = u.getCollectorToCreate();
+    const collector3 = u.getCollectorToCreate();
     collector3.name += '3';
-    Collector.create(collector3);
+    return Promise.join(
+      Collector.create(collector1),
+      Collector.create(collector2),
+      Collector.create(collector3),
+    )
+    .then(([c1, c2, c3]) => {
+      coll1 = c1;
+      coll2 = c2;
+      coll3 = c3;
+    })
+    .then(() => GeneratorTemplate.create(generatorTemplate))
+    .then(() => Promise.join(
+      Generator.create(g1, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+      Generator.create(g2, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+    ))
+    .then(([g1, g2]) => {
+      gen1 = g1;
+      gen2 = g2;
+    });
   });
 
   beforeEach((done) => {
@@ -71,7 +104,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
         name: `${tu.namePrefix}cg2`,
         description: 'desc2',
         createdBy: user.id,
-        collectors: [collector3.name],
+        collectors: [coll3.name],
       });
     })
     .then((created) => {
@@ -106,7 +139,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
       .set('Authorization', token)
       .send({
         description: 'hi',
-        collectors: [collector1.name, collector2.name],
+        collectors: [coll1.name, coll2.name],
       })
       .expect(httpStatus.OK)
       .end((err, res) => {
@@ -124,7 +157,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
   it('patch replaces collectors', (done) => {
     api.patch(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token)
-      .send({ collectors: [collector1.name] })
+      .send({ collectors: [coll1.name] })
       .expect(httpStatus.OK)
       .end((err) => {
         if (err) {
@@ -133,7 +166,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
 
         return api.patch(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
-          .send({ collectors: [collector2.name] })
+          .send({ collectors: [coll2.name] })
           .expect(httpStatus.OK)
           .end((_err, _res) => {
             if (_err) {
@@ -143,7 +176,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
             expect(_res.body).to.have.property('name', cg.name);
             expect(_res.body.collectors).to.have.lengthOf(1);
             expect(_res.body.collectors[0])
-              .to.have.property('name', collector2.name);
+              .to.have.property('name', coll2.name);
             return done();
           });
       });
@@ -152,7 +185,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
   it('reject if collector already in a different collector group', (done) => {
     api.patch(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token)
-      .send({ collectors: [collector3.name] })
+      .send({ collectors: [coll3.name] })
       .expect(httpStatus.BAD_REQUEST)
       .end((err, res) => {
         if (err) {
@@ -178,14 +211,106 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
 
       api.patch(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token)
-      .send({ collectors: [collector3.name] })
+      .send({ collectors: [coll3.name] })
       .expect(httpStatus.OK)
       .end((err, res) => {
         if (err) {
           return done(err);
         }
 
-        expect(res.body.collectors[0].name).to.equal(collector3.name);
+        expect(res.body.collectors[0].name).to.equal(coll3.name);
+        done();
+      });
+    });
+  });
+
+  it('patch with empty generator list', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({ description: 'new desc', generators: [] })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body).to.have.property('description', 'new desc');
+      expect(res.body.generators).to.be.empty;
+      return done();
+    });
+  });
+
+  it('patch with valid generators', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({
+      description: 'hi',
+      generators: [gen1.name, gen2.name],
+    })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body).to.have.property('name', cg.name);
+      expect(res.body).to.have.property('description', 'hi');
+      expect(res.body.generators).to.have.lengthOf(2);
+      return done();
+    });
+  });
+
+  it('patch replaces generators', (done) => {
+    api.patch(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({ generators: [gen1.name] })
+    .expect(httpStatus.OK)
+    .end((err) => {
+      if (err) {
+        return done(err);
+      }
+
+      return api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ generators: [gen2.name] })
+      .expect(httpStatus.OK)
+      .end((_err, _res) => {
+        if (_err) {
+          return done(_err);
+        }
+
+        expect(_res.body).to.have.property('name', cg.name);
+        expect(_res.body.generators).to.have.lengthOf(1);
+        expect(_res.body.generators[0])
+          .to.have.property('name', gen2.name);
+        return done();
+      });
+    });
+  });
+
+  it('reject if generator already in a different collector group', (done) => {
+    api.patch(`/v1/collectorGroups/${cg2.name}`)
+    .set('Authorization', token)
+    .send({ generators: [gen1.name] })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      api.patch(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ generators: [gen1.name] })
+      .expect(httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors).to.have.lengthOf(1);
+        expect(res.body.errors[0]).to.have.property('message',
+          'Cannot double-assign generator(s) [gen1] to collector groups');
+        expect(res.body.errors[0]).to.have.property('type', 'ValidationError');
         done();
       });
     });
@@ -194,7 +319,7 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
   it('reject if no write perm', (done) => {
     api.patch(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token2)
-      .send({ description: 'foo', collectors: [collector1.name] })
+      .send({ description: 'foo', collectors: [coll1.name] })
       .expect(httpStatus.FORBIDDEN)
       .end((err, res) => {
         if (err) {
@@ -226,11 +351,6 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
 
     let collectorAlive1;
     let collectorAlive2;
-    let generatorInst;
-    const generator = gu.getGenerator();
-    const generatorTemplate = gtu.getGeneratorTemplate();
-    gu.createSGtoSGTMapping(generatorTemplate, generator);
-    generator.isActive = true;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers(now);
@@ -241,13 +361,6 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
       .then((collectors) => {
         collectorAlive1 = collectors[0];
         collectorAlive2 = collectors[1];
-        return GeneratorTemplate.create(generatorTemplate);
-      })
-      .then(() => Generator.create(generator,
-        { validate: false, include: Generator.options.defaultScope.include }))
-      .then((gen) => {
-        generatorInst = gen;
-        return generatorInst.setCollectorGroup(cg);
       })
       .then(() => done())
       .catch(done);
@@ -255,91 +368,20 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
 
     afterEach(() => clock.restore());
 
-    it('unassigned generator, patch collector group with collectors should ' +
-      'set currentCollector if alive collector is available', (done) => {
-      generatorInst.reload()
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector).to.not.exist;
-        api.patch(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          collectors: [collector1.name, collectorAlive1.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+    describe('update collectors >', () => {
+      beforeEach(() => Promise.join(
+        cg.setGenerators([gen1, gen2]),
+      ));
 
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members([collector1.name, collectorAlive1.name]);
-
-          api.get(`/v1/generators/${generatorInst.name}`)
-          .set('Authorization', token)
-          .expect(httpStatus.OK)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
-            return done();
-          });
-        });
-      });
-    });
-
-    it('unassigned generator, patch collector group with collectors should ' +
-      'not set currentCollector if no alive collector is available', (done) => {
-      generatorInst.reload()
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector).to.not.exist;
-        api.patch(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          collectors: [collector1.name, collector2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members([collector1.name, collector2.name]);
-
-          api.get(`/v1/generators/${generatorInst.name}`)
-          .set('Authorization', token)
-          .expect(httpStatus.OK)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            expect(res.body.currentCollector).to.not.exist;
-            return done();
-          });
-        });
-      });
-    });
-
-    it('already assigned generator, patch collectorGroup should not change ' +
-      'currentCollector if currentCollector exists in updated collector list',
-      (done) => {
-        generatorInst.update({ collectorId: collectorAlive1.id })
-        .then((gen) => gen.reload())
+      it('unassigned generator, patch collector group with collectors should ' +
+        'set currentCollector if alive collector is available', (done) => {
+        gen1.reload()
         .then((updatedGenInst) => {
-          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          expect(updatedGenInst.currentCollector).to.not.exist;
           api.patch(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
           .send({
-            collectors: [collector1.name, collectorAlive1.name, collectorAlive2.name],
+            collectors: [coll1.name, collectorAlive1.name],
           })
           .expect(httpStatus.OK)
           .end((err, res) => {
@@ -349,13 +391,11 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
 
             const collectors = res.body.collectors;
             expect(Array.isArray(collectors)).to.be.true;
-            expect(collectors.length).to.equal(3);
+            expect(collectors.length).to.equal(2);
             const collectorNames = collectors.map((collector) => collector.name);
-            expect(collectorNames).to.have.members(
-              [collector1.name, collectorAlive1.name, collectorAlive2.name]
-            );
+            expect(collectorNames).to.have.members([coll1.name, collectorAlive1.name]);
 
-            api.get(`/v1/generators/${generatorInst.name}`)
+            api.get(`/v1/generators/${gen1.name}`)
             .set('Authorization', token)
             .expect(httpStatus.OK)
             .end((err, res) => {
@@ -367,89 +407,814 @@ describe('tests/api/v1/collectorGroups/patch.js >', () => {
               return done();
             });
           });
+        });
+      });
+
+      it('unassigned generator, patch collector group with collectors should ' +
+        'not set currentCollector if no alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll1.name, coll2.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members([coll1.name, coll2.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        });
+      });
+
+      it('already assigned generator, patch collectorGroup should not change ' +
+        'currentCollector if currentCollector exists in updated collector list',
+        (done) => {
+          gen1.update({ collectorId: collectorAlive1.id })
+          .then((gen) => gen.reload())
+          .then((updatedGenInst) => {
+            expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+            api.patch(`/v1/collectorGroups/${cg.name}`)
+            .set('Authorization', token)
+            .send({
+              collectors: [coll1.name, collectorAlive1.name, collectorAlive2.name],
+            })
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              const collectors = res.body.collectors;
+              expect(Array.isArray(collectors)).to.be.true;
+              expect(collectors.length).to.equal(3);
+              const collectorNames = collectors.map((collector) => collector.name);
+              expect(collectorNames).to.have.members(
+                [coll1.name, collectorAlive1.name, collectorAlive2.name]
+              );
+
+              api.get(`/v1/generators/${gen1.name}`)
+              .set('Authorization', token)
+              .expect(httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+                return done();
+              });
+            });
+          }).catch(done);
+        });
+
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to null if currentCollector does not exist in ' +
+        'updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll1.name, coll2.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll1.name, coll2.name]
+            );
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
         }).catch(done);
       });
 
-    it('already assigned generator, patch collectorGroup should set ' +
-      'currentCollector to null if currentCollector does not exist in ' +
-      'updated collector list', (done) => {
-      generatorInst.update({ collectorId: collectorAlive1.id })
-      .then((gen) => gen.reload())
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
-        api.patch(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          collectors: [collector1.name, collector2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members(
-            [collector1.name, collector2.name]
-          );
-
-          api.get(`/v1/generators/${generatorInst.name}`)
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to another alive collector if currentCollector ' +
+        'does not exist in updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
+          .send({
+            collectors: [coll2.name, collectorAlive2.name],
+          })
           .expect(httpStatus.OK)
           .end((err, res) => {
             if (err) {
               return done(err);
             }
 
-            expect(res.body.currentCollector).to.not.exist;
-            return done();
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll2.name, collectorAlive2.name]
+            );
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
+              return done();
+            });
           });
-        });
-      }).catch(done);
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch collectors to empty list' +
+        'should set currentCollector to null', (done) => {
+        cg2.setCollectors([coll2, collectorAlive2])
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
     });
 
-    it('already assigned generator, patch collectorGroup should set ' +
-      'currentCollector to another alive collector if currentCollector ' +
-      'does not exist in updated collector list', (done) => {
-      generatorInst.update({ collectorId: collectorAlive1.id })
-      .then((gen) => gen.reload())
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
-        api.patch(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          collectors: [collector2.name, collectorAlive2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+    describe('update generators >', () => {
+      beforeEach(() => Promise.join(
+        cg.setCollectors([coll1, collectorAlive1, collectorAlive2]),
+        cg2.setCollectors([coll2, coll3]),
+      ));
 
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members(
-            [collector2.name, collectorAlive2.name]
-          );
-
-          api.get(`/v1/generators/${generatorInst.name}`)
+      it('unassigned generator, patch collector group with generators should ' +
+        'set currentCollector if alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.patch(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
+          .send({
+            generators: [gen1.name],
+          })
           .expect(httpStatus.OK)
           .end((err, res) => {
             if (err) {
               return done(err);
             }
 
-            expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
-            return done();
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+              return done();
+            });
           });
         });
-      }).catch(done);
+      });
+
+      it('unassigned generator, patch collector group with generators should ' +
+        'not set currentCollector if no alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.patch(`/v1/collectorGroups/${cg2.name}`)
+          .set('Authorization', token)
+          .send({
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        });
+      });
+
+      it('already assigned generator, patch collectorGroup should not change ' +
+        'currentCollector if currentCollector exists in updated collector list',
+        (done) => {
+          cg.setGenerators([gen1])
+          .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+          .then((gen) => gen.reload())
+          .then((updatedGenInst) => {
+            expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+            api.patch(`/v1/collectorGroups/${cg.name}`)
+            .set('Authorization', token)
+            .send({
+              generators: [gen1.name],
+            })
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              const generators = res.body.generators;
+              expect(Array.isArray(generators)).to.be.true;
+              expect(generators.length).to.equal(1);
+              const generatorNames = generators.map((generator) => generator.name);
+              expect(generatorNames).to.have.members([gen1.name]);
+
+              api.get(`/v1/generators/${gen1.name}`)
+              .set('Authorization', token)
+              .expect(httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+                return done();
+              });
+            });
+          }).catch(done);
+        });
+
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to null if currentCollector does not exist in ' +
+        'updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg2.name}`)
+          .set('Authorization', token)
+          .send({
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to another alive collector if currentCollector ' +
+        'does not exist in updated collector list', (done) => {
+        cg2.setCollectors([coll2, collectorAlive2])
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg2.name}`)
+          .set('Authorization', token)
+          .send({
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch generators to empty list ' +
+        'should set currentCollector to null', (done) => {
+        cg.setGenerators([gen1])
+        .then(() => cg.setCollectors([coll2, collectorAlive2]))
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            generators: [],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+    });
+
+    describe('update both >', () => {
+      beforeEach(() => Promise.join(
+        cg.setGenerators([gen1, gen2]),
+        cg.setCollectors([coll1, collectorAlive1, collectorAlive2]),
+      ));
+
+      it('unassigned generator, patch collector group should ' +
+        'set currentCollector if alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll1.name, collectorAlive1.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members([coll1.name, collectorAlive1.name]);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+              return done();
+            });
+          });
+        });
+      });
+
+      it('unassigned generator, patch collector group should ' +
+        'not set currentCollector if no alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll1.name, coll2.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members([coll1.name, coll2.name]);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        });
+      });
+
+      it('already assigned generator, patch collectorGroup should not change ' +
+        'currentCollector if currentCollector exists in updated collector list',
+        (done) => {
+          gen1.update({ collectorId: collectorAlive1.id })
+          .then((gen) => gen.reload())
+          .then((updatedGenInst) => {
+            expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+            api.patch(`/v1/collectorGroups/${cg.name}`)
+            .set('Authorization', token)
+            .send({
+              collectors: [coll1.name, collectorAlive1.name, collectorAlive2.name],
+              generators: [gen1.name],
+            })
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              const collectors = res.body.collectors;
+              expect(Array.isArray(collectors)).to.be.true;
+              expect(collectors.length).to.equal(3);
+              const collectorNames = collectors.map((collector) => collector.name);
+              expect(collectorNames).to.have.members(
+                [coll1.name, collectorAlive1.name, collectorAlive2.name]
+              );
+
+              const generators = res.body.generators;
+              expect(Array.isArray(generators)).to.be.true;
+              expect(generators.length).to.equal(1);
+              const generatorNames = generators.map((generator) => generator.name);
+              expect(generatorNames).to.have.members([gen1.name]);
+
+              api.get(`/v1/generators/${gen1.name}`)
+              .set('Authorization', token)
+              .expect(httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+                return done();
+              });
+            });
+          }).catch(done);
+        });
+
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to null if currentCollector does not exist in ' +
+        'updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll1.name, coll2.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll1.name, coll2.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch collectorGroup should set ' +
+        'currentCollector to another alive collector if currentCollector ' +
+        'does not exist in updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [coll2.name, collectorAlive2.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll2.name, collectorAlive2.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch collectors to empty list ' +
+        'should set currentCollector to null', (done) => {
+        cg.setCollectors([coll2, collectorAlive2])
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(0);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch generators to empty list ' +
+        'should set currentCollector to null', (done) => {
+        cg.setCollectors([coll2, collectorAlive2])
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [collectorAlive1.name],
+            generators: [],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(1);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [collectorAlive1.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
+
+      it('already assigned generator, patch collectors and generators to empty list' +
+        'should set currentCollector to null', (done) => {
+        cg.setCollectors([coll2, collectorAlive2])
+        .then(() => gen1.update({ collectorId: collectorAlive1.id }))
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.patch(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            collectors: [],
+            generators: [],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(0);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
     });
   });
 });

--- a/tests/api/v1/collectorGroups/put.js
+++ b/tests/api/v1/collectorGroups/put.js
@@ -11,6 +11,7 @@
  */
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
+const Promise = require('bluebird');
 const api = supertest(require('../../../../express').app);
 const httpStatus = require('../../../../api/v1/constants').httpStatus;
 const tu = require('../../../testUtils');
@@ -28,11 +29,21 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
   let user;
   let token;
   let token2;
-  let collector1;
-  let collector2;
-  let collector3;
+  let coll1;
+  let coll2;
+  let coll3;
   let cg = { name: '' };
   let cg2;
+
+  let gen1;
+  let gen2;
+  let g1 = gu.getBasic({ name: 'gen1' });
+  let g2 = gu.getBasic({ name: 'gen2' });
+  const generatorTemplate = gtu.getGeneratorTemplate();
+  gu.createSGtoSGTMapping(generatorTemplate, g1);
+  gu.createSGtoSGTMapping(generatorTemplate, g2);
+  g1.isActive = true;
+  g2.isActive = true;
 
   before((done) => {
     tu.createUserAndToken()
@@ -48,15 +59,37 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
   });
 
   beforeEach(() => {
-    collector1 = u.getCollectorToCreate();
+    const collector1 = u.getCollectorToCreate();
     collector1.name += '1';
-    Collector.create(collector1);
-    collector2 = u.getCollectorToCreate();
+    const collector2 = u.getCollectorToCreate();
     collector2.name += '2';
-    Collector.create(collector2);
-    collector3 = u.getCollectorToCreate();
+    const collector3 = u.getCollectorToCreate();
     collector3.name += '3';
-    Collector.create(collector3);
+    return Promise.join(
+      Collector.create(collector1),
+      Collector.create(collector2),
+      Collector.create(collector3),
+    )
+    .then(([c1, c2, c3]) => {
+      coll1 = c1;
+      coll2 = c2;
+      coll3 = c3;
+    })
+    .then(() => GeneratorTemplate.create(generatorTemplate))
+    .then(() => Promise.join(
+      Generator.create(g1, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+      Generator.create(g2, {
+        validate: false,
+        include: Generator.options.defaultScope.include,
+      }),
+    ))
+    .then(([g1, g2]) => {
+      gen1 = g1;
+      gen2 = g2;
+    });
   });
 
   beforeEach((done) => {
@@ -71,14 +104,14 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
         name: `${tu.namePrefix}cg2`,
         description: 'desc2',
         createdBy: user.id,
-        collectors: [collector3.name],
+        collectors: [coll3.name],
       });
     })
     .then((created) => {
       cg2 = created;
       done();
     })
-      .catch(done);
+    .catch(done);
   });
 
   afterEach(u.forceDelete);
@@ -107,7 +140,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
       .send({
         name: cg.name,
         description: 'hi',
-        collectors: [collector1.name, collector2.name],
+        collectors: [coll1.name, coll2.name],
       })
       .expect(httpStatus.OK)
       .end((err, res) => {
@@ -127,7 +160,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
       .set('Authorization', token)
       .send({
         description: 'hi',
-        collectors: [collector1.name, collector2.name],
+        collectors: [coll1.name, coll2.name],
       })
       .expect(httpStatus.BAD_REQUEST)
       .end((err, res) => {
@@ -147,7 +180,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
   it('put replaces collectors', (done) => {
     api.put(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token)
-      .send({ name: cg.name, collectors: [collector1.name] })
+      .send({ name: cg.name, collectors: [coll1.name] })
       .expect(httpStatus.OK)
       .end((err) => {
         if (err) {
@@ -158,7 +191,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
           .set('Authorization', token)
           .send({
             name: cg.name,
-            collectors: [collector2.name],
+            collectors: [coll2.name],
           })
           .expect(httpStatus.OK)
           .end((_err, _res) => {
@@ -168,7 +201,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
 
             expect(_res.body.collectors).to.have.lengthOf(1);
             expect(_res.body.collectors[0])
-              .to.have.property('name', collector2.name);
+              .to.have.property('name', coll2.name);
             expect(_res.body).to.have.property('description', '');
             return done();
           });
@@ -178,7 +211,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
   it('reject if collector already in a different collector group', (done) => {
     api.put(`/v1/collectorGroups/${cg.name}`)
       .set('Authorization', token)
-      .send({ name: cg.name, collectors: [collector3.name] })
+      .send({ name: cg.name, collectors: [coll3.name] })
       .expect(httpStatus.BAD_REQUEST)
       .end((err, res) => {
         if (err) {
@@ -204,14 +237,103 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
 
       api.put(`/v1/collectorGroups/${cg2.name}`)
       .set('Authorization', token)
-      .send({ name: cg2.name, collectors: [collector3.name] })
+      .send({ name: cg2.name, collectors: [coll3.name] })
       .expect(httpStatus.OK)
       .end((err, res) => {
         if (err) {
           return done(err);
         }
 
-        expect(res.body.collectors[0].name).to.equal(collector3.name);
+        expect(res.body.collectors[0].name).to.equal(coll3.name);
+        done();
+      });
+    });
+  });
+
+  it('put with empty generator list', (done) => {
+    api.put(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({ name: cg.name, description: 'new desc', generators: [] })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body).to.have.property('description', 'new desc');
+      expect(res.body.generators).to.be.empty;
+      return done();
+    });
+  });
+
+  it('put with valid generators', (done) => {
+    api.put(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({ name: cg.name, description: 'hi', generators: [gen1.name, gen2.name] })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body).to.have.property('name', cg.name);
+      expect(res.body).to.have.property('description', 'hi');
+      expect(res.body.generators).to.have.lengthOf(2);
+      return done();
+    });
+  });
+
+  it('put replaces generators', (done) => {
+    api.put(`/v1/collectorGroups/${cg.name}`)
+    .set('Authorization', token)
+    .send({ name: cg.name, generators: [gen1.name] })
+    .expect(httpStatus.OK)
+    .end((err) => {
+      if (err) {
+        return done(err);
+      }
+
+      return api.put(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ name: cg.name, generators: [gen2.name] })
+      .expect(httpStatus.OK)
+      .end((_err, _res) => {
+        if (_err) {
+          return done(_err);
+        }
+
+        expect(_res.body).to.have.property('name', cg.name);
+        expect(_res.body.generators).to.have.lengthOf(1);
+        expect(_res.body.generators[0])
+        .to.have.property('name', gen2.name);
+        return done();
+      });
+    });
+  });
+
+  it('reject if generator already in a different collector group', (done) => {
+    api.put(`/v1/collectorGroups/${cg2.name}`)
+    .set('Authorization', token)
+    .send({ name: cg2.name, generators: [gen1.name] })
+    .expect(httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      api.put(`/v1/collectorGroups/${cg.name}`)
+      .set('Authorization', token)
+      .send({ name: cg.name, generators: [gen1.name] })
+      .expect(httpStatus.BAD_REQUEST)
+      .end((err, res) => {
+        if (err) {
+          return done(err);
+        }
+
+        expect(res.body.errors).to.have.lengthOf(1);
+        expect(res.body.errors[0]).to.have.property('message',
+          'Cannot double-assign generator(s) [gen1] to collector groups');
+        expect(res.body.errors[0]).to.have.property('type', 'ValidationError');
         done();
       });
     });
@@ -223,7 +345,7 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
       .send({
         name: cg.name,
         description: 'foo',
-        collectors: [collector1.name],
+        collectors: [coll1.name],
       })
       .expect(httpStatus.FORBIDDEN)
       .end((err, res) => {
@@ -256,11 +378,6 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
 
     let collectorAlive1;
     let collectorAlive2;
-    let generatorInst;
-    const generator = gu.getGenerator();
-    const generatorTemplate = gtu.getGeneratorTemplate();
-    gu.createSGtoSGTMapping(generatorTemplate, generator);
-    generator.isActive = true;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers(now);
@@ -271,13 +388,6 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
       .then((collectors) => {
         collectorAlive1 = collectors[0];
         collectorAlive2 = collectors[1];
-        return GeneratorTemplate.create(generatorTemplate);
-      })
-      .then(() => Generator.create(generator,
-        { validate: false, include: Generator.options.defaultScope.include }))
-      .then((gen) => {
-        generatorInst = gen;
-        return generatorInst.setCollectorGroup(cg);
       })
       .then(() => done())
       .catch(done);
@@ -285,94 +395,23 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
 
     afterEach(() => clock.restore());
 
-    it('unassigned generator, put collector group with collectors should ' +
-      'set currentCollector if alive collector is available', (done) => {
-      generatorInst.reload()
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector).to.not.exist;
-        api.put(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          name: cg.name,
-          collectors: [collector1.name, collectorAlive1.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
+    describe('update collectors and generators >', () => {
+      beforeEach(() => Promise.join(
+        cg.setGenerators([gen1, gen2]),
+        cg.setCollectors([coll1, collectorAlive1, collectorAlive2]),
+      ));
 
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members([collector1.name, collectorAlive1.name]);
-
-          api.get(`/v1/generators/${generatorInst.name}`)
-          .set('Authorization', token)
-          .expect(httpStatus.OK)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
-            return done();
-          });
-        });
-      });
-    });
-
-    it('unassigned generator, put collector group with collectors should ' +
-      'not set currentCollector if no alive collector is available', (done) => {
-      generatorInst.reload()
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector).to.not.exist;
-        api.put(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          name: cg.name,
-          collectors: [collector1.name, collector2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members([collector1.name, collector2.name]);
-
-          api.get(`/v1/generators/${generatorInst.name}`)
-          .set('Authorization', token)
-          .expect(httpStatus.OK)
-          .end((err, res) => {
-            if (err) {
-              return done(err);
-            }
-
-            expect(res.body.currentCollector).to.not.exist;
-            return done();
-          });
-        });
-      });
-    });
-
-    it('already assigned generator, put collectorGroup should not change ' +
-      'currentCollector if currentCollector exists in updated collector list',
-      (done) => {
-        generatorInst.update({ collectorId: collectorAlive1.id })
-        .then((gen) => gen.reload())
+      it('unassigned generator, put collector group should ' +
+        'set currentCollector if alive collector is available', (done) => {
+        gen1.reload()
         .then((updatedGenInst) => {
-          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          expect(updatedGenInst.currentCollector).to.not.exist;
           api.put(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
           .send({
             name: cg.name,
-            collectors: [collector1.name, collectorAlive1.name, collectorAlive2.name],
+            collectors: [coll1.name, collectorAlive1.name],
+            generators: [gen1.name],
           })
           .expect(httpStatus.OK)
           .end((err, res) => {
@@ -382,13 +421,17 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
 
             const collectors = res.body.collectors;
             expect(Array.isArray(collectors)).to.be.true;
-            expect(collectors.length).to.equal(3);
+            expect(collectors.length).to.equal(2);
             const collectorNames = collectors.map((collector) => collector.name);
-            expect(collectorNames).to.have.members(
-              [collector1.name, collectorAlive1.name, collectorAlive2.name]
-            );
+            expect(collectorNames).to.have.members([coll1.name, collectorAlive1.name]);
 
-            api.get(`/v1/generators/${generatorInst.name}`)
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
             .set('Authorization', token)
             .expect(httpStatus.OK)
             .end((err, res) => {
@@ -400,127 +443,328 @@ describe('tests/api/v1/collectorGroups/put.js >', () => {
               return done();
             });
           });
+        });
+      });
+
+      it('unassigned generator, put collector group should ' +
+        'not set currentCollector if no alive collector is available', (done) => {
+        gen1.reload()
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector).to.not.exist;
+          api.put(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            name: cg.name,
+            collectors: [coll1.name, coll2.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members([coll1.name, coll2.name]);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        });
+      });
+
+      it('already assigned generator, put collectorGroup should not change ' +
+        'currentCollector if currentCollector exists in updated collector list',
+        (done) => {
+          gen1.update({ collectorId: collectorAlive1.id })
+          .then((gen) => gen.reload())
+          .then((updatedGenInst) => {
+            expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+            api.put(`/v1/collectorGroups/${cg.name}`)
+            .set('Authorization', token)
+            .send({
+              name: cg.name,
+              collectors: [coll1.name, collectorAlive1.name, collectorAlive2.name],
+              generators: [gen1.name],
+            })
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              const collectors = res.body.collectors;
+              expect(Array.isArray(collectors)).to.be.true;
+              expect(collectors.length).to.equal(3);
+              const collectorNames = collectors.map((collector) => collector.name);
+              expect(collectorNames).to.have.members(
+                [coll1.name, collectorAlive1.name, collectorAlive2.name]
+              );
+
+              const generators = res.body.generators;
+              expect(Array.isArray(generators)).to.be.true;
+              expect(generators.length).to.equal(1);
+              const generatorNames = generators.map((generator) => generator.name);
+              expect(generatorNames).to.have.members([gen1.name]);
+
+              api.get(`/v1/generators/${gen1.name}`)
+              .set('Authorization', token)
+              .expect(httpStatus.OK)
+              .end((err, res) => {
+                if (err) {
+                  return done(err);
+                }
+
+                expect(res.body.currentCollector.name).to.equal(collectorAlive1.name);
+                return done();
+              });
+            });
+          }).catch(done);
+        });
+
+      it('already assigned generator, put collectorGroup should set ' +
+        'currentCollector to null if currentCollector does not exist in ' +
+        'updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.put(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            name: cg.name,
+            collectors: [coll1.name, coll2.name],
+            generators: [gen1.name],
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll1.name, coll2.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
         }).catch(done);
       });
 
-    it('already assigned generator, put collectorGroup should set ' +
-      'currentCollector to null if currentCollector does not exist in ' +
-      'updated collector list', (done) => {
-      generatorInst.update({ collectorId: collectorAlive1.id })
-      .then((gen) => gen.reload())
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
-        api.put(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          name: cg.name,
-          collectors: [collector1.name, collector2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members(
-            [collector1.name, collector2.name]
-          );
-
-          api.get(`/v1/generators/${generatorInst.name}`)
+      it('already assigned generator, put collectorGroup should set ' +
+        'currentCollector to another alive collector if currentCollector ' +
+        'does not exist in updated collector list', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.put(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
+          .send({
+            name: cg.name,
+            collectors: [coll2.name, collectorAlive2.name],
+            generators: [gen1.name],
+          })
           .expect(httpStatus.OK)
           .end((err, res) => {
             if (err) {
               return done(err);
             }
 
-            expect(res.body.currentCollector).to.not.exist;
-            return done();
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(2);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [coll2.name, collectorAlive2.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
+              return done();
+            });
           });
-        });
-      }).catch(done);
-    });
+        }).catch(done);
+      });
 
-    it('already assigned generator, put collectorGroup should set ' +
-      'currentCollector to null if no collectors specified', (done) => {
-      generatorInst.update({ collectorId: collectorAlive1.id })
-      .then((gen) => gen.reload())
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
-        api.put(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          name: cg.name,
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(0);
-
-          api.get(`/v1/generators/${generatorInst.name}`)
+      it('already assigned generator, put collectors to empty ' +
+        'should set currentCollector to null', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.put(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
+          .send({
+            name: cg.name,
+            generators: [gen1.name],
+          })
           .expect(httpStatus.OK)
           .end((err, res) => {
             if (err) {
               return done(err);
             }
 
-            expect(res.body.currentCollector).to.not.exist;
-            return done();
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(0);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(1);
+            const generatorNames = generators.map((generator) => generator.name);
+            expect(generatorNames).to.have.members([gen1.name]);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
           });
-        });
-      }).catch(done);
-    });
+        }).catch(done);
+      });
 
-    it('already assigned generator, put collectorGroup should set ' +
-      'currentCollector to another alive collector if currentCollector ' +
-      'does not exist in updated collector list', (done) => {
-      generatorInst.update({ collectorId: collectorAlive1.id })
-      .then((gen) => gen.reload(gen._modelOptions.defaultScope))
-      .then((updatedGenInst) => {
-        expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
-        api.put(`/v1/collectorGroups/${cg.name}`)
-        .set('Authorization', token)
-        .send({
-          name: cg.name,
-          collectors: [collector2.name, collectorAlive2.name],
-        })
-        .expect(httpStatus.OK)
-        .end((err, res) => {
-          if (err) {
-            return done(err);
-          }
-
-          const collectors = res.body.collectors;
-          expect(Array.isArray(collectors)).to.be.true;
-          expect(collectors.length).to.equal(2);
-          const collectorNames = collectors.map((collector) => collector.name);
-          expect(collectorNames).to.have.members(
-            [collector2.name, collectorAlive2.name]
-          );
-
-          api.get(`/v1/generators/${generatorInst.name}`)
+      it('already assigned generator, put generators to empty ' +
+        'should set currentCollector to null', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.put(`/v1/collectorGroups/${cg.name}`)
           .set('Authorization', token)
+          .send({
+            name: cg.name,
+            collectors: [collectorAlive1.name],
+          })
           .expect(httpStatus.OK)
           .end((err, res) => {
             if (err) {
               return done(err);
             }
 
-            expect(res.body.currentCollector.name).to.equal(collectorAlive2.name);
-            return done();
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(1);
+            const collectorNames = collectors.map((collector) => collector.name);
+            expect(collectorNames).to.have.members(
+              [collectorAlive1.name]
+            );
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
           });
-        });
-      }).catch(done);
+        }).catch(done);
+      });
+
+      it('already assigned generator, put collectors and generators to empty ' +
+        'should set currentCollector to null', (done) => {
+        gen1.update({ collectorId: collectorAlive1.id })
+        .then((gen) => gen.reload())
+        .then((updatedGenInst) => {
+          expect(updatedGenInst.currentCollector.name).to.be.equal(collectorAlive1.name);
+          api.put(`/v1/collectorGroups/${cg.name}`)
+          .set('Authorization', token)
+          .send({
+            name: cg.name,
+          })
+          .expect(httpStatus.OK)
+          .end((err, res) => {
+            if (err) {
+              return done(err);
+            }
+
+            const collectors = res.body.collectors;
+            expect(Array.isArray(collectors)).to.be.true;
+            expect(collectors.length).to.equal(0);
+
+            const generators = res.body.generators;
+            expect(Array.isArray(generators)).to.be.true;
+            expect(generators.length).to.equal(0);
+
+            api.get(`/v1/generators/${gen1.name}`)
+            .set('Authorization', token)
+            .expect(httpStatus.OK)
+            .end((err, res) => {
+              if (err) {
+                return done(err);
+              }
+
+              expect(res.body.currentCollector).to.not.exist;
+              return done();
+            });
+          });
+        }).catch(done);
+      });
     });
   });
 });

--- a/tests/api/v1/collectors/patch.js
+++ b/tests/api/v1/collectors/patch.js
@@ -76,6 +76,10 @@ describe('tests/api/v1/collectors/patch.js >', () => {
     .catch(done);
   });
 
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
+  });
+
   beforeEach((done) => {
     Promise.all([
       Collector.create(collector1),
@@ -108,10 +112,6 @@ describe('tests/api/v1/collectors/patch.js >', () => {
         .then((g) => g.setCurrentCollector(null)),
     ]))
   );
-
-  beforeEach(() => {
-    clock = sinon.useFakeTimers(now);
-  });
 
   afterEach(() => clock.restore());
 

--- a/tests/api/v1/collectors/patch.js
+++ b/tests/api/v1/collectors/patch.js
@@ -11,12 +11,18 @@
  */
 'use strict'; // eslint-disable-line strict
 const supertest = require('supertest');
+const sinon = require('sinon');
 const api = supertest(require('../../../../express').app);
 const constants = require('../../../../api/v1/constants');
 const tu = require('../../../testUtils');
 const u = require('./utils');
+const gu = require('../generators/utils');
+const gtu = require('../generatorTemplates/utils');
 const path = '/v1/collectors';
 const Collector = tu.db.Collector;
+const CollectorGroup = tu.db.CollectorGroup;
+const Generator = tu.db.Generator;
+const GeneratorTemplate = tu.db.GeneratorTemplate;
 const expect = require('chai').expect;
 const jwtUtil = require('../../../../utils/jwtUtil');
 
@@ -24,6 +30,42 @@ describe('tests/api/v1/collectors/patch.js >', () => {
   let i = 0;
   let token;
   let collectorToken;
+  let clock;
+  const now = Date.now();
+
+  let collector1 = u.getCollectorToCreate();
+  let collector2 = u.getCollectorToCreate();
+  let collector3 = u.getCollectorToCreate();
+  collector1.name += 1;
+  collector2.name += 2;
+  collector3.name += 3;
+  collector1.status = 'Running';
+  collector2.status = 'Running';
+  collector3.status = 'Running';
+  collector1.lastHeartbeat = now;
+  collector2.lastHeartbeat = now;
+  collector3.lastHeartbeat = now;
+
+  let collectorGroup1 = { name: `${tu.namePrefix}-cg1`, description: 'test' };
+  let collectorGroup2 = { name: `${tu.namePrefix}-cg2`, description: 'test' };
+  let collectorGroup3 = { name: `${tu.namePrefix}-cg3`, description: 'test' };
+  collectorGroup1.collectors = [collector1.name];
+  collectorGroup2.collectors = [collector2.name];
+  collectorGroup3.collectors = [collector3.name];
+
+  const gen1 = gu.getBasic({ name: 'gen1' });
+  const gen2 = gu.getBasic({ name: 'gen2' });
+  const gen3 = gu.getBasic({ name: 'gen3' });
+  const generatorTemplate = gtu.getGeneratorTemplate();
+  gu.createSGtoSGTMapping(generatorTemplate, gen1);
+  gu.createSGtoSGTMapping(generatorTemplate, gen2);
+  gu.createSGtoSGTMapping(generatorTemplate, gen3);
+  gen1.isActive = true;
+  gen2.isActive = true;
+  gen3.isActive = true;
+  gen1.collectorGroup = collectorGroup1.name;
+  gen2.collectorGroup = collectorGroup2.name;
+  gen3.collectorGroup = collectorGroup3.name;
 
   before((done) => {
     tu.createToken()
@@ -35,21 +77,49 @@ describe('tests/api/v1/collectors/patch.js >', () => {
   });
 
   beforeEach((done) => {
-    Collector.create(u.getCollectorToCreate())
-    .then((c) => {
-      collectorToken = jwtUtil.createToken(c.name, tu.userName,
+    Promise.all([
+      Collector.create(collector1),
+      Collector.create(collector2),
+      Collector.create(collector3),
+    ])
+    .then(([c1]) => {
+      collectorToken = jwtUtil.createToken(c1.name, tu.userName,
         { IsCollector: true });
-      i = c.id;
+      i = c1.id;
       done();
     })
     .catch(done);
   });
 
+  beforeEach(() =>
+    Promise.all([
+      CollectorGroup.createCollectorGroup(collectorGroup1),
+      CollectorGroup.createCollectorGroup(collectorGroup2),
+      CollectorGroup.createCollectorGroup(collectorGroup3),
+    ])
+  );
+
+  beforeEach(() =>
+    GeneratorTemplate.create(generatorTemplate)
+    .then(() => Promise.all([
+      Generator.createWithCollectors(gen1),
+      Generator.createWithCollectors(gen2),
+      Generator.createWithCollectors(gen3)
+        .then((g) => g.setCurrentCollector(null)),
+    ]))
+  );
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
+  });
+
+  afterEach(() => clock.restore());
+
   afterEach(u.forceDelete);
   after(tu.forceDeleteUser);
 
   it('update description', (done) => {
-    api.patch(`${path}/${i}`)
+    api.patch(`${path}/${collector1.name}`)
     .set('Authorization', token)
     .send({ description: 'abcdefg' })
     .expect(constants.httpStatus.OK)
@@ -73,7 +143,7 @@ describe('tests/api/v1/collectors/patch.js >', () => {
 
   it('error, update version, user token provided instead of collector token',
   (done) => {
-    api.patch(`${path}/${i}`)
+    api.patch(`${path}/${collector1.name}`)
     .set('Authorization', token)
     .send({ version: '1.1.1' })
     .expect(constants.httpStatus.FORBIDDEN)
@@ -86,7 +156,7 @@ describe('tests/api/v1/collectors/patch.js >', () => {
   });
 
   it('ok, update version, collector token provided', (done) => {
-    api.patch(`${path}/${i}`)
+    api.patch(`${path}/${collector1.name}`)
     .set('Authorization', collectorToken)
     .send({ version: '1.1.1' })
     .expect(constants.httpStatus.OK)
@@ -101,6 +171,137 @@ describe('tests/api/v1/collectors/patch.js >', () => {
     .expect(constants.httpStatus.NOT_FOUND)
     .end((err /* , res */) => {
       done();
+    });
+  });
+
+  it('ok: empty patch doesnt replace collector group', (done) => {
+    api.patch(`${path}/${collector1.name}`)
+    .set('Authorization', token)
+    .send({ description: '...' })
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      const { collectorGroup } = res.body;
+      expect(collectorGroup.name).to.equal(collectorGroup1.name);
+      done();
+    });
+  });
+
+  it('ok: PATCH collectorGroup', (done) => {
+    api.patch(`${path}/${collector1.name}`)
+    .set('Authorization', token)
+    .send({ collectorGroup: collectorGroup2.name })
+    .expect(constants.httpStatus.OK)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      const { collectorGroup } = res.body;
+      expect(collectorGroup.name).to.equal(collectorGroup2.name);
+      done();
+    });
+  });
+
+  it('error: nonexistent collector group', (done) => {
+    api.patch(`${path}/${collector1.name}`)
+    .set('Authorization', token)
+    .send({ collectorGroup: 'aaa' })
+    .expect(constants.httpStatus.NOT_FOUND)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+
+      expect(res.body.errors[0].message).to.equal('CollectorGroup "aaa" not found.');
+      done();
+    });
+  });
+
+  describe('generator assignment', () => {
+    it('cg1 -> cg2: unassigns gens in old group', (done) => {
+      Promise.all([
+        Generator.findOne({ where: { name: gen1.name } }),
+        Generator.findOne({ where: { name: gen2.name } }),
+        Generator.findOne({ where: { name: gen3.name } }),
+      ])
+      .then(([gen1, gen2, gen3]) => {
+        expect(gen1.currentCollector.name).to.equal(collector1.name);
+        expect(gen2.currentCollector.name).to.equal(collector2.name);
+        expect(gen3.currentCollector).to.not.exist;
+      })
+      .then(() => Promise.all([
+        CollectorGroup.findOne({ where: { name: collectorGroup1.name } }),
+      ]))
+      .then(() => {
+        api.patch(`${path}/${collector1.name}`)
+        .set('Authorization', token)
+        .send({ collectorGroup: collectorGroup2.name })
+        .expect(constants.httpStatus.OK)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          Promise.all([
+            Generator.findOne({ where: { name: gen1.name } }),
+            Generator.findOne({ where: { name: gen2.name } }),
+            Generator.findOne({ where: { name: gen3.name } }),
+          ])
+          .then(([gen1, gen2, gen3]) => {
+            expect(gen1.currentCollector).to.not.exist;
+            expect(gen2.currentCollector.name).to.equal(collector2.name);
+            expect(gen3.currentCollector).to.not.exist;
+          })
+          .then(() => done())
+          .catch(done);
+        });
+      })
+      .catch(done);
+    });
+
+    it('cg1 -> cg3: reassigns gens in old and new group', (done) => {
+      Promise.all([
+        Generator.findOne({ where: { name: gen1.name } }),
+        Generator.findOne({ where: { name: gen2.name } }),
+        Generator.findOne({ where: { name: gen3.name } }),
+      ])
+      .then(([gen1, gen2, gen3]) => {
+        expect(gen1.currentCollector.name).to.equal(collector1.name);
+        expect(gen2.currentCollector.name).to.equal(collector2.name);
+        expect(gen3.currentCollector).to.not.exist;
+      })
+      .then(() => Promise.all([
+        CollectorGroup.findOne({ where: { name: collectorGroup1.name } }),
+      ]))
+      .then(() => {
+        api.patch(`${path}/${collector1.name}`)
+        .set('Authorization', token)
+        .send({ collectorGroup: collectorGroup3.name })
+        .expect(constants.httpStatus.OK)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+
+          Promise.all([
+            Generator.findOne({ where: { name: gen1.name } }),
+            Generator.findOne({ where: { name: gen2.name } }),
+            Generator.findOne({ where: { name: gen3.name } }),
+          ])
+          .then(([gen1, gen2, gen3]) => {
+            expect(gen1.currentCollector).to.not.exist;
+            expect(gen2.currentCollector.name).to.equal(collector2.name);
+            expect(gen3.currentCollector.name).to.equal(collector1.name);
+          })
+          .then(() => done())
+          .catch(done);
+        });
+      })
+      .catch(done);
     });
   });
 });


### PR DESCRIPTION
previously, the associations could only be set from these endpoints:
- generator -> collectorGroup (Generator post/patch/put)
- collectorGroup -> collectors (CollectorGroup post/patch/put)


this PR adds the ability to set it up this way as well:
- collector -> collectorGroup (Collector patch)
- collectorGroup -> generators (CollectorGroup post/patch/put)