### PR TITLE
Resolve sample filtered get problem

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -1377,13 +1377,15 @@ module.exports = {
       .then((filteredKeys) => {
         let keys = filteredKeys;
 
-        if (!hasOrder || opts.order === ['name']) {
-          filteredKeys.sort();
-          keys = modelUtils.applyLimitAndOffset(opts, filteredKeys);
-        } else if (opts.order === ['-name']) {
-          filteredKeys.sort();
-          filteredKeys.reverse();
-          keys = modelUtils.applyLimitAndOffset(opts, filteredKeys);
+        if (hasNameFilterOnly) {
+          if (!hasOrder || opts.order === ['name']) {
+            filteredKeys.sort();
+            keys = modelUtils.applyLimitAndOffset(opts, filteredKeys);
+          } else if (opts.order === ['-name']) {
+            filteredKeys.sort();
+            filteredKeys.reverse();
+            keys = modelUtils.applyLimitAndOffset(opts, filteredKeys);
+          }
         }
 
         return getSamplesAndAspects(keys);

--- a/cache/models/utils.js
+++ b/cache/models/utils.js
@@ -87,12 +87,19 @@ function applyFiltersOnSampleObjs(sampleArray, opts) {
     });
   }
 
-  const sortByName = opts.order &&
+  const hasNameFilterOnly = Object.keys(opts.filter).length === 1 &&
+    opts.filter.name;
+  const sortByNameOnly = opts.order &&
     (opts.order === ['name'] || opts.order === ['-name']);
 
   // If sorting was not applied on keys, sort and apply limit/offset
-  if (opts.order && !sortByName) {
-    filtered = sortByOrder(filtered, opts.order);
+  if (!hasNameFilterOnly || !sortByNameOnly) {
+    if (opts.order) {
+      filtered = sortByOrder(filtered, opts.order);
+    } else {
+      filtered = sortByOrder(filtered, ['name']);
+    }
+
     filtered = applyLimitAndOffset(opts, filtered);
   }
 

--- a/tests/cache/models/samples/get.js
+++ b/tests/cache/models/samples/get.js
@@ -499,6 +499,21 @@ describe('tests/cache/models/samples/get.js, ' +
           .end(done);
       });
 
+      it('filter by status and limit', (done) => {
+        api.get(path + '?status=Invalid&limit=2')
+          .set('Authorization', token)
+          .expect(constants.httpStatus.OK)
+          .expect((res) => {
+            expect(res.body.length).to.equal(2);
+            expect(res.body[0].name).to.equal(s1s3a1);
+            expect(res.body[1].name).to.equal(s1s3a2);
+            res.body.forEach((obj) => {
+              expect(obj.status).to.equal('Invalid');
+            });
+          })
+          .end(done);
+      });
+
       it('filter by value, sort by status', (done) => {
         api.get(path + '?value=5&sort=-name')
           .set('Authorization', token)


### PR DESCRIPTION
Missed a check that we should apply name sort and limit on keys only when the samples need to be filtered by name only.
added a test as well

To be honest, I would not be surprised if we find out that the endpoint is not working correctly for some other specific combination because the tests are not comprehensive and it is fairly complex logic with lots of conditions (to make it more optimized). I am going to create a story to write comprehensive tests for this endpoint.