### PR TITLE
Add docker-compose build step to quickstart

### DIFF
--- a/docs/docs/05-quickstartlocaldocker.md
+++ b/docs/docs/05-quickstartlocaldocker.md
@@ -9,4 +9,5 @@ title: Quick Start with Local Docker
 # Start refocus with dependencies
 1. Clone this git repository.
 2. Run `cd refocus`.
-3. Run `docker-compose up`
+3. Run `docker-compose build`
+4. Run `docker-compose up`


### PR DESCRIPTION
We are missing a step in the docker setup process. 
Added it to the quick start guide