### PR TITLE
Get samples: Correct sscan param passed

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -739,7 +739,7 @@ function sscanAndFilterSampleKeys(cursor, filteredSamples, opts) {
         return Array.from(filteredSamples);
       }
 
-      return sscanAndFilterSampleKeys(newCursor, filteredSamples);
+      return sscanAndFilterSampleKeys(newCursor, filteredSamples, opts);
     });
 }
 


### PR DESCRIPTION
Missed the param when calling function recursively.

Found out when testing manually for /samples?status=Critical with prod data.

Hard to surface this in tests because sscan is called recursively when the number of samples are large enough (number of samples in one iteration is random when using sscan)