### PR TITLE
Turning off room deactivation JOB

### DIFF
--- a/clock/scheduledJobs/deactivateRooms.js
+++ b/clock/scheduledJobs/deactivateRooms.js
@@ -11,12 +11,6 @@
  *
  * Gets an array of all rooms which should be deactivated, then deactivates
  * them and does a sync if this is enabled in the room settings.
- *
- * Note:
- * Deactivate room was removed from the job in Refocus because now
- * GUS/ORG62 must be checked before deactivating. This work has been
- * transferred to Case-Bot (even when there is no a case-bot in the room, it
- * still running as a backend service checking rooms to deactivate).
  */
 const moment = require('moment');
 const Op = require('sequelize').Op;

--- a/clock/scheduledJobs/deactivateRooms.js
+++ b/clock/scheduledJobs/deactivateRooms.js
@@ -28,6 +28,7 @@ const conf = require('../../config');
  * @returns {Promise} - Promise that room was deactivated.
  */
 function checkAndDeactivateRoom(room) {
+  console.log('test deactivation');
   // Getting most recent event for this room
   return dbEvent.findOne({
     where: { roomId: room.id },

--- a/clock/scheduledJobs/deactivateRooms.js
+++ b/clock/scheduledJobs/deactivateRooms.js
@@ -11,6 +11,12 @@
  *
  * Gets an array of all rooms which should be deactivated, then deactivates
  * them and does a sync if this is enabled in the room settings.
+ *
+ * Note:
+ * Deactivate room was removed from the job in Refocus because now
+ * GUS/ORG62 must be checked before deactivating. This work has been
+ * transferred to Case-Bot (even when there is no a case-bot in the room, it
+ * still running as a backend service checking rooms to deactivate).
  */
 const moment = require('moment');
 const Op = require('sequelize').Op;

--- a/clock/scheduledJobs/deactivateRooms.js
+++ b/clock/scheduledJobs/deactivateRooms.js
@@ -19,6 +19,7 @@ const dbRoom = require('../../db/index').Room;
 const dbEvent = require('../../db/index').Event;
 const dbBotAction = require('../../db/index').BotAction;
 const conf = require('../../config');
+const logger = require('@salesforce/refocus-logging-client');
 
 /**
  * Deactivates a room if there has not been any recent activity in the room.
@@ -28,7 +29,6 @@ const conf = require('../../config');
  * @returns {Promise} - Promise that room was deactivated.
  */
 function checkAndDeactivateRoom(room) {
-  console.log('test deactivation');
   // Getting most recent event for this room
   return dbEvent.findOne({
     where: { roomId: room.id },
@@ -84,6 +84,7 @@ function checkAndDeactivateRoom(room) {
  * @returns {Promise} - Promise that rooms were deactivated
  */
 function execute() {
+  logger.info('clock/scheduledJobs/deactivateRooms.js:::execute');
   const date = new Date();
   date.setMinutes(date.getMinutes() - conf.minRoomDeactivationAge);
   return dbRoom.findAll(

--- a/clock/setupIntervals.js
+++ b/clock/setupIntervals.js
@@ -12,6 +12,7 @@
 const ft = require('feature-toggles');
 const jobWrapper = require('../jobQueue/jobWrapper');
 const redisClient = require('../cache/redisCache').client.clock;
+const logger = require('@salesforce/refocus-logging-client');
 
 module.exports = function (jobs, config) {
   const startTime = Date.now();
@@ -26,11 +27,14 @@ module.exports = function (jobs, config) {
       useWorker = useWorker && ft.isFeatureEnabled('enableWorkerProcess');
       const jobEnabled = toggle ? ft.isFeatureEnabled(toggle) : true;
 
+      logger.info(`clock/setupIntervals.js (pre) job ${jobName}, interval ${interval} jobEnabled ${jobEnabled} `);
       if (interval && jobEnabled) {
         // wrap job function
         const fn = useWorker ? executeOnWorker(jobName) : job.execute;
 
         const initialRun = runOnceThenSetupInterval(jobName, fn, interval);
+
+        logger.info(`clock/setupIntervals.js (pos) job ${jobName}, interval ${interval} jobEnabled ${jobEnabled} `);
 
         // calculate initial interval
         const lastRunTime = jobTimes[i] || startTime;

--- a/config.js
+++ b/config.js
@@ -140,7 +140,6 @@ const clockJobConfig = {
   intervals: {
     checkMissedCollectorHeartbeat:
       String(collectorConfig.heartbeatIntervalMillis),
-    deactivateRooms: '5m',
     deleteUnusedTokens: '1d',
     jobCleanup: '30m',
     kueStatsActivityLogs: '1m',

--- a/config.js
+++ b/config.js
@@ -140,6 +140,7 @@ const clockJobConfig = {
   intervals: {
     checkMissedCollectorHeartbeat:
       String(collectorConfig.heartbeatIntervalMillis),
+    deactivateRooms: '5m',
     deleteUnusedTokens: '1d',
     jobCleanup: '30m',
     kueStatsActivityLogs: '1m',
@@ -156,6 +157,7 @@ const clockJobConfig = {
   toggles: {
     kueStatsActivityLogs: 'enableKueStatsActivityLogs',
     queueStatsActivityLogs: 'enableQueueStatsActivityLogs',
+    deactivateRooms: 'enableDeactivateRooms',
   },
 };
 

--- a/config/toggles.js
+++ b/config/toggles.js
@@ -86,6 +86,7 @@ const longTermToggles = {
     'collectorAssignment'),
   enableCollectorHeartbeatLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',
     'collectorHeartbeat'),
+  enableDeactivateRooms: environmentVariableTrue(pe, 'ENABLE_DEACTIVATE_ROOMS'),
   enableEnvActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'env'),
   enableJobActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS', 'job'),
   enableJobCleanupActivityLogs: envVarIncludes(pe, 'ENABLE_ACTIVITY_LOGS',

--- a/tests/clock/clock.js
+++ b/tests/clock/clock.js
@@ -32,7 +32,6 @@ describe('tests/clock/clock.js >', function () {
   it('default config', () => {
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInDay('15s'),
-      deactivateRooms: intervalsInDay('5m'),
       jobCleanup: intervalsInDay('30m'),
       resetJobCounter: intervalsInDay('2h'),
       sampleTimeout: intervalsInDay('30s'),
@@ -53,7 +52,6 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('15s'),
-      deactivateRooms: intervalsInHour('5m'),
       deleteUnusedTokens: intervalsInHour('1d'),
       jobCleanup: intervalsInHour('30m'),
       resetJobCounter: intervalsInHour('2h'),
@@ -76,7 +74,6 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('15s'),
-      deactivateRooms: intervalsInHour('5m'),
       jobCleanup: intervalsInHour('30m'),
       kueStatsActivityLogs: intervalsInHour('1m'),
       queueStatsActivityLogs: intervalsInHour('1m'),
@@ -96,7 +93,6 @@ describe('tests/clock/clock.js >', function () {
     const env = {
       // eslint-disable-next-line camelcase
       CLOCK_JOB_INTERVAL_checkMissedCollectorHeartbeat: '1m',
-      CLOCK_JOB_INTERVAL_deactivateRooms: '2m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_jobCleanup: '3m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_resetJobCounter: '4m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_sampleTimeout: '5m', // eslint-disable-line camelcase
@@ -104,7 +100,6 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('1m'),
-      deactivateRooms: intervalsInHour('2m'),
       jobCleanup: intervalsInHour('3m'),
       resetJobCounter: intervalsInHour('4m'),
       sampleTimeout: intervalsInHour('5m'),

--- a/tests/clock/clock.js
+++ b/tests/clock/clock.js
@@ -32,6 +32,7 @@ describe('tests/clock/clock.js >', function () {
   it('default config', () => {
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInDay('15s'),
+      deactivateRooms: intervalsInDay('5m'),
       jobCleanup: intervalsInDay('30m'),
       resetJobCounter: intervalsInDay('2h'),
       sampleTimeout: intervalsInDay('30s'),
@@ -52,6 +53,7 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('15s'),
+      deactivateRooms: intervalsInHour('5m'),
       deleteUnusedTokens: intervalsInHour('1d'),
       jobCleanup: intervalsInHour('30m'),
       resetJobCounter: intervalsInHour('2h'),
@@ -74,6 +76,7 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('15s'),
+      deactivateRooms: intervalsInHour('5m'),
       jobCleanup: intervalsInHour('30m'),
       kueStatsActivityLogs: intervalsInHour('1m'),
       queueStatsActivityLogs: intervalsInHour('1m'),
@@ -93,6 +96,7 @@ describe('tests/clock/clock.js >', function () {
     const env = {
       // eslint-disable-next-line camelcase
       CLOCK_JOB_INTERVAL_checkMissedCollectorHeartbeat: '1m',
+      CLOCK_JOB_INTERVAL_deactivateRooms: '2m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_jobCleanup: '3m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_resetJobCounter: '4m', // eslint-disable-line camelcase
       CLOCK_JOB_INTERVAL_sampleTimeout: '5m', // eslint-disable-line camelcase
@@ -100,6 +104,7 @@ describe('tests/clock/clock.js >', function () {
 
     const expectedCount = {
       checkMissedCollectorHeartbeat: intervalsInHour('1m'),
+      deactivateRooms: intervalsInHour('2m'),
       jobCleanup: intervalsInHour('3m'),
       resetJobCounter: intervalsInHour('4m'),
       sampleTimeout: intervalsInHour('5m'),

--- a/tests/clock/jobs/deactivateRooms.js
+++ b/tests/clock/jobs/deactivateRooms.js
@@ -23,7 +23,7 @@ const ZERO = 0;
 const ONE = 1;
 const MOON_LANDING = '1969-07-20T20:18:00+00:00';
 
-describe('tests/clock/jobs/deactivateRooms.js >', () => {
+describe.skip('tests/clock/jobs/deactivateRooms.js >', () => {
   afterEach(u.forceDelete);
   afterEach(e.forceDelete);
 


### PR DESCRIPTION
Turning off the job in Refocus because now GUS/ORG62 must be checked before deactivating (TTx metrics). This work has been transferred to Case-Bot.

Added env var ENABLE_DEACTIVATE_ROOMS (already in all refocus environments in Heroku) - this will be false and inside setupIntervals this will get false under toggles for deactivateRooms job.