### PR TITLE
Add 'hasMultipartKey' attribute to botAction and botData

### DIFF
--- a/api/v1/helpers/nouns/botActions.js
+++ b/api/v1/helpers/nouns/botActions.js
@@ -25,8 +25,8 @@ module.exports = {
     users: 'writers',
   },
   baseUrl: '/v1/botActions',
+  hasMultipartKey: true,
   model: BotActions,
   modelName: 'botActions',
   timePeriodFilters: ['createdAt', 'updatedAt'],
-  hasMultipartKey: true,
 }; // exports

--- a/api/v1/helpers/nouns/botActions.js
+++ b/api/v1/helpers/nouns/botActions.js
@@ -28,4 +28,5 @@ module.exports = {
   model: BotActions,
   modelName: 'botActions',
   timePeriodFilters: ['createdAt', 'updatedAt'],
+  hasMultipartKey: true,
 }; // exports

--- a/api/v1/helpers/nouns/botData.js
+++ b/api/v1/helpers/nouns/botData.js
@@ -25,8 +25,8 @@ module.exports = {
     users: 'writers',
   },
   baseUrl: '/v1/botData',
+  hasMultipartKey: true,
   model: BotData,
   modelName: 'botData',
   timePeriodFilters: ['createdAt', 'updatedAt'],
-  hasMultipartKey: true,
 }; // exports

--- a/api/v1/helpers/nouns/botData.js
+++ b/api/v1/helpers/nouns/botData.js
@@ -28,4 +28,5 @@ module.exports = {
   model: BotData,
   modelName: 'botData',
   timePeriodFilters: ['createdAt', 'updatedAt'],
+  hasMultipartKey: true,
 }; // exports

--- a/tests/api/v1/botActions/delete.js
+++ b/tests/api/v1/botActions/delete.js
@@ -78,24 +78,10 @@ describe('tests/api/v1/botActions/delete.js >', () => {
     });
   });
 
-  it('Pass, delete botAction by name', (done) => {
-    api.delete(`${path}/${testBotAction.name}`)
-    .set('Authorization', token)
-    .expect(constants.httpStatus.OK)
-    .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
-
-      expect(res.body.name).to.equal(u.name);
-      done(err);
-    });
-  });
-
-  it('Fail, botAction not found', (done) => {
+  it('Fail, botId required', (done) => {
     api.delete(`${path}/INVALID_ID`)
     .set('Authorization', token)
-    .expect(constants.httpStatus.NOT_FOUND)
+    .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
 });

--- a/tests/api/v1/botActions/get.js
+++ b/tests/api/v1/botActions/get.js
@@ -205,10 +205,10 @@ describe('tests/api/v1/botActions/get.js >', () => {
     });
   });
 
-  it('Fail, id not found', (done) => {
+  it('Fail, botId required', (done) => {
     api.get(`${path}/INVALID_ID`)
     .set('Authorization', token)
-    .expect(constants.httpStatus.NOT_FOUND)
+    .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
 });

--- a/tests/api/v1/botData/delete.js
+++ b/tests/api/v1/botData/delete.js
@@ -78,24 +78,10 @@ describe('tests/api/v1/botData/delete.js >', () => {
     });
   });
 
-  it('Pass, delete botData by name', (done) => {
-    api.delete(`${path}/${saveBotData.name}`)
-    .set('Authorization', token)
-    .expect(constants.httpStatus.OK)
-    .end((err, res) => {
-      if (err) {
-        return done(err);
-      }
-
-      expect(res.body.name).to.equal(u.name);
-      done(err);
-    });
-  });
-
-  it('Fail, botData not found', (done) => {
+  it('Fail, invalid id', (done) => {
     api.delete(`${path}/INVALID_ID`)
     .set('Authorization', token)
-    .expect(constants.httpStatus.NOT_FOUND)
+    .expect(constants.httpStatus.BAD_REQUEST)
     .end(done);
   });
 });

--- a/tests/api/v1/common/owner.js
+++ b/tests/api/v1/common/owner.js
@@ -38,7 +38,7 @@ const modelsToTest = {
   subjects: ['post', 'put', 'patch'],
 };
 
-const skipByName = ['events', 'generatorTemplates'];
+const skipByName = ['events', 'generatorTemplates', 'botActions', 'botData'];
 
 let adminToken;
 let mainUser;


### PR DESCRIPTION
Since botAction and botData both have non-unique parameter `name`, we need to add the ```hasMultipartKey``` attribute to the helper files to allow the API to return multiple results when we query them by name. 

### Before: 
![Screenshot 2019-07-31 at 11 36 53](https://user-images.githubusercontent.com/23287645/62205536-8f70c500-b387-11e9-8ed4-9575f6eed257.png)

### After
![Screenshot 2019-07-31 at 11 35 43](https://user-images.githubusercontent.com/23287645/62205539-90a1f200-b387-11e9-9f84-96a6f494213f.png)
 