### PR TITLE
upgrade stack to heroku-20

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,5 +16,6 @@
       "description": "A secret key for signing the session ID cookie.",
       "generator": "secret"
     }
-  }
+  },
+  "stack": "heroku-20"
 }


### PR DESCRIPTION
Refocus is running in Heroku-16 stack, which will be end-of-life on May 1st, 2021.
We need to upgrade it to Heroku-20.

Ref:
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq
https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack