### PR TITLE
Update redisCache.js

### DIFF
--- a/cache/redisCache.js
+++ b/cache/redisCache.js
@@ -54,10 +54,9 @@ const opts = {
     return Math.min(options.attempt * rconf.retryStrategy.backoffFactor,
       rconf.retryStrategy.backoffMax);
   }, // retryStrategy
-  socket: {
-    tls: true,
-    rejectUnauthorized: false,
-  }, //socket
+  tls: {
+    rejectUnauthorized: false
+  },
 };
 
 if (featureToggles.isFeatureEnabled('enableRedisConnectionLogging')) {


### PR DESCRIPTION
Switch to the pre 4.0 client syntax

https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-node-js