### PR TITLE
Upsert batching

### DIFF
--- a/cache/models/samples.js
+++ b/cache/models/samples.js
@@ -347,7 +347,8 @@ function getOneSample(sampleName) {
  * @throws {Object} Error object
  */
 function prepareSampleForUpsert(newSample, sampleAttributes, user) {
-  const { subjectExists, aspectExists, aspectWriters, existingSample, sampleStatus } = sampleAttributes;
+  const { subjectExists, aspectExists, aspectWriters, existingSample, sampleStatus }
+    = sampleAttributes;
 
   const userName = user ? user.name : false;
   const sampleName = newSample.name;
@@ -480,13 +481,13 @@ function upsertSamples(samplesAndAttributes, user) {
   });
 
   // all samples: get updated hash
-  batch.returnAll(allSampleNames, 'updatedSamples', (batch, sampleName) => {
-    return batch.getHash(constants.objectType.sample, sampleName)
-  });
+  batch.returnAll(allSampleNames, 'updatedSamples', (batch, sampleName) =>
+    batch.getHash(constants.objectType.sample, sampleName)
+  );
 
   return batch.exec()
-  .then(({ updatedSamples }) => {
-    return updatedSamples.map((updatedSample, i) => {
+  .then(({ updatedSamples }) =>
+    updatedSamples.map((updatedSample, i) => {
       const { sampleAttributes } = samplesAndAttributes[i];
 
       sampleStore.arrayObjsStringsToJson(updatedSample, constants.fieldsToStringify.sample);
@@ -496,8 +497,8 @@ function upsertSamples(samplesAndAttributes, user) {
       }
 
       return updatedSample;
-    });
-  });
+    })
+  );
 }
 
 function upsertOneSample(sample, sampleAttributes, user) {
@@ -506,7 +507,7 @@ function upsertOneSample(sample, sampleAttributes, user) {
     if (upsertedSample instanceof Error) {
       throw upsertedSample;
     } else {
-      return upsertedSample
+      return upsertedSample;
     }
   });
 }
@@ -524,10 +525,10 @@ function getValuesForSamples(samplesReq) {
     parseName(squery.name.toLowerCase())
   );
 
-  let aspNames = parsedNames.map(({ aspect }) => aspect.name );
+  let aspNames = parsedNames.map(({ aspect }) => aspect.name);
   aspNames = Array.from(new Set(aspNames));
 
-  let absPaths = parsedNames.map(({ subject }) => subject.absolutePath );
+  let absPaths = parsedNames.map(({ subject }) => subject.absolutePath);
   absPaths = Array.from(new Set(absPaths));
 
   return redisOps.batchCmds()
@@ -1433,7 +1434,7 @@ module.exports = {
       .then((result) =>
         prepareSampleForPublish(result, sampleAttributes)
       );
-    })
+    });
   },
 
   /**
@@ -1477,7 +1478,7 @@ module.exports = {
       validSamples.forEach((sample, i) => {
         const { newSample, sampleAttributes } = samplesAndAttributes[i];
         try {
-          prepareSampleForUpsert(newSample, sampleAttributes, user)
+          prepareSampleForUpsert(newSample, sampleAttributes, user);
         } catch (err) {
           delete samplesAndAttributes[i];
           errors[i] = { isFailed: true, explanation: err };

--- a/cache/redisOps.js
+++ b/cache/redisOps.js
@@ -242,7 +242,6 @@ class RedisOps {
     }
   }
 
-
   /**
    * Execute the queued batch commands if this is the top-level RedisOps object,
    * or continue the batch chain if it's nested.

--- a/cache/statusCalculation.js
+++ b/cache/statusCalculation.js
@@ -123,26 +123,35 @@ function prepareValue(value) {
  * Calculate the sample status based on this value and the existing ranges sorted set.
  *
  * @param  {Object} redisOps - batched or unbatched redisOps object
- * @param  {String} aspName - aspect name
+ * @param  {String} sampleName - sample name
  * @param  {Number} value - sample value
  * @returns {String} - resulting status
  */
