### PR TITLE
Bull: resolve redis connection url

### DIFF
--- a/jobQueue/setup.js
+++ b/jobQueue/setup.js
@@ -26,14 +26,17 @@ const redisOptions = {
   redis: conf.redis.instanceUrl.queue,
 };
 
+let redisUrlForBull = redisOptions.redis;
+
 const redisInfo = urlParser.parse(redisOptions.redis, true);
 if (redisInfo.protocol !== PROTOCOL_PREFIX) {
   redisOptions.redis = 'redis:' + redisOptions.redis;
+  redisUrlForBull = 'redis:' + redisUrlForBull;
 }
 
 const jobQueue = kue.createQueue(redisOptions);
 const bulkDelSubQueue = new BullQueue(
-  conf.jobType.bulkDeleteSubjects, redisOptions.redis);
+  conf.jobType.bulkDeleteSubjects, redisUrlForBull);
 
 function resetJobQueue() {
   return Promise.map(jobQueue.workers, (w) =>


### PR DESCRIPTION
When testing in devbox, I was getting Redis econnrefused error when Bull queue was used in heroku. These changes resolves that issue.