-function calculateStatus(redisOps, aspName, value) {
+function calculateStatus(redisOps, sampleName, value) {
+  const aspName = sampleName.split('|')[1];
   const key = redisStore.toKey(keyType.aspRanges, aspName);
-  return redisOps.zrangebyscore(key, value, '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
-  .then(([member, score]) => {
-    if (member) {
-      score = Number(score);
-      const [precedence, rangeType, status] = member.split(':'); // jscs:ignore
-      if (rangeType === 'max') {
-        return status;
-      } else if (rangeType === 'min' && value === score) {
-        return status;
-      }
-    }
 
-    return Status.Invalid;
-  });
+  try {
+    value = prepareValue(value);
+  } catch (err) {
+    return redisOps.returnValue(err.message);
+  }
+
+  return redisOps.transform((batch) => (
+      batch.zrangebyscore(key, value, '+inf', 'WITHSCORES', 'LIMIT', 0, 1)
+    ), ([member, score]) => {
+      if (member) {
+        score = Number(score);
+        const [precedence, rangeType, status] = member.split(':'); // jscs:ignore
+        if (rangeType === 'max') {
+          return status;
+        } else if (rangeType === 'min' && value === score) {
+          return status;
+        }
+      }
+
+      return Status.Invalid;
+    });
 }
 
 /**

--- a/realtime/redisPublisher.js
+++ b/realtime/redisPublisher.js
@@ -190,7 +190,8 @@ function publishSample(sample, event) {
   if (!sample.absolutePath) {
     sample.absolutePath = absPath;
   }
-  if ( !(sample.subject && sample.aspect) ) {
+
+  if (!(sample.subject && sample.aspect)) {
     sample.subject = { absolutePath: absPath };
     sample.aspect = { name: aspName };
   }
@@ -211,7 +212,7 @@ function publishSample(sample, event) {
       .then(({ subTags, aspTags }) => {
         sample.subject.tags = subTags;
         sample.aspect.tags = aspTags;
-      })
+      });
     }
   })
 

--- a/tests/cache/models/samples/helperFunctions.js
+++ b/tests/cache/models/samples/helperFunctions.js
@@ -98,10 +98,8 @@ describe('tests/cache/models/samples/helperFunctions.js >', () => {
           expect(res).to.equal(true);
           return checkWritePerm(aspName, otherUser.name, true);
         })
-        .catch((obj) => {
-          const err = obj.explanation;
+        .catch((err) => {
           expect(err.name).to.equal('UpdateDeleteForbidden');
-          expect(obj.isFailed).to.equal(true);
           expect(err.explanation).to.equal('User "___myUniqueUser" does ' +
             'not have write permission for aspect "___TEST_ASPECT"');
           done();

--- a/tests/cache/models/samples/updateSampleAttributes.js
+++ b/tests/cache/models/samples/updateSampleAttributes.js
@@ -60,7 +60,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Invalid');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -122,7 +122,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Invalid');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -180,7 +180,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Critical');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -238,7 +238,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
     }).then((asp) => {
       aspObj = asp;
       qb.aspectId = asp.id;
-      return updateSampleAttributes(qb, samp);
+      return updateSampleAttributes(qb, samp, 'Invalid');
     })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -297,7 +297,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Critical');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -357,7 +357,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Critical');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -418,7 +418,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Critical');
       })
       .then(() => {
         expect(qb).to.deep.equal({
@@ -478,7 +478,7 @@ describe('tests/cache/models/samples/updateSampleAttributes.js >', () => {
       .then((asp) => {
         aspObj = asp;
         qb.aspectId = asp.id;
-        return updateSampleAttributes(qb, samp);
+        return updateSampleAttributes(qb, samp, 'Critical');
       })
       .then(() => {
         expect(qb).to.deep.equal({

--- a/tests/cache/models/samples/upsertBulk.js
+++ b/tests/cache/models/samples/upsertBulk.js
@@ -249,7 +249,7 @@ describe('tests/cache/models/samples/upsertBulk.js, ' +
       expect(response[2].explanation).to.have.property('name',
         'ResourceNotFoundError');
       expect(response[2].explanation).to.have.property('explanation',
-        'Invalid sample name "___invalid_name"');
+        'Invalid sample name "___Invalid_Name"');
       done();
     })
       .catch(done);


### PR DESCRIPTION
In order to improve bulkUpsert performance, batch together all the redis commands instead of sending them sequentially.

Previously: 
```
for each sample: (sequential)
  get aspect writers
  get sample hash
  get asp/sub exists (if sample is new)
  get sample status
  set sample hash
  get sample hash
  get tags
```
(6-7 * numSamples) sequential requests to redis
(7-9 * numSamples) commands executed on redis


Now: 
 ```
Batch 1: (parallel)
  for each aspect:
    get writers/tags/exists
  for each subject:
    get tags/exists
  for each sample:
    get hash/status

Batch 2: (parallel)
  for each sample:
    set hash
    get hash
```
2 requests to redis, no matter how many samples
(4\*numSamples + 3\*numAspects + 2\*numSubjects) commands executed on redis